### PR TITLE
sha2 v0.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# RustCrypto: hashes
-[![Build Status](https://travis-ci.org/RustCrypto/hashes.svg?branch=master)](https://travis-ci.org/RustCrypto/hashes) [![dependency status](https://deps.rs/repo/github/RustCrypto/hashes/status.svg)](https://deps.rs/repo/github/RustCrypto/hashes)
+# RustCrypto: hashes [![Build Status](https://travis-ci.org/RustCrypto/hashes.svg?branch=master)](https://travis-ci.org/RustCrypto/hashes)
 
 Collection of [cryptographic hash functions][1] written in pure Rust.
 

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.8.2 (2020-05-23)
+### Added
+- Expose compression function under the `compress` feature flag ([#108])
+
+### Changed
+- Use `libc` crate for `aarch64` consts ([#109])
+- Minor code cleanups ([#94])
+
+[#109]: https://github.com/RustCrypto/hashes/pull/109
+[#108]: https://github.com/RustCrypto/hashes/pull/108
+[#94]: https://github.com/RustCrypto/hashes/pull/94
+
+## 0.8.1 (2020-01-05)
+
+## 0.8.0 (2018-10-02)
+
+## 0.7.1 (2018-04-27)
+
+## 0.6.0 (2017-06-12)
+
+## 0.5.3 (2017-06-03)
+
+## 0.5.2 (2017-05-08)
+
+## 0.5.1 (2017-05-01)
+
+## 0.5.0 (2017-04-06)
+
+## 0.4.2 (2017-01-23)
+
+## 0.4.1 (2017-01-20)
+
+## 0.4.0 (2016-12-24)
+
+## 0.3.0 (2016-11-17)
+
+## 0.2.0 (2016-10-26)
+
+## 0.1.2 (2016-05-06)
+
+## 0.1.1 (2016-05-06)
+
+## 0.1.0 (2016-05-06)

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "sha2"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
-description = "SHA-2 hash functions"
+description = """
+Pure Rust implementation of the SHA-2 hash function family
+including SHA-224, SHA-256, SHA-384, and SHA-512.
+"""
 documentation = "https://docs.rs/sha2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha2", "hash", "digest"]
@@ -32,4 +35,5 @@ compress = []
 asm-aarch64 = ["asm", "libc"]
 
 [badges]
+maintenance = { status = "actively-developed" }
 travis-ci = { repository = "RustCrypto/hashes" }

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -54,6 +54,7 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/SHA-2
 //! [2]: https://github.com/RustCrypto/hashes
+
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 


### PR DESCRIPTION
### Added
- Expose compression function under the `compress` feature flag ([#108])

### Changed
- Use `libc` crate for `aarch64` consts ([#109])
- Minor code cleanups ([#94])

[#109]: https://github.com/RustCrypto/hashes/pull/109
[#108]: https://github.com/RustCrypto/hashes/pull/108
[#94]: https://github.com/RustCrypto/hashes/pull/94