### PR TITLE
sha1: 2018 edition and `digest` crate upgrade

### DIFF
--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -5,6 +5,7 @@ description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/sha-1"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha1", "hash", "digest"]
@@ -14,15 +15,15 @@ categories = ["cryptography", "no-std"]
 name = "sha1"
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 fake-simd = "0.1"
 sha1-asm = { version = "0.4", optional = true }
 opaque-debug = "0.2"
 libc = { version = "0.2.68", optional = true }
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/sha1/benches/lib.rs
+++ b/sha1/benches/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate sha1;
 
+use digest::bench;
 bench!(sha1::Sha1);

--- a/sha1/examples/sha1sum.rs
+++ b/sha1/examples/sha1sum.rs
@@ -1,5 +1,3 @@
-extern crate sha1;
-
 use sha1::{Digest, Sha1};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/sha1/src/aarch64.rs
+++ b/sha1/src/aarch64.rs
@@ -2,6 +2,7 @@ use libc::{getauxval, AT_HWCAP, HWCAP_SHA1};
 
 #[inline(always)]
 pub fn sha1_supported() -> bool {
+    #[allow(unsafe_code)]
     let hwcaps: u64 = unsafe { getauxval(AT_HWCAP) };
     (hwcaps & HWCAP_SHA1) != 0
 }

--- a/sha1/src/utils.rs
+++ b/sha1/src/utils.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
 
+use crate::consts::{BLOCK_LEN, K0, K1, K2, K3};
+use crate::simd::u32x4;
 use block_buffer::byteorder::{ByteOrder, BE};
-use consts::{BLOCK_LEN, K0, K1, K2, K3};
 use digest::generic_array::typenum::U64;
 use digest::generic_array::GenericArray;
-use simd::u32x4;
 
 type Block = GenericArray<u8, U64>;
 

--- a/sha1/tests/lib.rs
+++ b/sha1/tests/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate sha1;
+use sha1;
 
 use digest::dev::{digest_test, one_million_a};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.