### PR TITLE
Fix an overflow in Streebog causing panic or incorrect output

### DIFF
--- a/streebog/src/streebog.rs
+++ b/streebog/src/streebog.rs
@@ -61,12 +61,10 @@ impl StreebogState {
     }
 
     fn update_sigma(&mut self, m: &Block) {
-        let mut over = false;
+        let mut carry = 0;
         for (a, b) in self.sigma.iter_mut().zip(m.iter()) {
-            let (res, loc_over) = (*a).overflowing_add(*b);
-            *a = res;
-            if over { *a += 1; }
-            over = loc_over;
+            carry = (*a as u16) + (*b as u16) + (carry >> 8);
+            *a = (carry & 0xFF) as u8;
         }
     }
 


### PR DESCRIPTION
There is a bug in the `update_sigma` function of Streebog.

For example for the input consisting of 96 bytes of 255 (0xFF), current crate either panics:

```
$ ./target/debug/examples/streebog256sum ffs
thread 'main' panicked at 'attempt to add with overflow', streebog/src/streebog.rs:68:23
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

Or produces an incorrect output:

```
$ ./target/release/examples/streebog256sum ffs
b9260dbf1e41a461b964a31035f60ebbe508c4946f443ba8974922f1f55e1e3f        ffs
```

Compare output with OpenSSL using the GOST engine:

```
$ openssl dgst -md_gost12_256 ffs
md_gost12_256(ffs)= cec87784e5b15bb20e1717ff8e940c9ef9a156401f31546f48a4314ad9f34606
```

Due to poor specification and missing KATs a number of other impls have run into similar issues 
https://github.com/gpg/libgcrypt/commit/da6cd4fea30f79cf9d8f9b2f1c6daf3aea39fa9c