### PR TITLE
shabal: 2018 edition and `digest` crate upgrade

### DIFF
--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -5,18 +5,19 @@ description = "Shabal hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/shabal"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "shabal", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
-block-buffer = "0.7"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/shabal/benches/shabal.rs
+++ b/shabal/benches/shabal.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate shabal;
 
+use digest::bench;
 bench!(shabal::Shabal256);

--- a/shabal/examples/shabal256sum.rs
+++ b/shabal/examples/shabal256sum.rs
@@ -1,5 +1,3 @@
-extern crate shabal;
-
 use shabal::{Digest, Shabal256};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/shabal/examples/shabal512sum.rs
+++ b/shabal/examples/shabal512sum.rs
@@ -1,5 +1,3 @@
-extern crate shabal;
-
 use shabal::{Digest, Shabal512};
 use std::env;
 use std::fs;
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/shabal/src/lib.rs
+++ b/shabal/src/lib.rs
@@ -23,7 +23,7 @@
 //! let mut hasher = Shabal256::new();
 //!
 //! // process input message
-//! hasher.input(b"helloworld");
+//! hasher.update(b"helloworld");
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 32]
@@ -36,10 +36,12 @@
 //!
 //! [1]: https://www.cs.rit.edu/~ark/20090927/Round2Candidates/Shabal.pdf
 //! [2]: https://github.com/RustCrypto/hashes
+
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
 
-extern crate block_buffer;
 #[macro_use]
 extern crate opaque_debug;
 #[macro_use]
@@ -50,5 +52,5 @@ extern crate std;
 mod consts;
 mod shabal;
 
+pub use crate::shabal::{Shabal192, Shabal224, Shabal256, Shabal384, Shabal512};
 pub use digest::Digest;
-pub use shabal::{Shabal192, Shabal224, Shabal256, Shabal384, Shabal512};

--- a/shabal/src/shabal.rs
+++ b/shabal/src/shabal.rs
@@ -4,9 +4,9 @@ use block_buffer::BlockBuffer;
 use digest::generic_array::typenum::{U24, U28, U32, U48, U64};
 use digest::generic_array::GenericArray;
 pub use digest::Digest;
-use digest::{BlockInput, FixedOutput, Input, Reset};
+use digest::{BlockInput, FixedOutput, Reset, Update};
 
-use consts::{
+use crate::consts::{
     A_INIT_192, A_INIT_224, A_INIT_256, A_INIT_384, A_INIT_512, B_INIT_192, B_INIT_224, B_INIT_256,
     B_INIT_384, B_INIT_512, C_INIT_192, C_INIT_224, C_INIT_256, C_INIT_384, C_INIT_512,
 };
@@ -37,11 +37,13 @@ impl EngineState {
     }
 
     fn process_block(&mut self, block: &Block) {
+        #[allow(unsafe_code)]
         let block = unsafe { &*(block.as_ptr() as *const [u8; 64]) };
         compress(self, block);
     }
 
     fn process_final_block(&mut self, block: &Block) {
+        #[allow(unsafe_code)]
         let block = unsafe { &*(block.as_ptr() as *const [u8; 64]) };
         compress_final(self, block);
     }
@@ -269,8 +271,8 @@ impl BlockInput for Shabal512 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Shabal512 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+impl Update for Shabal512 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
         self.engine.input(input.as_ref());
     }
 }
@@ -311,8 +313,8 @@ impl BlockInput for Shabal384 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Shabal384 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+impl Update for Shabal384 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
         self.engine.input(input.as_ref());
     }
 }
@@ -353,8 +355,8 @@ impl BlockInput for Shabal256 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Shabal256 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+impl Update for Shabal256 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
         self.engine.input(input.as_ref());
     }
 }
@@ -395,8 +397,8 @@ impl BlockInput for Shabal224 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Shabal224 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+impl Update for Shabal224 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
         self.engine.input(input.as_ref());
     }
 }
@@ -437,8 +439,8 @@ impl BlockInput for Shabal192 {
     type BlockSize = BlockSize;
 }
 
-impl Input for Shabal192 {
-    fn input<B: AsRef<[u8]>>(&mut self, input: B) {
+impl Update for Shabal192 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
         self.engine.input(input.as_ref());
     }
 }

--- a/shabal/tests/lib.rs
+++ b/shabal/tests/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
-#[macro_use]
-extern crate digest;
-extern crate shabal;
 
 use digest::dev::{digest_test, one_million_a};
+use digest::new_test;
 
 new_test!(shabal192_main, "shabal192", shabal::Shabal192, digest_test);
 new_test!(shabal224_main, "shabal224", shabal::Shabal224, digest_test);


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.