### PR TITLE
md2: 2018 edition and `digest` crate upgrade

### DIFF
--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -5,18 +5,19 @@ license = "MIT OR Apache-2.0"
 authors = ["RustCrypto Developers"]
 description = "MD2 hash function"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/md2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "md2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/md2/benches/lib.rs
+++ b/md2/benches/lib.rs
@@ -2,6 +2,6 @@
 #![feature(test)]
 #[macro_use]
 extern crate digest;
-extern crate md2;
+use md2;
 
 bench!(md2::Md2);

--- a/md2/examples/md2sum.rs
+++ b/md2/examples/md2sum.rs
@@ -1,5 +1,3 @@
-extern crate md2;
-
 use md2::{Digest, Md2};
 use std::env;
 use std::fs;
@@ -17,7 +15,7 @@ fn process<R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/md2/src/lib.rs
+++ b/md2/src/lib.rs
@@ -12,7 +12,7 @@
 //! let mut hasher = Md2::new();
 //!
 //! // process input message
-//! hasher.input(b"hello world");
+//! hasher.update(b"hello world");
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 16]
@@ -25,14 +25,18 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/MD4
 //! [2]: https://github.com/RustCrypto/hashes
+
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::needless_range_loop))]
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
 #[macro_use]
 extern crate opaque_debug;
+
 #[macro_use]
 pub extern crate digest;
-extern crate block_buffer;
+
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -41,7 +45,7 @@ use block_buffer::BlockBuffer;
 use digest::generic_array::typenum::U16;
 use digest::generic_array::GenericArray;
 pub use digest::Digest;
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 
 mod consts;
 
@@ -99,8 +103,8 @@ impl BlockInput for Md2 {
     type BlockSize = U16;
 }
 
-impl Input for Md2 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+impl Update for Md2 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
         let input = input.as_ref();
         let self_state = &mut self.state;
         self.buffer.input(input, |d| self_state.process_block(d));

--- a/md2/tests/lib.rs
+++ b/md2/tests/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate md2;
+use md2;
 
 use digest::dev::{digest_test, one_million_a};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.