### PR TITLE
Allow compile-time detection of crypto extension on AArch64

### DIFF
--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -30,7 +30,7 @@ std = ["digest/std"]
 asm = ["sha1-asm"]
 
 # TODO: Remove this feature once is_aarch64_feature_detected!() is stabilised.
-# Only used on AArch64 Linux systems.
+# Only used on AArch64 Linux systems, when built without the crypto target_feature.
 asm-aarch64 = ["asm", "libc"]
 
 [badges]

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -32,10 +32,12 @@
 // Give relevant error messages if the user tries to enable AArch64 asm on unsupported platforms.
 #[cfg(all(feature = "asm-aarch64", target_arch = "aarch64", not(target_os = "linux")))]
 compile_error!("Your OS isn’t yet supported for runtime-checking of AArch64 features.");
-#[cfg(all(feature = "asm-aarch64", target_os = "linux", not(target_arch = "aarch64")))]
-compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" on non-AArch64 Linux systems.");
-#[cfg(all(not(feature = "asm-aarch64"), feature = "asm", target_arch = "aarch64", target_os = "linux"))]
-compile_error!("Enable the \"asm-aarch64\" feature on AArch64 if you want to use asm.");
+#[cfg(all(feature = "asm-aarch64", not(target_arch = "aarch64")))]
+compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" on non-AArch64 systems.");
+#[cfg(all(feature = "asm-aarch64", target_arch = "aarch64", target_feature = "crypto"))]
+compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" when building for AArch64 systems with crypto extensions.");
+#[cfg(all(not(feature = "asm-aarch64"), feature = "asm", target_arch = "aarch64", not(target_feature = "crypto"), target_os = "linux"))]
+compile_error!("Enable the \"asm-aarch64\" feature on AArch64 if you want to use asm detected at runtime, or build with the crypto extensions support, for instance with RUSTFLAGS='-C target-cpu=native' on a compatible CPU.");
 
 extern crate block_buffer;
 #[macro_use] extern crate opaque_debug;

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -27,7 +27,7 @@ std = ["digest/std"]
 asm = ["sha2-asm"]
 
 # TODO: Remove this feature once is_aarch64_feature_detected!() is stabilised.
-# Only used on AArch64 Linux systems.
+# Only used on AArch64 Linux systems, when built without the crypto target_feature.
 asm-aarch64 = ["asm", "libc"]
 
 [badges]

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -61,10 +61,12 @@
 // Give relevant error messages if the user tries to enable AArch64 asm on unsupported platforms.
 #[cfg(all(feature = "asm-aarch64", target_arch = "aarch64", not(target_os = "linux")))]
 compile_error!("Your OS isn’t yet supported for runtime-checking of AArch64 features.");
-#[cfg(all(feature = "asm-aarch64", target_os = "linux", not(target_arch = "aarch64")))]
-compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" on non-AArch64 Linux systems.");
-#[cfg(all(not(feature = "asm-aarch64"), feature = "asm", target_arch = "aarch64", target_os = "linux"))]
-compile_error!("Enable the \"asm-aarch64\" feature on AArch64 if you want to use asm.");
+#[cfg(all(feature = "asm-aarch64", not(target_arch = "aarch64")))]
+compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" on non-AArch64 systems.");
+#[cfg(all(feature = "asm-aarch64", target_arch = "aarch64", target_feature = "crypto"))]
+compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" when building for AArch64 systems with crypto extensions.");
+#[cfg(all(not(feature = "asm-aarch64"), feature = "asm", target_arch = "aarch64", not(target_feature = "crypto"), target_os = "linux"))]
+compile_error!("Enable the \"asm-aarch64\" feature on AArch64 if you want to use asm detected at runtime, or build with the crypto extensions support, for instance with RUSTFLAGS='-C target-cpu=native' on a compatible CPU.");
 
 extern crate block_buffer;
 extern crate fake_simd as simd;
@@ -80,7 +82,7 @@ extern crate libc;
 mod consts;
 #[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 mod sha256_utils;
-#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
+#[cfg(any(not(feature = "asm"), target_arch = "aarch64"))]
 mod sha512_utils;
 #[cfg(feature = "asm-aarch64")]
 mod aarch64;

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -6,9 +6,9 @@ use block_buffer::byteorder::{BE, ByteOrder};
 
 use consts::{STATE_LEN, H384, H512, H512_TRUNC_224, H512_TRUNC_256};
 
-#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
+#[cfg(any(not(feature = "asm"), target_arch = "aarch64"))]
 use sha512_utils::compress512;
-#[cfg(all(feature = "asm", not(feature = "asm-aarch64")))]
+#[cfg(all(feature = "asm", not(target_arch = "aarch64")))]
 use sha2_asm::compress512;
 
 type BlockSize = U128;


### PR DESCRIPTION
The existing way depends on the `libc` crate, only works on Linux, and does a `getauxval()` call each 64 bytes of input.

This commit adds support for doing this detection at compile-time, if the `"crypto"` `target_feature` is enabled we can use the same code-path as amd64 and reuse the `asm` feature. It should also work on non-Linux `target_os`, but this is untested.

A new `compile_error!()` has been added helping users figure out the best way to build this crate.

Benchmarks don’t seem to change much without the `getauxval()` call, they’re all within error range.