### PR TITLE
k12: 2018 edition and `digest` crate upgrade

### DIFF
--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -5,16 +5,17 @@ description = "Experimental pure Rust implementation of the KangarooTwelve hash 
 authors = ["Diggory Hardy <github1@dhardy.name>"]
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/k12"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/k12/src/lanes.rs
+++ b/k12/src/lanes.rs
@@ -1,6 +1,7 @@
 /// Copied from `arrayref` crate
 macro_rules! array_ref {
     ($arr:expr, $offset:expr, $len:expr) => {{
+        #[allow(unsafe_code)]
         {
             #[inline]
             unsafe fn as_array<T>(slice: &[T]) -> &[T; $len] {

--- a/k12/src/lib.rs
+++ b/k12/src/lib.rs
@@ -9,7 +9,11 @@
 // <https://github.com/dhardy/hash-bench/blob/master/src/k12.rs>
 
 #![no_std]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
 
+// TODO(tarcieri): eliminate alloc requirement
 extern crate alloc;
 
 #[macro_use]
@@ -136,9 +140,12 @@ fn f(input: &[u8], suffix: u8, mut output_len: usize) -> Vec<u8> {
     output
 }
 
+#[allow(unsafe_code)]
 fn read_u64(bytes: &[u8; 8]) -> u64 {
     unsafe { *(bytes as *const _ as *const u64) }.to_le()
 }
+
+#[allow(unsafe_code)]
 fn write_u64(val: u64) -> [u8; 8] {
     unsafe { *(&val.to_le() as *const u64 as *const _) }
 }


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.