### PR TITLE
sha1, sha2: Use libc for AArch64 consts too

### DIFF
--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -18,7 +18,7 @@ block-buffer = "0.7"
 fake-simd = "0.1"
 sha1-asm = { version = "0.4", optional = true }
 opaque-debug = "0.2"
-libc = { version = "0.2", optional = true }
+libc = { version = "0.2.68", optional = true }
 
 [dev-dependencies]
 digest = { version = "0.8", features = ["dev"] }

--- a/sha1/src/aarch64.rs
+++ b/sha1/src/aarch64.rs
@@ -1,9 +1,7 @@
-// TODO: Import those from libc, see https://github.com/rust-lang/libc/pull/1638
-const AT_HWCAP: u64 = 16;
-const HWCAP_SHA1: u64 = 32;
+use libc::{getauxval, AT_HWCAP, HWCAP_SHA1};
 
 #[inline(always)]
 pub fn sha1_supported() -> bool {
-    let hwcaps: u64 = unsafe { ::libc::getauxval(AT_HWCAP) };
+    let hwcaps: u64 = unsafe { getauxval(AT_HWCAP) };
     (hwcaps & HWCAP_SHA1) != 0
 }

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -15,7 +15,7 @@ block-buffer = "0.7"
 fake-simd = "0.1"
 opaque-debug = "0.2"
 sha2-asm = { version="0.5", optional=true }
-libc = { version = "0.2", optional = true }
+libc = { version = "0.2.68", optional = true }
 
 [dev-dependencies]
 digest = { version = "0.8", features = ["dev"] }

--- a/sha2/src/aarch64.rs
+++ b/sha2/src/aarch64.rs
@@ -1,9 +1,7 @@
-// TODO: Import those from libc, see https://github.com/rust-lang/libc/pull/1638
-const AT_HWCAP: u64 = 16;
-const HWCAP_SHA2: u64 = 64;
+use libc::{getauxval, AT_HWCAP, HWCAP_SHA2};
 
 #[inline(always)]
 pub fn sha2_supported() -> bool {
-    let hwcaps: u64 = unsafe { ::libc::getauxval(AT_HWCAP) };
+    let hwcaps: u64 = unsafe { getauxval(AT_HWCAP) };
     (hwcaps & HWCAP_SHA2) != 0
 }


### PR DESCRIPTION
Now that https://github.com/rust-lang/libc/pull/1638 got merged and a new `libc` release got made (0.2.68), we can use them instead of hardcoding their values.

This bumps the `libc` dependency to the earliest version with these consts.

There is no functional change, just one TODO less.