### PR TITLE
md4: 2018 edition and `digest` crate upgrade

### DIFF
--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -5,19 +5,20 @@ description = "MD4 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/md4"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "md4", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 fake-simd = "0.1"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/md4/benches/lib.rs
+++ b/md4/benches/lib.rs
@@ -2,6 +2,6 @@
 #![feature(test)]
 #[macro_use]
 extern crate digest;
-extern crate md4;
+use md4;
 
 bench!(md4::Md4);

--- a/md4/examples/md4sum.rs
+++ b/md4/examples/md4sum.rs
@@ -1,5 +1,3 @@
-extern crate md4;
-
 use md4::{Digest, Md4};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/md4/src/lib.rs
+++ b/md4/src/lib.rs
@@ -12,7 +12,7 @@
 //! let mut hasher = Md4::new();
 //!
 //! // process input message
-//! hasher.input(b"hello world");
+//! hasher.update(b"hello world");
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 16]
@@ -25,25 +25,28 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/MD4
 //! [2]: https://github.com/RustCrypto/hashes
+
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
+#![deny(unsafe_code)]
+#![warn(rust_2018_idioms)]
+
 #[macro_use]
 extern crate opaque_debug;
 #[macro_use]
 pub extern crate digest;
-extern crate block_buffer;
+
 extern crate fake_simd as simd;
 #[cfg(feature = "std")]
 extern crate std;
 
+use crate::simd::u32x4;
 use block_buffer::byteorder::{ByteOrder, LE};
 use block_buffer::BlockBuffer;
 use digest::generic_array::typenum::{U16, U64};
 use digest::generic_array::GenericArray;
 pub use digest::Digest;
-use digest::{BlockInput, FixedOutput, Input, Reset};
-use simd::u32x4;
+use digest::{BlockInput, FixedOutput, Reset, Update};
 
 // initial values for Md4State
 const S: u32x4 = u32x4(0x6745_2301, 0xEFCD_AB89, 0x98BA_DCFE, 0x1032_5476);
@@ -151,8 +154,8 @@ impl BlockInput for Md4 {
     type BlockSize = U64;
 }
 
-impl Input for Md4 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+impl Update for Md4 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
         let input = input.as_ref();
         // Unlike Sha1 and Sha2, the length value in MD4 is defined as
         // the length of the message mod 2^64 - ie: integer overflow is OK.

--- a/md4/tests/lib.rs
+++ b/md4/tests/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate md4;
+use md4;
 
 use digest::dev::{digest_test, one_million_a};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.