### PR TITLE
Use absolute imports for blake2 simd submodules.

### DIFF
--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -80,7 +80,6 @@
 #![warn(missing_docs)]
 
 #![cfg_attr(feature = "simd", feature(platform_intrinsics, repr_simd))]
-#![cfg_attr(feature = "simd_opt", feature(cfg_target_feature))]
 #![cfg_attr(feature = "simd_asm", feature(asm))]
 
 extern crate byte_tools;

--- a/blake2/src/simd/mod.rs
+++ b/blake2/src/simd/mod.rs
@@ -79,7 +79,7 @@ macro_rules! impl_vector4 {
             #[cfg(feature = "simd")]
             #[inline(always)]
             fn shuffle_left_1(self) -> Self {
-                use simdint::simd_shuffle4;
+                use simd::simdint::simd_shuffle4;
                 unsafe { simd_shuffle4(self, self, [1, 2, 3, 0]) }
             }
 
@@ -92,7 +92,7 @@ macro_rules! impl_vector4 {
             #[cfg(feature = "simd")]
             #[inline(always)]
             fn shuffle_left_2(self) -> Self {
-                use simdint::simd_shuffle4;
+                use simd::simdint::simd_shuffle4;
                 unsafe { simd_shuffle4(self, self, [2, 3, 0, 1]) }
             }
 
@@ -105,7 +105,7 @@ macro_rules! impl_vector4 {
             #[cfg(feature = "simd")]
             #[inline(always)]
             fn shuffle_left_3(self) -> Self {
-                use simdint::simd_shuffle4;
+                use simd::simdint::simd_shuffle4;
                 unsafe { simd_shuffle4(self, self, [3, 0, 1, 2]) }
             }
 

--- a/blake2/src/simd/simd_opt/u32x4.rs
+++ b/blake2/src/simd/simd_opt/u32x4.rs
@@ -7,7 +7,7 @@
 
 #![cfg_attr(feature = "clippy", allow(inline_always))]
 
-use simdty::u32x4;
+use simd::simdty::u32x4;
 
 #[cfg(feature = "simd_opt")]
 #[inline(always)]

--- a/blake2/src/simd/simd_opt/u64x4.rs
+++ b/blake2/src/simd/simd_opt/u64x4.rs
@@ -7,7 +7,7 @@
 
 #![cfg_attr(feature = "clippy", allow(inline_always))]
 
-use simdty::u64x4;
+use simd::simdty::u64x4;
 
 #[cfg(feature = "simd_opt")]
 #[inline(always)]
@@ -100,7 +100,7 @@ fn rotate_right_16(vec: u64x4) -> u64x4 {
           target_feature = "neon",
           target_arch = "arm"))]
 mod simd_asm_neon_arm {
-    use simdty::{u64x2, u64x4};
+    use simd::simdty::{u64x2, u64x4};
 
     #[inline(always)]
     fn vext_u64(vec: u64x2, b: u8) -> u64x2 {
@@ -115,7 +115,7 @@ mod simd_asm_neon_arm {
 
     #[inline(always)]
     pub fn rotate_right_vext(vec: u64x4, b: u8) -> u64x4 {
-        use simdint::{simd_shuffle2, simd_shuffle4};
+        use simd::simdint::{simd_shuffle2, simd_shuffle4};
 
         unsafe {
             let tmp0 = vext_u64(simd_shuffle2(vec, vec, [0, 1]), b);

--- a/blake2/src/simd/simdop.rs
+++ b/blake2/src/simd/simdop.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use simd::simdty::{u32x4, u64x4};
-#[cfg(feature = "simd")] use simdint;
+#[cfg(feature = "simd")] use simd::simdint;
 
 use core::ops::{Add, BitXor, Shl, Shr};
 


### PR DESCRIPTION
This fixes a slew of unresolved imports when trying to build with simd enabled on nightly.

```
❯ cargo +nightly build --features simd_asm
   Compiling blake2 v0.7.0 (file:///Users/dreid/hashes/blake2)
error[E0432]: unresolved import `simdint`
 --> blake2/src/simd/simdop.rs:9:30
  |
9 | #[cfg(feature = "simd")] use simdint;
  |                              ^^^^^^^ no `simdint` in the root

error[E0432]: unresolved import `simdty`
  --> blake2/src/simd/simd_opt/u32x4.rs:10:5
   |
10 | use simdty::u32x4;
   |     ^^^^^^ Did you mean `simd::simdty`?

error[E0432]: unresolved import `simdty`
  --> blake2/src/simd/simd_opt/u64x4.rs:10:5
   |
10 | use simdty::u64x4;
   |     ^^^^^^ Did you mean `simd::simdty`?

error[E0432]: unresolved import `simdint`
   --> blake2/src/simd/mod.rs:82:21
    |
82  |                 use simdint::simd_shuffle4;
    |                     ^^^^^^^ Did you mean `self::simdint`?
...
121 | impl_vector4!(u32x4, u32);
    | -------------------------- in this macro invocation

error[E0432]: unresolved import `simdint`
   --> blake2/src/simd/mod.rs:95:21
    |
95  |                 use simdint::simd_shuffle4;
    |                     ^^^^^^^ Did you mean `self::simdint`?
...
121 | impl_vector4!(u32x4, u32);
    | -------------------------- in this macro invocation

error[E0432]: unresolved import `simdint`
   --> blake2/src/simd/mod.rs:108:21
    |
108 |                 use simdint::simd_shuffle4;
    |                     ^^^^^^^ Did you mean `self::simdint`?
...
121 | impl_vector4!(u32x4, u32);
    | -------------------------- in this macro invocation

error[E0432]: unresolved import `simdint`
   --> blake2/src/simd/mod.rs:82:21
    |
82  |                 use simdint::simd_shuffle4;
    |                     ^^^^^^^ Did you mean `self::simdint`?
...
122 | impl_vector4!(u64x4, u64);
    | -------------------------- in this macro invocation

error[E0432]: unresolved import `simdint`
   --> blake2/src/simd/mod.rs:95:21
    |
95  |                 use simdint::simd_shuffle4;
    |                     ^^^^^^^ Did you mean `self::simdint`?
...
122 | impl_vector4!(u64x4, u64);
    | -------------------------- in this macro invocation

error[E0432]: unresolved import `simdint`
   --> blake2/src/simd/mod.rs:108:21
    |
108 |                 use simdint::simd_shuffle4;
    |                     ^^^^^^^ Did you mean `self::simdint`?
...
122 | impl_vector4!(u64x4, u64);
    | -------------------------- in this macro invocation

error: aborting due to 9 previous errors

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `blake2`.

To learn more, run the command again with --verbose.
```