### PR TITLE
groestl: 2018 edition and `digest` crate upgrade

### DIFF
--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -5,18 +5,19 @@ description = "Grøstl hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/groestl"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "groestl", "grostl", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/groestl/benches/groestl256.rs
+++ b/groestl/benches/groestl256.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate groestl;
 
+use digest::bench;
 bench!(groestl::Groestl256);

--- a/groestl/benches/groestl512.rs
+++ b/groestl/benches/groestl512.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate groestl;
 
+use digest::bench;
 bench!(groestl::Groestl512);

--- a/groestl/src/groestl.rs
+++ b/groestl/src/groestl.rs
@@ -6,7 +6,7 @@ use digest;
 use digest::generic_array::typenum::{Quot, U8};
 use digest::generic_array::{ArrayLength, GenericArray};
 
-use state::{xor_generic_array, GroestlState};
+use crate::state::{xor_generic_array, GroestlState};
 
 #[derive(Clone)]
 pub struct Groestl<BlockSize>

--- a/groestl/src/lib.rs
+++ b/groestl/src/lib.rs
@@ -19,7 +19,7 @@
 //! let mut hasher = Groestl256::default();
 //!
 //! // process input message
-//! hasher.input(b"my message");
+//! hasher.update(b"my message");
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 32]
@@ -34,13 +34,17 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/Grøstl
 //! [2]: https://github.com/RustCrypto/hashes
+
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-#[macro_use]
-extern crate opaque_debug;
+
+// TODO: import all digest macros via 2018 module syntax
 #[macro_use]
 pub extern crate digest;
-extern crate block_buffer;
+
+#[macro_use]
+extern crate opaque_debug;
+
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -48,7 +52,7 @@ use digest::generic_array::typenum::{Unsigned, U128, U28, U32, U48, U64};
 use digest::generic_array::GenericArray;
 pub use digest::Digest;
 use digest::InvalidOutputSize;
-use digest::{BlockInput, FixedOutput, Input, Reset, VariableOutput};
+use digest::{BlockInput, FixedOutput, Reset, Update, VariableOutput};
 
 mod consts;
 mod groestl;
@@ -57,7 +61,7 @@ mod state;
 #[macro_use]
 mod macros;
 
-use groestl::Groestl;
+use crate::groestl::Groestl;
 
 impl_groestl!(Groestl512, U64, U128);
 impl_groestl!(Groestl384, U48, U128);

--- a/groestl/src/macros.rs
+++ b/groestl/src/macros.rs
@@ -17,8 +17,8 @@ macro_rules! impl_groestl {
             type BlockSize = $block;
         }
 
-        impl Input for $state {
-            fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+        impl Update for $state {
+            fn update(&mut self, input: impl AsRef<[u8]>) {
                 let input = input.as_ref();
                 self.groestl.process(input);
             }
@@ -56,8 +56,8 @@ macro_rules! impl_variable_groestl {
             type BlockSize = $block;
         }
 
-        impl Input for $state {
-            fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+        impl Update for $state {
+            fn update(&mut self, input: impl AsRef<[u8]>) {
                 self.groestl.process(input.as_ref());
             }
         }

--- a/groestl/src/state.rs
+++ b/groestl/src/state.rs
@@ -1,10 +1,10 @@
 use core::ops::Div;
 
+use crate::consts::{B, C_P, C_Q, SBOX, SHIFTS_P, SHIFTS_P_WIDE, SHIFTS_Q, SHIFTS_Q_WIDE};
+use crate::matrix::Matrix;
 use block_buffer::byteorder::{ByteOrder, BE};
-use consts::{B, C_P, C_Q, SBOX, SHIFTS_P, SHIFTS_P_WIDE, SHIFTS_Q, SHIFTS_Q_WIDE};
 use digest::generic_array::typenum::{Quot, U8};
 use digest::generic_array::{ArrayLength, GenericArray};
-use matrix::Matrix;
 
 #[derive(Copy, Clone)]
 pub struct GroestlState<BlockSize>
@@ -189,7 +189,7 @@ where
 #[cfg(test)]
 mod test {
     use super::{xor_generic_array, GroestlState};
-    use consts::{C_P, C_Q, SHIFTS_P};
+    use crate::consts::{C_P, C_Q, SHIFTS_P};
     use digest::generic_array::typenum::U64;
     use digest::generic_array::GenericArray;
 

--- a/groestl/tests/lib.rs
+++ b/groestl/tests/lib.rs
@@ -1,9 +1,6 @@
 #![no_std]
-#[macro_use]
-extern crate digest;
-extern crate groestl;
 
-use digest::dev::digest_test;
+use digest::{dev::digest_test, new_test};
 
 new_test!(
     groestl_224_main,


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.