### PR TITLE
gost94: 2018 edition and `digest` crate upgrade

### DIFF
--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -5,18 +5,19 @@ description = "GOST R 34.11-94 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/gost94"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "gost94", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/gost94/benches/lib.rs
+++ b/gost94/benches/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate gost94;
 
+use digest::bench;
 bench!(gost94::Gost94Test);

--- a/gost94/examples/gost94_cryptopro_sum.rs
+++ b/gost94/examples/gost94_cryptopro_sum.rs
@@ -1,5 +1,3 @@
-extern crate gost94;
-
 use gost94::{Digest, Gost94CryptoPro};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/gost94/examples/gost94_test_sum.rs
+++ b/gost94/examples/gost94_test_sum.rs
@@ -1,5 +1,3 @@
-extern crate gost94;
-
 use gost94::{Digest, Gost94Test};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/gost94/src/gost94.rs
+++ b/gost94/src/gost94.rs
@@ -1,11 +1,9 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::needless_range_loop))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
 use block_buffer::block_padding::ZeroPadding;
 use block_buffer::byteorder::{ByteOrder, LE};
 use block_buffer::BlockBuffer;
 use digest::generic_array::typenum::U32;
 use digest::generic_array::GenericArray;
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 
 pub(crate) type Block = [u8; 32];
 
@@ -222,8 +220,8 @@ impl BlockInput for Gost94 {
     type BlockSize = U32;
 }
 
-impl Input for Gost94 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+impl Update for Gost94 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
         let input = input.as_ref();
         let self_state = &mut self.state;
         self_state.update_n(input.len());

--- a/gost94/src/lib.rs
+++ b/gost94/src/lib.rs
@@ -12,7 +12,7 @@
 //! let mut hasher = Gost94Test::new();
 //!
 //! // process input message
-//! hasher.input(b"hello world");
+//! hasher.update(b"hello world");
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 32]
@@ -29,7 +29,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-extern crate block_buffer;
+
 #[macro_use]
 pub extern crate digest;
 #[macro_use]
@@ -47,7 +47,7 @@ mod test_param;
 
 pub use digest::Digest;
 
-pub use cryptopro::Gost94CryptoPro;
-pub use gost94::Gost94;
-pub use s2015::Gost94s2015;
-pub use test_param::Gost94Test;
+pub use crate::cryptopro::Gost94CryptoPro;
+pub use crate::gost94::Gost94;
+pub use crate::s2015::Gost94s2015;
+pub use crate::test_param::Gost94Test;

--- a/gost94/src/macros.rs
+++ b/gost94/src/macros.rs
@@ -2,7 +2,7 @@ macro_rules! gost94_impl {
     ($state:ident, $sbox:expr) => {
         use digest::generic_array::typenum::U32;
         use digest::generic_array::GenericArray;
-        use digest::{BlockInput, FixedOutput, Input, Reset};
+        use digest::{BlockInput, FixedOutput, Reset, Update};
         use $crate::gost94::{Block, Gost94, SBox};
 
         #[derive(Clone)]
@@ -22,10 +22,10 @@ macro_rules! gost94_impl {
             type BlockSize = U32;
         }
 
-        impl Input for $state {
-            fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+        impl Update for $state {
+            fn update(&mut self, input: impl AsRef<[u8]>) {
                 let input = input.as_ref();
-                self.sh.input(input);
+                self.sh.update(input);
             }
         }
 

--- a/gost94/tests/lib.rs
+++ b/gost94/tests/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate gost94;
+use gost94;
 
 use digest::dev::{digest_test, one_million_a};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.