### PR TITLE
whirlpool: 2018 edition and `digest` crate upgrade

### DIFF
--- a/streebog/benches/streebog256.rs
+++ b/streebog/benches/streebog256.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-use streebog;
 
+use digst::bench;
 bench!(streebog::Streebog256);

--- a/streebog/benches/streebog512.rs
+++ b/streebog/benches/streebog512.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-use streebog;
 
+use digest::bench;
 bench!(streebog::Streebog512);

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -5,20 +5,21 @@ description = "Whirlpool hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+edition = "2018"
 documentation = "https://docs.rs/whirlpool"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "whirlpool", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.8"
+digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
 byte-tools = "0.3"
-block-buffer = "0.7"
 opaque-debug = "0.2"
 whirlpool-asm = { version="0.5", optional=true }
 
 [dev-dependencies]
-digest = { version = "0.8", features = ["dev"] }
+digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
 hex-literal = "0.1"
 
 [features]

--- a/whirlpool/benches/lib.rs
+++ b/whirlpool/benches/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![feature(test)]
-#[macro_use]
-extern crate digest;
-extern crate whirlpool;
 
+use digest::bench;
 bench!(whirlpool::Whirlpool);

--- a/whirlpool/examples/whirlpool_sum.rs
+++ b/whirlpool/examples/whirlpool_sum.rs
@@ -1,5 +1,3 @@
-extern crate whirlpool;
-
 use std::env;
 use std::fs;
 use std::io::{self, Read};
@@ -25,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.input(&buffer[..n]);
+        sh.update(&buffer[..n]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/whirlpool/src/utils.rs
+++ b/whirlpool/src/utils.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::identity_op, clippy::needless_range_loop, clippy::double_parens))]
 
+use crate::consts::*;
 use block_buffer::byteorder::{ByteOrder, BE};
-use consts::*;
 
 pub fn compress(hash: &mut [u64; 8], buffer: &[u8; 64]) {
     let mut k = [0u64; 8];

--- a/whirlpool/tests/lib.rs
+++ b/whirlpool/tests/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-extern crate whirlpool;
+use whirlpool;
 
 use digest::dev::{digest_test, one_million_a};
 


### PR DESCRIPTION
Upgrades to Rust 2018 edition and the (now 2018 edition) `digest` v0.9.0-pre crate.