### PR TITLE
blake2: 2018 edition and `digest` crate upgrade

### DIFF
--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -5,21 +5,22 @@ description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/blake2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "blake2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
+digest = { version = "= 0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
 byte-tools = "0.3"
 byteorder = { version = "1", default-features = false }
-crypto-mac = "0.7"
+crypto-mac = { version = "= 0.8.0-pre", git = "https://github.com/rustcrypto/traits" }
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
-crypto-mac = { version = "0.7", features = ["dev"] }
+digest = { version = "= 0.9.0-pre", features = ["dev"], git = "https://github.com/rustcrypto/traits" }
+crypto-mac = { version = "0.8.0-pre", features = ["dev"], git = "https://github.com/rustcrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/blake2/benches/blake2b.rs
+++ b/blake2/benches/blake2b.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate blake2;
 
+use digest::bench;
 bench!(blake2::Blake2b);

--- a/blake2/benches/blake2s.rs
+++ b/blake2/benches/blake2s.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate blake2;
 
+use digest::bench;
 bench!(blake2::Blake2s);

--- a/blake2/examples/blake2b_sum.rs
+++ b/blake2/examples/blake2b_sum.rs
@@ -1,4 +1,4 @@
-extern crate blake2;
+
 
 use blake2::{Blake2b, Digest};
 use std::env;
@@ -25,7 +25,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/blake2/examples/blake2s_sum.rs
+++ b/blake2/examples/blake2s_sum.rs
@@ -1,4 +1,4 @@
-extern crate blake2;
+
 
 use blake2::{Blake2s, Digest};
 use std::env;
@@ -25,7 +25,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/blake2/src/blake2b.rs
+++ b/blake2/src/blake2b.rs
@@ -1,5 +1,5 @@
 use digest::generic_array::typenum::{U64, U128};
-use consts::BLAKE2B_IV;
+use crate::consts::BLAKE2B_IV;
 
 blake2_impl!(VarBlake2b, Blake2b, u64, u64x4, read_u64, U64, U128,
     32, 24, 16, 63, BLAKE2B_IV,

--- a/blake2/src/blake2s.rs
+++ b/blake2/src/blake2s.rs
@@ -1,5 +1,5 @@
 use digest::generic_array::typenum::{U32, U64};
-use consts::BLAKE2S_IV;
+use crate::consts::BLAKE2S_IV;
 
 blake2_impl!(VarBlake2s, Blake2s, u32, u32x4, read_u32, U32, U64,
     16, 12, 8, 7, BLAKE2S_IV,

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -14,7 +14,7 @@
 //! let mut hasher = Blake2b::new();
 //!
 //! // write input message
-//! hasher.input(b"hello world");
+//! hasher.update(b"hello world");
 //!
 //! // read hash digest and consume hasher
 //! let res = hasher.result();
@@ -25,7 +25,7 @@
 //!
 //! // same example for `Blake2s`:
 //! let mut hasher = Blake2s::new();
-//! hasher.input(b"hello world");
+//! hasher.update(b"hello world");
 //! let res = hasher.result();
 //! assert_eq!(res[..], hex!("
 //!     9aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b
@@ -38,15 +38,15 @@
 //! ## Variable output size
 //!
 //! If you need variable sized output you can use `VarBlake2b` and `VarBlake2s`
-//! which support variable output sizes through `VariableOutput` trait. `Input`
+//! which support variable output sizes through `VariableOutput` trait. `Update`
 //! trait has to be imported as well.
 //!
 //! ```rust
 //! use blake2::VarBlake2b;
-//! use blake2::digest::{Input, VariableOutput};
+//! use blake2::digest::{Update, VariableOutput};
 //!
 //! let mut hasher = VarBlake2b::new(10).unwrap();
-//! hasher.input(b"my_input");
+//! hasher.update(b"my_input");
 //! hasher.variable_result(|res| {
 //!     assert_eq!(res, [44, 197, 92, 132, 228, 22, 146, 78, 100, 0])
 //! })
@@ -58,22 +58,22 @@
 //!
 //! ```rust
 //! use blake2::Blake2b;
-//! use blake2::crypto_mac::Mac;
+//! use blake2::crypto_mac::{Mac, NewMac};
 //!
 //! let mut hasher = Blake2b::new_varkey(b"my key").unwrap();
-//! hasher.input(b"hello world");
+//! hasher.update(b"hello world");
 //!
-//! // `result` has type `MacResult` which is a thin wrapper around array of
-//! // bytes for providing constant time equality check
+//! // `result` has type `crypto_mac::Output` which is a thin wrapper around
+//! // a byte array and provides a constant time equality check
 //! let result = hasher.result();
-//! // To get underlying array use `code` method, but be carefull, since
-//! // incorrect use of the code value may permit timing attacks which defeat
-//! // the security provided by the `MacResult`
-//! let code_bytes = result.code();
+//! // To get underlying array use the `into_bytes` method, but be careful,
+//! // since incorrect use of the code value may permit timing attacks which
+//! // defeat the security provided by the `crypto_mac::Output`
+//! let code_bytes = result.into_bytes();
 //!
 //! // To verify the message it's recommended to use `verify` method
 //! let mut hasher = Blake2b::new_varkey(b"my key").unwrap();
-//! hasher.input(b"hello world");
+//! hasher.update(b"hello world");
 //! // `verify` return `Ok(())` if code is correct, `Err(MacError)` otherwise
 //! hasher.verify(&code_bytes).unwrap();
 //! ```
@@ -83,6 +83,7 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2
 //! [2]: https://github.com/cesarb/blake2-rfc
+
 #![no_std]
 #![doc(html_logo_url =
     "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
@@ -93,9 +94,9 @@
 
 #[macro_use] extern crate opaque_debug;
 #[macro_use] pub extern crate digest;
-extern crate byte_tools;
-extern crate byteorder;
-pub extern crate crypto_mac;
+
+
+pub use crypto_mac;
 
 #[cfg(feature = "std")]
 extern crate std;
@@ -113,5 +114,5 @@ mod blake2b;
 mod blake2s;
 
 pub use digest::Digest;
-pub use blake2b::{Blake2b, VarBlake2b};
-pub use blake2s::{Blake2s, VarBlake2s};
+pub use crate::blake2b::{Blake2b, VarBlake2b};
+pub use crate::blake2s::{Blake2s, VarBlake2s};

--- a/blake2/src/simd.rs
+++ b/blake2/src/simd.rs
@@ -79,7 +79,7 @@ macro_rules! impl_vector4 {
             #[cfg(feature = "simd")]
             #[inline(always)]
             fn shuffle_left_1(self) -> Self {
-                use simd::simdint::simd_shuffle4;
+                use crate::simd::simdint::simd_shuffle4;
                 unsafe { simd_shuffle4(self, self, [1, 2, 3, 0]) }
             }
 
@@ -92,7 +92,7 @@ macro_rules! impl_vector4 {
             #[cfg(feature = "simd")]
             #[inline(always)]
             fn shuffle_left_2(self) -> Self {
-                use simd::simdint::simd_shuffle4;
+                use crate::simd::simdint::simd_shuffle4;
                 unsafe { simd_shuffle4(self, self, [2, 3, 0, 1]) }
             }
 
@@ -105,7 +105,7 @@ macro_rules! impl_vector4 {
             #[cfg(feature = "simd")]
             #[inline(always)]
             fn shuffle_left_3(self) -> Self {
-                use simd::simdint::simd_shuffle4;
+                use crate::simd::simdint::simd_shuffle4;
                 unsafe { simd_shuffle4(self, self, [3, 0, 1, 2]) }
             }
 

--- a/blake2/src/simd/simd_opt.rs
+++ b/blake2/src/simd/simd_opt.rs
@@ -7,12 +7,13 @@
 
 #![cfg_attr(feature = "clippy", allow(clippy::inline_always))]
 
+#[allow(unused_macros)]
 #[cfg(feature = "simd")]
 macro_rules! transmute_shuffle {
     ($tmp:ident, $shuffle:ident, $vec:expr, $idx:expr) => {
         unsafe {
-            use simd::simdty::$tmp;
-            use simd::simdint::$shuffle;
+            use crate::simd::simdty::$tmp;
+            use crate::simd::simdint::$shuffle;
             use core::mem::transmute;
 
             let tmp_i: $tmp = transmute($vec);
@@ -29,7 +30,7 @@ macro_rules! transmute_shuffle {
 macro_rules! simd_opt {
     ($vec:ident) => {
         pub mod $vec {
-            use simd::simdty::$vec;
+            use crate::simd::simdty::$vec;
 
             #[inline(always)]
             pub fn rotate_right_const(vec: $vec, n: u32) -> $vec {

--- a/blake2/src/simd/simd_opt/u32x4.rs
+++ b/blake2/src/simd/simd_opt/u32x4.rs
@@ -7,7 +7,7 @@
 
 #![cfg_attr(feature = "clippy", allow(clippy::inline_always))]
 
-use simd::simdty::u32x4;
+use crate::simd::simdty::u32x4;
 
 #[cfg(feature = "simd_opt")]
 #[inline(always)]

--- a/blake2/src/simd/simd_opt/u64x4.rs
+++ b/blake2/src/simd/simd_opt/u64x4.rs
@@ -7,7 +7,7 @@
 
 #![cfg_attr(feature = "clippy", allow(clippy::inline_always))]
 
-use simd::simdty::u64x4;
+use crate::simd::simdty::u64x4;
 
 #[cfg(feature = "simd_opt")]
 #[inline(always)]
@@ -100,7 +100,7 @@ fn rotate_right_16(vec: u64x4) -> u64x4 {
           target_feature = "neon",
           target_arch = "arm"))]
 mod simd_asm_neon_arm {
-    use simd::simdty::{u64x2, u64x4};
+    use crate::simd::simdty::{u64x2, u64x4};
 
     #[inline(always)]
     fn vext_u64(vec: u64x2, b: u8) -> u64x2 {
@@ -115,7 +115,7 @@ mod simd_asm_neon_arm {
 
     #[inline(always)]
     pub fn rotate_right_vext(vec: u64x4, b: u8) -> u64x4 {
-        use simd::simdint::{simd_shuffle2, simd_shuffle4};
+        use crate::simd::simdint::{simd_shuffle2, simd_shuffle4};
 
         unsafe {
             let tmp0 = vext_u64(simd_shuffle2(vec, vec, [0, 1]), b);

--- a/blake2/src/simd/simdop.rs
+++ b/blake2/src/simd/simdop.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use simd::simdty::{u32x4, u64x4};
-#[cfg(feature = "simd")] use simd::simdint;
+use crate::simd::simdty::{u32x4, u64x4};
+#[cfg(feature = "simd")] use crate::simd::simdint;
 
 use core::ops::{Add, BitXor, Shl, Shr};
 

--- a/blake2/src/simd/simdty.rs
+++ b/blake2/src/simd/simdty.rs
@@ -9,7 +9,7 @@
 #![allow(non_camel_case_types)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::inline_always))]
 
-use as_bytes::Safe;
+use crate::as_bytes::Safe;
 
 #[cfg(feature = "simd")]
 macro_rules! decl_simd {

--- a/blake2/tests/lib.rs
+++ b/blake2/tests/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate blake2;
+use blake2;
 
 use digest::dev::{digest_test, variable_test};
 

--- a/blake2/tests/mac.rs
+++ b/blake2/tests/mac.rs
@@ -1,7 +1,6 @@
 #![no_std]
-#[macro_use]
-extern crate crypto_mac;
-extern crate blake2;
+
+use crypto_mac::new_test;
 
 new_test!(blake2b_mac, "blake2b/mac", blake2::Blake2b);
 new_test!(blake2s_mac, "blake2s/mac", blake2::Blake2s);

--- a/blake2/tests/persona.rs
+++ b/blake2/tests/persona.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate hex_literal;
 
-extern crate blake2;
+
 
 use blake2::{Blake2b, Blake2s, Digest};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.