### PR TITLE
streebog: 2018 edition and `digest` crate upgrade

### DIFF
--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -5,19 +5,20 @@ description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/streebog"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "streebog", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 byte-tools = "0.3"
-block-buffer = "0.7"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/streebog/benches/streebog256.rs
+++ b/streebog/benches/streebog256.rs
@@ -2,6 +2,6 @@
 #![feature(test)]
 #[macro_use]
 extern crate digest;
-extern crate streebog;
+use streebog;
 
 bench!(streebog::Streebog256);

--- a/streebog/benches/streebog512.rs
+++ b/streebog/benches/streebog512.rs
@@ -2,6 +2,6 @@
 #![feature(test)]
 #[macro_use]
 extern crate digest;
-extern crate streebog;
+use streebog;
 
 bench!(streebog::Streebog512);

--- a/streebog/examples/streebog256sum.rs
+++ b/streebog/examples/streebog256sum.rs
@@ -1,5 +1,3 @@
-extern crate streebog;
-
 use std::env;
 use std::fs;
 use std::io::{self, Read};
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/streebog/examples/streebog512sum.rs
+++ b/streebog/examples/streebog512sum.rs
@@ -1,5 +1,3 @@
-extern crate streebog;
-
 use std::env;
 use std::fs;
 use std::io::{self, Read};
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/streebog/src/lib.rs
+++ b/streebog/src/lib.rs
@@ -19,7 +19,7 @@
 //! // create a hasher object, to use it do not forget to import `Digest` trait
 //! let mut hasher = Streebog256::new();
 //! // write input message
-//! hasher.input(b"my message");
+//! hasher.update(b"my message");
 //! // read hash digest (it will consume hasher)
 //! let result = hasher.result();
 //!
@@ -29,7 +29,7 @@
 //!
 //! // same for Streebog512
 //! let mut hasher = Streebog512::new();
-//! hasher.input(b"my message");
+//! hasher.update(b"my message");
 //! let result = hasher.result();
 //!
 //! assert_eq!(result[..], hex!("
@@ -43,10 +43,12 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/Streebog
 //! [2]: https://github.com/RustCrypto/hashes
+
 #![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
-extern crate block_buffer;
-extern crate byte_tools;
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
 #[macro_use]
 pub extern crate digest;
 #[macro_use]
@@ -57,13 +59,16 @@ extern crate std;
 use digest::generic_array::typenum::{U32, U64};
 pub use digest::Digest;
 #[cfg(feature = "std")]
-use digest::Input;
+use digest::Update;
 
 mod consts;
 mod streebog;
 mod table;
 
+/// Streebog256
 pub type Streebog256 = streebog::Streebog<U32>;
+
+/// Streebog512
 pub type Streebog512 = streebog::Streebog<U64>;
 
 impl_opaque_debug!(Streebog512);

--- a/streebog/src/table.rs
+++ b/streebog/src/table.rs
@@ -2075,7 +2075,7 @@ pub const SHUFFLED_LIN_TABLE: [[u64; 256]; 8] = [
 #[cfg(test)]
 mod test {
     use super::SHUFFLED_LIN_TABLE;
-    use consts::{A, P};
+    use crate::consts::{A, P};
 
     fn gen_table() -> [[u64; 256]; 8] {
         let mut table: [[u64; 256]; 8] = [[0; 256]; 8];

--- a/streebog/tests/lib.rs
+++ b/streebog/tests/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate streebog;
+use streebog;
 
 use digest::dev::digest_test;
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.