### PR TITLE
Enable sha1 and sha2 AArch64 extensions from asm-hashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,18 @@ matrix:
     - env: NAME=features-test
       rust: nightly
       script: ./test_features.sh
+    - env: NAME=test-aarch64
+      arch: arm64
+      rust: nightly
+      script:
+        - cd sha1
+        - cargo test --verbose --release --features asm-aarch64
+        - cargo bench --verbose
+        - cargo bench --verbose --features asm-aarch64
+        - cd ../sha2
+        - cargo test --verbose --release --features asm-aarch64
+        - cargo bench --verbose
+        - cargo bench --verbose --features asm-aarch64
 
 install:
   - cargo install cross || true

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -18,6 +18,7 @@ block-buffer = "0.7"
 fake-simd = "0.1"
 sha1-asm = { version = "0.4", optional = true }
 opaque-debug = "0.2"
+libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 digest = { version = "0.8", features = ["dev"] }
@@ -27,6 +28,10 @@ hex-literal = "0.1"
 default = ["std"]
 std = ["digest/std"]
 asm = ["sha1-asm"]
+
+# TODO: Remove this feature once is_aarch64_feature_detected!() is stabilised.
+# Only used on AArch64 Linux systems.
+asm-aarch64 = ["asm", "libc"]
 
 [badges]
 travis-ci = { repository = "RustCrypto/hashes" }

--- a/sha1/src/aarch64.rs
+++ b/sha1/src/aarch64.rs
@@ -1,0 +1,9 @@
+// TODO: Import those from libc, see https://github.com/rust-lang/libc/pull/1638
+const AT_HWCAP: u64 = 16;
+const HWCAP_SHA1: u64 = 32;
+
+#[inline(always)]
+pub fn sha1_supported() -> bool {
+    let hwcaps: u64 = unsafe { ::libc::getauxval(AT_HWCAP) };
+    (hwcaps & HWCAP_SHA1) != 0
+}

--- a/sha1/src/consts.rs
+++ b/sha1/src/consts.rs
@@ -2,16 +2,16 @@
 
 pub const STATE_LEN: usize = 5;
 
-#[cfg(not(feature = "asm"))]
+#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 pub const BLOCK_LEN: usize = 16;
 
-#[cfg(not(feature = "asm"))]
+#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 pub const K0: u32 = 0x5A827999u32;
-#[cfg(not(feature = "asm"))]
+#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 pub const K1: u32 = 0x6ED9EBA1u32;
-#[cfg(not(feature = "asm"))]
+#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 pub const K2: u32 = 0x8F1BBCDCu32;
-#[cfg(not(feature = "asm"))]
+#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 pub const K3: u32 = 0xCA62C1D6u32;
 
 pub const H: [u32; STATE_LEN] = [

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -15,6 +15,7 @@ block-buffer = "0.7"
 fake-simd = "0.1"
 opaque-debug = "0.2"
 sha2-asm = { version="0.5", optional=true }
+libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 digest = { version = "0.8", features = ["dev"] }
@@ -24,6 +25,10 @@ hex-literal = "0.1"
 default = ["std"]
 std = ["digest/std"]
 asm = ["sha2-asm"]
+
+# TODO: Remove this feature once is_aarch64_feature_detected!() is stabilised.
+# Only used on AArch64 Linux systems.
+asm-aarch64 = ["asm", "libc"]
 
 [badges]
 travis-ci = { repository = "RustCrypto/hashes" }

--- a/sha2/src/aarch64.rs
+++ b/sha2/src/aarch64.rs
@@ -1,0 +1,9 @@
+// TODO: Import those from libc, see https://github.com/rust-lang/libc/pull/1638
+const AT_HWCAP: u64 = 16;
+const HWCAP_SHA2: u64 = 64;
+
+#[inline(always)]
+pub fn sha2_supported() -> bool {
+    let hwcaps: u64 = unsafe { ::libc::getauxval(AT_HWCAP) };
+    (hwcaps & HWCAP_SHA2) != 0
+}

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -57,6 +57,15 @@
 #![no_std]
 #![doc(html_logo_url =
     "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+
+// Give relevant error messages if the user tries to enable AArch64 asm on unsupported platforms.
+#[cfg(all(feature = "asm-aarch64", target_arch = "aarch64", not(target_os = "linux")))]
+compile_error!("Your OS isn’t yet supported for runtime-checking of AArch64 features.");
+#[cfg(all(feature = "asm-aarch64", target_os = "linux", not(target_arch = "aarch64")))]
+compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" on non-AArch64 Linux systems.");
+#[cfg(all(not(feature = "asm-aarch64"), feature = "asm", target_arch = "aarch64", target_os = "linux"))]
+compile_error!("Enable the \"asm-aarch64\" feature on AArch64 if you want to use asm.");
+
 extern crate block_buffer;
 extern crate fake_simd as simd;
 #[macro_use] extern crate opaque_debug;
@@ -65,12 +74,16 @@ extern crate fake_simd as simd;
 extern crate sha2_asm;
 #[cfg(feature = "std")]
 extern crate std;
+#[cfg(feature = "asm-aarch64")]
+extern crate libc;
 
 mod consts;
-#[cfg(not(feature = "asm"))]
+#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 mod sha256_utils;
-#[cfg(not(feature = "asm"))]
+#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 mod sha512_utils;
+#[cfg(feature = "asm-aarch64")]
+mod aarch64;
 mod sha256;
 mod sha512;
 

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -24,9 +24,23 @@ struct Engine256State {
 impl Engine256State {
     fn new(h: &[u32; STATE_LEN]) -> Engine256State { Engine256State { h: *h } }
 
+    #[cfg(not(feature = "asm-aarch64"))]
     pub fn process_block(&mut self, block: &Block) {
         let block = unsafe { &*(block.as_ptr() as *const [u8; 64]) };
         compress256(&mut self.h, block);
+    }
+
+    #[cfg(feature = "asm-aarch64")]
+    pub fn process_block(&mut self, block: &Block) {
+        let block = unsafe { &*(block.as_ptr() as *const [u8; 64]) };
+        // TODO: Replace this platform-specific call with is_aarch64_feature_detected!("sha2") once
+        // that macro is stabilised and https://github.com/rust-lang/rfcs/pull/2725 is implemented
+        // to let us use it on no_std.
+        if ::aarch64::sha2_supported() {
+            compress256(&mut self.h, block);
+        } else {
+            ::sha256_utils::compress256(&mut self.h, block);
+        }
     }
 }
 

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -6,9 +6,9 @@ use block_buffer::byteorder::{BE, ByteOrder};
 
 use consts::{STATE_LEN, H384, H512, H512_TRUNC_224, H512_TRUNC_256};
 
-#[cfg(not(feature = "asm"))]
+#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 use sha512_utils::compress512;
-#[cfg(feature = "asm")]
+#[cfg(all(feature = "asm", not(feature = "asm-aarch64")))]
 use sha2_asm::compress512;
 
 type BlockSize = U128;


### PR DESCRIPTION
This follows https://github.com/RustCrypto/asm-hashes/pull/10

`getauxval()` is extremely cheap, as it is just a pointer to the beginning of the stack, so it doesn’t make much sense to use a `lazy_static!()` to remember the flags (at least I can’t see any difference while profiling).

Sorry about #96, I force-pushed from the wrong repository and can’t reopen the PR due to that…

Here are some benchmarks on my Nintendo Switch:

Without this patch (or without `--features=asm`):
```
test sha1_10      ... bench:          66 ns/iter (+/- 0) = 151 MB/s
test sha1_100     ... bench:         497 ns/iter (+/- 1) = 201 MB/s
test sha1_1000    ... bench:       4,799 ns/iter (+/- 16) = 208 MB/s
test sha1_10000   ... bench:      47,646 ns/iter (+/- 134) = 209 MB/s
test sha256_10    ... bench:          98 ns/iter (+/- 0) = 102 MB/s
test sha256_100   ... bench:         815 ns/iter (+/- 4) = 122 MB/s
test sha256_1000  ... bench:       7,980 ns/iter (+/- 76) = 125 MB/s
test sha256_10000 ... bench:      79,373 ns/iter (+/- 793) = 125 MB/s
```

With this patch:
```
test sha1_10      ... bench:          32 ns/iter (+/- 1) = 312 MB/s
test sha1_100     ... bench:         165 ns/iter (+/- 1) = 606 MB/s
test sha1_1000    ... bench:       1,480 ns/iter (+/- 5) = 675 MB/s
test sha1_10000   ... bench:      14,246 ns/iter (+/- 26) = 701 MB/s
test sha256_10    ... bench:          30 ns/iter (+/- 0) = 333 MB/s
test sha256_100   ... bench:         167 ns/iter (+/- 0) = 598 MB/s
test sha256_1000  ... bench:       1,554 ns/iter (+/- 7) = 643 MB/s
test sha256_10000 ... bench:      15,231 ns/iter (+/- 88) = 656 MB/s
```