### PR TITLE
ripemd160: 2018 edition and `digest` crate upgrade

### DIFF
--- a/ripemd160/Cargo.toml
+++ b/ripemd160/Cargo.toml
@@ -1,21 +1,23 @@
 [package]
 name = "ripemd160"
 version = "0.8.0"
+description = "RIPEMD-160 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
-description = "RIPEMD-160 hash function"
+readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/ripemd160"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "ripemd160", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/ripemd160/benches/lib.rs
+++ b/ripemd160/benches/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate ripemd160;
 
+use digest::bench;
 bench!(ripemd160::Ripemd160);

--- a/ripemd160/examples/ripemd160sum.rs
+++ b/ripemd160/examples/ripemd160sum.rs
@@ -1,5 +1,3 @@
-extern crate ripemd160;
-
 use ripemd160::{Digest, Ripemd160};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/ripemd160/src/lib.rs
+++ b/ripemd160/src/lib.rs
@@ -12,7 +12,7 @@
 //! let mut hasher = Ripemd160::new();
 //!
 //! // process input message
-//! hasher.input(b"Hello world!");
+//! hasher.update(b"Hello world!");
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 20]
@@ -25,9 +25,12 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/RIPEMD
 //! [2]: https://github.com/RustCrypto/hashes
+
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-extern crate block_buffer;
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
 #[macro_use]
 extern crate opaque_debug;
 #[macro_use]
@@ -40,10 +43,10 @@ use block_buffer::BlockBuffer;
 use digest::generic_array::typenum::{U20, U64};
 use digest::generic_array::GenericArray;
 pub use digest::Digest;
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 
 mod block;
-use block::{process_msg_block, DIGEST_BUF_LEN, H0};
+use crate::block::{process_msg_block, DIGEST_BUF_LEN, H0};
 
 /// Structure representing the state of a Ripemd160 computation
 #[derive(Clone)]
@@ -67,8 +70,8 @@ impl BlockInput for Ripemd160 {
     type BlockSize = U64;
 }
 
-impl Input for Ripemd160 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+impl Update for Ripemd160 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
         let input = input.as_ref();
         // Assumes that input.len() can be converted to u64 without overflow
         self.len += input.len() as u64;

--- a/ripemd160/tests/lib.rs
+++ b/ripemd160/tests/lib.rs
@@ -2,7 +2,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate ripemd160;
+use ripemd160;
 
 use digest::dev::{digest_test, one_million_a};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.