### PR TITLE
md5: 2018 edition and `digest` crate upgrade

### DIFF
--- a/md2/benches/lib.rs
+++ b/md2/benches/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-use md2;
 
+use digest::bench;
 bench!(md2::Md2);

--- a/md4/benches/lib.rs
+++ b/md4/benches/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-use md4;
 
+use digest::bench;
 bench!(md4::Md4);

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -5,6 +5,7 @@ description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/md-5"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "md5", "hash", "digest"]
@@ -14,13 +15,13 @@ categories = ["cryptography", "no-std"]
 name = "md5"
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 md5-asm = { version = "0.4", optional=true}
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/md5/benches/lib.rs
+++ b/md5/benches/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate md5;
 
+use digest::bench;
 bench!(md5::Md5);

--- a/md5/examples/md5sum.rs
+++ b/md5/examples/md5sum.rs
@@ -1,5 +1,3 @@
-extern crate md5;
-
 use md5::{Digest, Md5};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/md5/src/utils.rs
+++ b/md5/src/utils.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::inline_always, clippy::many_single_char_names))]
 
+use crate::consts::RC;
 use block_buffer::byteorder::{ByteOrder, LE};
-use consts::RC;
 
 #[inline(always)]
 fn op_f(w: u32, x: u32, y: u32, z: u32, m: u32, c: u32, s: u32) -> u32 {

--- a/md5/tests/lib.rs
+++ b/md5/tests/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate md5;
+use md5;
 
 use digest::dev::{digest_test, one_million_a};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.