### PR TITLE
Cargo.toml: use patch.crates-io directive for digest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ members = [
     "streebog",
     "whirlpool",
 ]
+
+[patch.crates-io]
+digest = { git = "https://github.com/RustCrypto/traits" }
+block-buffer = { git = "https://github.com/RustCrypto/utils" }
+crypto-mac = { git = "https://github.com/rustcrypto/traits" }

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -12,15 +12,15 @@ keywords = ["crypto", "blake2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "= 0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+digest = "= 0.9.0-pre"
 byte-tools = "0.3"
 byteorder = { version = "1", default-features = false }
-crypto-mac = { version = "= 0.8.0-pre", git = "https://github.com/rustcrypto/traits" }
+crypto-mac = "= 0.8.0-pre"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "= 0.9.0-pre", features = ["dev"], git = "https://github.com/rustcrypto/traits" }
-crypto-mac = { version = "0.8.0-pre", features = ["dev"], git = "https://github.com/rustcrypto/traits" }
+digest = { version = "= 0.9.0-pre", features = ["dev"] }
+crypto-mac = { version = "0.8.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["crypto", "gost94", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "0.9.0-pre"
+block-buffer = "0.7"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["crypto", "groestl", "grostl", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "0.9.0-pre"
+block-buffer = "0.7"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["crypto", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
+digest = "0.9.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["crypto", "md2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "0.9.0-pre"
+block-buffer = "0.7"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -12,13 +12,13 @@ keywords = ["crypto", "md4", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "0.9.0-pre"
+block-buffer = "0.7"
 fake-simd = "0.1"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -15,13 +15,13 @@ categories = ["cryptography", "no-std"]
 name = "md5"
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "0.9.0-pre"
+block-buffer = "0.7"
 md5-asm = { version = "0.4", optional=true}
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/ripemd160/Cargo.toml
+++ b/ripemd160/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["crypto", "ripemd160", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "0.9.0-pre"
+block-buffer = "0.7"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/ripemd320/Cargo.toml
+++ b/ripemd320/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["crypto", "ripemd320", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "0.9.0-pre"
+block-buffer = "0.7"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["cryptography", "no-std"]
 name = "sha1"
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "= 0.9.0-pre"
+block-buffer = "0.7"
 fake-simd = "0.1"
 sha1-asm = { version = "0.4", optional = true }
 opaque-debug = "0.2"
 libc = { version = "0.2.68", optional = true }
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "= 0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["crypto", "sha3", "keccak", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "= 0.9.0-pre"
+block-buffer = "0.7"
 byte-tools = "0.3"
 opaque-debug = "0.2"
 keccak = "0.1"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "= 0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["crypto", "shabal", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "= 0.9.0-pre"
+block-buffer = "0.7"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "= 0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -12,13 +12,13 @@ keywords = ["crypto", "streebog", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "= 0.9.0-pre"
+block-buffer = "0.7"
 byte-tools = "0.3"
 opaque-debug = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "= 0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["crypto", "whirlpool", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.9.0-pre", git = "https://github.com/RustCrypto/traits" }
-block-buffer = { version = "0.7", git = "https://github.com/RustCrypto/utils" }
+digest = "= 0.9.0-pre"
+block-buffer = "0.7"
 byte-tools = "0.3"
 opaque-debug = "0.2"
 whirlpool-asm = { version="0.5", optional=true }
 
 [dev-dependencies]
-digest = { version = "0.9.0-pre", features = ["dev"], git = "https://github.com/RustCrypto/traits" }
+digest = { version = "= 0.9.0-pre", features = ["dev"] }
 hex-literal = "0.1"
 
 [features]


### PR DESCRIPTION
...and `block-modes. Now that all the crates have been upgraded, it's possible to pull in the new version globally to the namespace.

Also pulls in `block-buffer` and `crypto-mac` this way.