### PR TITLE
ripemd320: 2018 edition and `digest` crate upgrade

### DIFF
--- a/ripemd320/Cargo.toml
+++ b/ripemd320/Cargo.toml
@@ -5,18 +5,19 @@ description = "RIPEMD-320 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/ripemd320"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "ripemd320", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/ripemd320/benches/lib.rs
+++ b/ripemd320/benches/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate ripemd320;
 
+use digest::bench;
 bench!(ripemd320::Ripemd320);

--- a/ripemd320/examples/ripemd320sum.rs
+++ b/ripemd320/examples/ripemd320sum.rs
@@ -1,5 +1,3 @@
-extern crate ripemd320;
-
 use ripemd320::{Digest, Ripemd320};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/ripemd320/src/lib.rs
+++ b/ripemd320/src/lib.rs
@@ -12,7 +12,7 @@
 //! let mut hasher = Ripemd320::new();
 //!
 //! // process input message
-//! hasher.input(b"Hello world!");
+//! hasher.update(b"Hello world!");
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 40]
@@ -28,7 +28,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-extern crate block_buffer;
+
 #[macro_use]
 extern crate opaque_debug;
 #[macro_use]
@@ -41,10 +41,10 @@ use block_buffer::BlockBuffer;
 use digest::generic_array::typenum::{U40, U64};
 use digest::generic_array::GenericArray;
 pub use digest::Digest;
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 
 mod block;
-use block::{process_msg_block, DIGEST_BUF_LEN, H0};
+use crate::block::{process_msg_block, DIGEST_BUF_LEN, H0};
 
 /// Structure representing the state of a ripemd320 computation
 #[derive(Clone)]
@@ -68,8 +68,8 @@ impl BlockInput for Ripemd320 {
     type BlockSize = U64;
 }
 
-impl Input for Ripemd320 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+impl Update for Ripemd320 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
         let input = input.as_ref();
         // Assumes that input.len() can be converted to u64 without overflow
         self.len += input.len() as u64;

--- a/ripemd320/tests/lib.rs
+++ b/ripemd320/tests/lib.rs
@@ -4,7 +4,7 @@
 
 #[macro_use]
 extern crate digest;
-extern crate ripemd320;
+use ripemd320;
 
 use digest::dev::{digest_test, one_million_a};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.