### PR TITLE
sha3: 2018 edition and `digest` crate upgrade

### DIFF
--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -5,20 +5,21 @@ description = "SHA-3 (Keccak) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/sha3"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha3", "keccak", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 byte-tools = "0.3"
 opaque-debug = "0.2"
 keccak = "0.1"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/sha3/benches/sha3_256.rs
+++ b/sha3/benches/sha3_256.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate sha3;
 
+use digest::bench;
 bench!(sha3::Sha3_256);

--- a/sha3/benches/sha3_512.rs
+++ b/sha3/benches/sha3_512.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate sha3;
 
+use digest::bench;
 bench!(sha3::Sha3_512);

--- a/sha3/examples/sha3_256sum.rs
+++ b/sha3/examples/sha3_256sum.rs
@@ -1,5 +1,3 @@
-extern crate sha3;
-
 use sha3::{Digest, Sha3_256};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/sha3/examples/sha3_512sum.rs
+++ b/sha3/examples/sha3_512sum.rs
@@ -1,5 +1,3 @@
-extern crate sha3;
-
 use sha3::{Digest, Sha3_512};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -25,7 +25,7 @@
 //! let mut hasher = Sha3_256::new();
 //!
 //! // write input message
-//! hasher.input(b"abc");
+//! hasher.update(b"abc");
 //!
 //! // read hash digest
 //! let result = hasher.result();
@@ -40,12 +40,12 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/SHA-3
 //! [2]: https://github.com/RustCrypto/hashes
+
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-#![deny(missing_docs, warnings)]
-extern crate block_buffer;
-extern crate byte_tools;
-extern crate keccak;
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
 #[macro_use]
 extern crate opaque_debug;
 #[macro_use]
@@ -59,7 +59,7 @@ use digest::generic_array::typenum::{
 };
 use digest::generic_array::GenericArray;
 pub use digest::Digest;
-use digest::{BlockInput, ExtendableOutput, FixedOutput, Input, Reset};
+use digest::{BlockInput, ExtendableOutput, FixedOutput, Reset, Update};
 
 mod paddings;
 #[macro_use]
@@ -67,8 +67,8 @@ mod macros;
 mod reader;
 mod state;
 
-pub use reader::Sha3XofReader;
-use state::Sha3State;
+pub use crate::reader::Sha3XofReader;
+use crate::state::Sha3State;
 
 sha3_impl!(
     Keccak224,

--- a/sha3/src/macros.rs
+++ b/sha3/src/macros.rs
@@ -32,8 +32,8 @@ macro_rules! sha3_impl {
             type BlockSize = $rate;
         }
 
-        impl Input for $state {
-            fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+        impl Update for $state {
+            fn update(&mut self, input: impl AsRef<[u8]>) {
                 self.absorb(input.as_ref())
             }
         }
@@ -69,8 +69,8 @@ macro_rules! shake_impl {
     ($state:ident, $rate:ident, $padding:ty, $doc:expr) => {
         impl_state!($state, $rate, $padding, $doc);
 
-        impl Input for $state {
-            fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+        impl Update for $state {
+            fn update(&mut self, input: impl AsRef<[u8]>) {
                 self.absorb(input.as_ref())
             }
         }

--- a/sha3/src/reader.rs
+++ b/sha3/src/reader.rs
@@ -1,5 +1,5 @@
+use crate::state::Sha3State;
 use digest::XofReader;
-use state::Sha3State;
 #[cfg(feature = "std")]
 use std::io;
 

--- a/sha3/src/state.rs
+++ b/sha3/src/state.rs
@@ -14,6 +14,7 @@ impl Sha3State {
         debug_assert_eq!(block.len() % 8, 0);
 
         if cfg!(target_endian = "little") {
+            #[allow(unsafe_code)]
             let state = unsafe { &mut *(self.state.as_mut_ptr() as *mut [u8; 8 * PLEN]) };
             for (d, i) in state.iter_mut().zip(block) {
                 *d ^= *i;
@@ -35,7 +36,10 @@ impl Sha3State {
     pub(crate) fn as_bytes<F: FnOnce(&[u8; 8 * PLEN])>(&self, f: F) {
         let mut data_copy;
         let data_ref: &[u8; 8 * PLEN] = if cfg!(target_endian = "little") {
-            unsafe { &*(self.state.as_ptr() as *const [u8; 8 * PLEN]) }
+            #[allow(unsafe_code)]
+            unsafe {
+                &*(self.state.as_ptr() as *const [u8; 8 * PLEN])
+            }
         } else {
             data_copy = [0u8; 8 * PLEN];
             LE::write_u64_into(&self.state, &mut data_copy);

--- a/sha3/tests/lib.rs
+++ b/sha3/tests/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate sha3;
+use sha3;
 
 use digest::dev::{digest_test, xof_test};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.