### PR TITLE
sha2: 2018 edition and `digest` crate upgrade

### DIFF
--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -8,21 +8,22 @@ including SHA-224, SHA-256, SHA-384, and SHA-512.
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/sha2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 fake-simd = "0.1"
 opaque-debug = "0.2"
 sha2-asm = { version = "0.5", optional = true }
 libc = { version = "0.2.68", optional = true }
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/sha2/benches/sha256.rs
+++ b/sha2/benches/sha256.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate sha2;
 
+use digest::bench;
 bench!(sha2::Sha256);

--- a/sha2/benches/sha512.rs
+++ b/sha2/benches/sha512.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate sha2;
 
+use digest::bench;
 bench!(sha2::Sha512);

--- a/sha2/examples/sha256sum.rs
+++ b/sha2/examples/sha256sum.rs
@@ -1,5 +1,3 @@
-extern crate sha2;
-
 use sha2::{Digest, Sha256};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/sha2/examples/sha512sum.rs
+++ b/sha2/examples/sha512sum.rs
@@ -1,5 +1,3 @@
-extern crate sha2;
-
 use sha2::{Digest, Sha512};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/sha2/src/consts.rs
+++ b/sha2/src/consts.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
 
-use simd::u32x4;
-use simd::u64x2;
+use crate::simd::u32x4;
+use crate::simd::u64x2;
 
 pub const STATE_LEN: usize = 8;
 pub const BLOCK_LEN: usize = 16;

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -29,7 +29,7 @@
 //! let mut hasher = Sha256::new();
 //!
 //! // write input message
-//! hasher.input(b"hello world");
+//! hasher.update(b"hello world");
 //!
 //! // read hash digest and consume hasher
 //! let result = hasher.result();
@@ -40,7 +40,7 @@
 //!
 //! // same for Sha512
 //! let mut hasher = Sha512::new();
-//! hasher.input(b"hello world");
+//! hasher.update(b"hello world");
 //! let result = hasher.result();
 //!
 //! assert_eq!(result[..], hex!("
@@ -57,6 +57,7 @@
 
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![warn(missing_docs, rust_2018_idioms)]
 
 // Give relevant error messages if the user tries to enable AArch64 asm on unsupported platforms.
 #[cfg(all(
@@ -82,7 +83,6 @@ compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" when build
 ))]
 compile_error!("Enable the \"asm-aarch64\" feature on AArch64 if you want to use asm detected at runtime, or build with the crypto extensions support, for instance with RUSTFLAGS='-C target-cpu=native' on a compatible CPU.");
 
-extern crate block_buffer;
 extern crate fake_simd as simd;
 #[macro_use]
 extern crate opaque_debug;
@@ -105,10 +105,10 @@ mod sha512;
 #[cfg(any(not(feature = "asm"), target_arch = "aarch64", feature = "compress"))]
 mod sha512_utils;
 
+pub use crate::sha256::{Sha224, Sha256};
+pub use crate::sha512::{Sha384, Sha512, Sha512Trunc224, Sha512Trunc256};
 pub use digest::Digest;
-pub use sha256::{Sha224, Sha256};
 #[cfg(feature = "compress")]
 pub use sha256_utils::compress256;
-pub use sha512::{Sha384, Sha512, Sha512Trunc224, Sha512Trunc256};
 #[cfg(feature = "compress")]
 pub use sha512_utils::compress512;

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -2,12 +2,12 @@ use block_buffer::byteorder::{ByteOrder, BE};
 use block_buffer::BlockBuffer;
 use digest::generic_array::typenum::{U28, U32, U64};
 use digest::generic_array::GenericArray;
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 
-use consts::{H224, H256, STATE_LEN};
+use crate::consts::{H224, H256, STATE_LEN};
 
 #[cfg(not(feature = "asm"))]
-use sha256_utils::compress256;
+use crate::sha256_utils::compress256;
 #[cfg(feature = "asm")]
 use sha2_asm::compress256;
 
@@ -64,7 +64,7 @@ impl Engine256 {
         }
     }
 
-    fn input(&mut self, input: &[u8]) {
+    fn update(&mut self, input: &[u8]) {
         // Assumes that input.len() can be converted to u64 without overflow
         self.len += (input.len() as u64) << 3;
         let self_state = &mut self.state;
@@ -104,9 +104,9 @@ impl BlockInput for Sha256 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Sha256 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
-        self.engine.input(input.as_ref());
+impl Update for Sha256 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
+        self.engine.update(input.as_ref());
     }
 }
 
@@ -146,9 +146,9 @@ impl BlockInput for Sha224 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Sha224 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
-        self.engine.input(input.as_ref());
+impl Update for Sha224 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
+        self.engine.update(input.as_ref());
     }
 }
 

--- a/sha2/src/sha256_utils.rs
+++ b/sha2/src/sha256_utils.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
 
+use crate::consts::{BLOCK_LEN, K32X4};
+use crate::simd::u32x4;
 use block_buffer::byteorder::{ByteOrder, BE};
-use consts::{BLOCK_LEN, K32X4};
-use simd::u32x4;
 
 /// Not an intrinsic, but works like an unaligned load.
 #[inline]

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -2,14 +2,14 @@ use block_buffer::byteorder::{ByteOrder, BE};
 use block_buffer::BlockBuffer;
 use digest::generic_array::typenum::{U128, U28, U32, U48, U64};
 use digest::generic_array::GenericArray;
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 
-use consts::{H384, H512, H512_TRUNC_224, H512_TRUNC_256, STATE_LEN};
+use crate::consts::{H384, H512, H512_TRUNC_224, H512_TRUNC_256, STATE_LEN};
 
+#[cfg(any(not(feature = "asm"), target_arch = "aarch64"))]
+use crate::sha512_utils::compress512;
 #[cfg(all(feature = "asm", not(target_arch = "aarch64")))]
 use sha2_asm::compress512;
-#[cfg(any(not(feature = "asm"), target_arch = "aarch64"))]
-use sha512_utils::compress512;
 
 type BlockSize = U128;
 type Block = GenericArray<u8, BlockSize>;
@@ -50,7 +50,7 @@ impl Engine512 {
         }
     }
 
-    fn input(&mut self, input: &[u8]) {
+    fn update(&mut self, input: &[u8]) {
         let (res, over) = self.len.1.overflowing_add((input.len() as u64) << 3);
         self.len.1 = res;
         if over {
@@ -92,9 +92,9 @@ impl BlockInput for Sha512 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Sha512 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
-        self.engine.input(input.as_ref());
+impl Update for Sha512 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
+        self.engine.update(input.as_ref());
     }
 }
 
@@ -135,9 +135,9 @@ impl BlockInput for Sha384 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Sha384 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
-        self.engine.input(input.as_ref());
+impl Update for Sha384 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
+        self.engine.update(input.as_ref());
     }
 }
 
@@ -178,9 +178,9 @@ impl BlockInput for Sha512Trunc256 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Sha512Trunc256 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
-        self.engine.input(input.as_ref());
+impl Update for Sha512Trunc256 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
+        self.engine.update(input.as_ref());
     }
 }
 
@@ -221,9 +221,9 @@ impl BlockInput for Sha512Trunc224 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Sha512Trunc224 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
-        self.engine.input(input.as_ref());
+impl Update for Sha512Trunc224 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
+        self.engine.update(input.as_ref());
     }
 }
 

--- a/sha2/src/sha512_utils.rs
+++ b/sha2/src/sha512_utils.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
 
+use crate::consts::{BLOCK_LEN, K64X2};
+use crate::simd::u64x2;
 use block_buffer::byteorder::{ByteOrder, BE};
-use consts::{BLOCK_LEN, K64X2};
-use simd::u64x2;
 
 /// Not an intrinsic, but works like an unaligned load.
 #[inline]

--- a/sha2/tests/lib.rs
+++ b/sha2/tests/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate sha2;
+use sha2;
 
 use digest::dev::{digest_test, one_million_a};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.