### PR TITLE
clippy fixups

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -10,6 +10,17 @@ on:
       - README.md
 
 jobs:
+  clippy:
+  runs-on: ubuntu-latest
+  steps:
+  - uses: actions/checkout@v1
+  - uses: actions-rs/toolchain@v1
+    with:
+      profile: minimal
+      toolchain: 1.41.0 # MSRV
+      components: clippy
+  - run: cargo clippy --all --all-features -- -D warnings
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/blake2/src/consts.rs
+++ b/blake2/src/consts.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 pub static SIGMA: [[usize; 16]; 12] = [
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],

--- a/blake2/src/simd.rs
+++ b/blake2/src/simd.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::inline_always))]
-
 mod simd_opt;
 mod simdint;
 mod simdop;

--- a/blake2/src/simd/simd_opt.rs
+++ b/blake2/src/simd/simd_opt.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![cfg_attr(feature = "clippy", allow(clippy::inline_always))]
-
 #[allow(unused_macros)]
 #[cfg(feature = "simd")]
 macro_rules! transmute_shuffle {

--- a/blake2/src/simd/simd_opt/u32x4.rs
+++ b/blake2/src/simd/simd_opt/u32x4.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![cfg_attr(feature = "clippy", allow(clippy::inline_always))]
-
 use crate::simd::simdty::u32x4;
 
 #[cfg(feature = "simd_opt")]

--- a/blake2/src/simd/simd_opt/u64x4.rs
+++ b/blake2/src/simd/simd_opt/u64x4.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![cfg_attr(feature = "clippy", allow(clippy::inline_always))]
-
 use crate::simd::simdty::u64x4;
 
 #[cfg(feature = "simd_opt")]

--- a/blake2/src/simd/simdty.rs
+++ b/blake2/src/simd/simdty.rs
@@ -5,9 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![allow(dead_code)]
-#![allow(non_camel_case_types)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::inline_always))]
+#![allow(dead_code, non_camel_case_types)]
 
 use crate::as_bytes::Safe;
 
@@ -65,7 +63,6 @@ pub type u16x16 = Simd16<u16>;
 
 pub type u8x32 = Simd32<u8>;
 
-#[cfg_attr(feature = "clippy", allow(clippy::inline_always))]
 impl<T> Simd4<T> {
     #[inline(always)]
     pub fn new(e0: T, e1: T, e2: T, e3: T) -> Simd4<T> {

--- a/blake2/tests/lib.rs
+++ b/blake2/tests/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use blake2;
 
 use digest::dev::{digest_test, variable_test};
 

--- a/gost94/src/gost94.rs
+++ b/gost94/src/gost94.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::many_single_char_names)]
+
 use block_buffer::block_padding::ZeroPadding;
 use block_buffer::byteorder::{ByteOrder, LE};
 use block_buffer::BlockBuffer;
@@ -16,11 +18,14 @@ pub type SBox = [[u8; 16]; 8];
 
 fn sbox(a: u32, s: &SBox) -> u32 {
     let mut v = 0;
+
+    #[allow(clippy::needless_range_loop)]
     for i in 0..8 {
         let shft = 4 * i;
         let k = ((a & (0b1111u32 << shft)) >> shft) as usize;
         v += u32::from(s[i][k]) << shft;
     }
+
     v
 }
 
@@ -28,6 +33,7 @@ fn g(a: u32, k: u32, s: &SBox) -> u32 {
     sbox(a.wrapping_add(k), s).rotate_left(11)
 }
 
+#[allow(clippy::needless_range_loop)]
 fn encrypt(msg: &mut [u8], key: Block, sbox: &SBox) {
     let mut k = [0u32; 8];
     let mut a = LE::read_u32(&msg[0..4]);
@@ -46,6 +52,7 @@ fn encrypt(msg: &mut [u8], key: Block, sbox: &SBox) {
         b = a;
         a = t;
     }
+
     LE::write_u32_into(&[b, a], msg);
 }
 
@@ -196,6 +203,7 @@ impl Gost94State {
     }
 }
 
+/// GOST94
 #[derive(Clone)]
 pub struct Gost94 {
     buffer: BlockBuffer<U32>,
@@ -204,7 +212,7 @@ pub struct Gost94 {
 }
 
 impl Gost94 {
-    // Create new GOST94 instance with given S-Box and IV
+    /// Create new [`Gost94`] instance with given S-Box and IV
     pub fn new(s: SBox, h: Block) -> Self {
         let n = Default::default();
         let sigma = Default::default();

--- a/gost94/src/macros.rs
+++ b/gost94/src/macros.rs
@@ -5,6 +5,7 @@ macro_rules! gost94_impl {
         use digest::{BlockInput, FixedOutput, Reset, Update};
         use $crate::gost94::{Block, Gost94, SBox};
 
+        /// GOST94 state
         #[derive(Clone)]
         pub struct $state {
             sh: Gost94,

--- a/gost94/tests/lib.rs
+++ b/gost94/tests/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use gost94;
 
 use digest::dev::{digest_test, one_million_a};
 

--- a/groestl/src/groestl.rs
+++ b/groestl/src/groestl.rs
@@ -2,7 +2,7 @@ use core::ops::Div;
 
 use block_buffer::byteorder::BE;
 use block_buffer::BlockBuffer;
-use digest;
+
 use digest::generic_array::typenum::{Quot, U8};
 use digest::generic_array::{ArrayLength, GenericArray};
 

--- a/groestl/src/matrix.rs
+++ b/groestl/src/matrix.rs
@@ -1,6 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::needless_range_loop))]
 use core::ops::{Index, IndexMut};
-
 use digest::generic_array::{ArrayLength, GenericArray};
 
 #[derive(Debug, Eq, PartialEq)]

--- a/k12/src/lanes.rs
+++ b/k12/src/lanes.rs
@@ -1,18 +1,4 @@
-/// Copied from `arrayref` crate
-macro_rules! array_ref {
-    ($arr:expr, $offset:expr, $len:expr) => {{
-        #[allow(unsafe_code)]
-        {
-            #[inline]
-            unsafe fn as_array<T>(slice: &[T]) -> &[T; $len] {
-                &*(slice.as_ptr() as *const [_; $len])
-            }
-            let offset = $offset;
-            let slice = &$arr[offset..offset + $len];
-            unsafe { as_array(slice) }
-        }
-    }};
-}
+#![allow(clippy::unreadable_literal)]
 
 macro_rules! REPEAT4 {
     ($e: expr) => {
@@ -104,6 +90,7 @@ pub fn keccak(lanes: &mut [u64; 25]) {
     let mut c = [0u64; 5];
     let (mut x, mut y): (usize, usize);
 
+    #[allow(clippy::needless_range_loop)]
     for round in 0..12 {
         // θ
         FOR5!(x, 1, {

--- a/md2/tests/lib.rs
+++ b/md2/tests/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use md2;
 
 use digest::dev::{digest_test, one_million_a};
 

--- a/md4/src/lib.rs
+++ b/md4/src/lib.rs
@@ -30,6 +30,7 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
+#![allow(clippy::many_single_char_names)]
 
 #[macro_use]
 extern crate opaque_debug;

--- a/md4/tests/lib.rs
+++ b/md4/tests/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use md4;
 
 use digest::dev::{digest_test, one_million_a};
 

--- a/md5/src/consts.rs
+++ b/md5/src/consts.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 /// Round constants
 #[cfg(not(feature = "asm"))]

--- a/md5/src/utils.rs
+++ b/md5/src/utils.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::inline_always, clippy::many_single_char_names))]
+#![allow(clippy::many_single_char_names)]
 
 use crate::consts::RC;
 use block_buffer::byteorder::{ByteOrder, LE};

--- a/md5/tests/lib.rs
+++ b/md5/tests/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use md5;
 
 use digest::dev::{digest_test, one_million_a};
 

--- a/ripemd160/tests/lib.rs
+++ b/ripemd160/tests/lib.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use ripemd160;
 
 use digest::dev::{digest_test, one_million_a};
 

--- a/ripemd320/tests/lib.rs
+++ b/ripemd320/tests/lib.rs
@@ -4,7 +4,6 @@
 
 #[macro_use]
 extern crate digest;
-use ripemd320;
 
 use digest::dev::{digest_test, one_million_a};
 

--- a/sha1/src/consts.rs
+++ b/sha1/src/consts.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 pub const STATE_LEN: usize = 5;
 

--- a/sha1/src/utils.rs
+++ b/sha1/src/utils.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
+#![allow(clippy::many_single_char_names)]
 
 use crate::consts::{BLOCK_LEN, K0, K1, K2, K3};
 use crate::simd::u32x4;

--- a/sha1/tests/lib.rs
+++ b/sha1/tests/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use sha1;
 
 use digest::dev::{digest_test, one_million_a};
 

--- a/sha2/src/consts.rs
+++ b/sha2/src/consts.rs
@@ -1,5 +1,4 @@
-#![allow(dead_code)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(dead_code, clippy::unreadable_literal)]
 
 use crate::simd::u32x4;
 use crate::simd::u64x2;

--- a/sha2/src/sha256_utils.rs
+++ b/sha2/src/sha256_utils.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
+#![allow(clippy::many_single_char_names)]
 
 use crate::consts::{BLOCK_LEN, K32X4};
 use crate::simd::u32x4;

--- a/sha2/src/sha512_utils.rs
+++ b/sha2/src/sha512_utils.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
+#![allow(clippy::many_single_char_names)]
 
 use crate::consts::{BLOCK_LEN, K64X2};
 use crate::simd::u64x2;

--- a/sha2/tests/lib.rs
+++ b/sha2/tests/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use sha2;
 
 use digest::dev::{digest_test, one_million_a};
 

--- a/sha3/src/state.rs
+++ b/sha3/src/state.rs
@@ -1,5 +1,4 @@
 use block_buffer::byteorder::{ByteOrder, LE};
-use keccak;
 
 const PLEN: usize = 25;
 

--- a/sha3/tests/lib.rs
+++ b/sha3/tests/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use sha3;
 
 use digest::dev::{digest_test, xof_test};
 

--- a/shabal/src/shabal.rs
+++ b/shabal/src/shabal.rs
@@ -136,7 +136,7 @@ impl EngineState {
     }
 
     #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))]
+    #[allow(clippy::too_many_arguments)]
     fn perm_elt(
         &mut self,
         xa0: usize,

--- a/streebog/benches/streebog256.rs
+++ b/streebog/benches/streebog256.rs
@@ -1,5 +1,5 @@
 #![no_std]
 #![feature(test)]
 
-use digst::bench;
+use digest::bench;
 bench!(streebog::Streebog256);

--- a/streebog/src/streebog.rs
+++ b/streebog/src/streebog.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::needless_range_loop, clippy::inline_always))]
 use block_buffer::block_padding::ZeroPadding;
 use block_buffer::byteorder::{ByteOrder, LE};
 use block_buffer::BlockBuffer;
@@ -50,6 +49,7 @@ impl StreebogState {
 
         lps(&mut key, n);
 
+        #[allow(clippy::needless_range_loop)]
         for i in 0..12 {
             lps(&mut block, &key);
             lps(&mut key, &C[i]);

--- a/streebog/src/table.rs
+++ b/streebog/src/table.rs
@@ -3,7 +3,7 @@
 //!
 //! It was created using `gen_table` function
 
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 pub const SHUFFLED_LIN_TABLE: [[u64; 256]; 8] = [
     [

--- a/streebog/tests/lib.rs
+++ b/streebog/tests/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use streebog;
 
 use digest::dev::digest_test;
 

--- a/whirlpool/src/consts.rs
+++ b/whirlpool/src/consts.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#![allow(clippy::unreadable_literal)]
 
 pub static R: usize = 10;
 

--- a/whirlpool/src/utils.rs
+++ b/whirlpool/src/utils.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::identity_op, clippy::needless_range_loop, clippy::double_parens))]
-
 use crate::consts::*;
 use block_buffer::byteorder::{ByteOrder, BE};
 
@@ -16,9 +14,10 @@ pub fn compress(hash: &mut [u64; 8], buffer: &[u8; 64]) {
         state[i] = block[i] ^ k[i];
     }
 
+    #[allow(clippy::needless_range_loop)]
     for r in 1..(R + 1) {
         for i in 0..8 {
-            l[i] = C0[(k[(0 + i) % 8] >> 56) as usize]
+            l[i] = C0[(k[(i) % 8] >> 56) as usize]
                 ^ C1[((k[(7 + i) % 8] >> 48) & 0xff) as usize]
                 ^ C2[((k[(6 + i) % 8] >> 40) & 0xff) as usize]
                 ^ C3[((k[(5 + i) % 8] >> 32) & 0xff) as usize]
@@ -30,7 +29,7 @@ pub fn compress(hash: &mut [u64; 8], buffer: &[u8; 64]) {
         }
         k = l;
         for i in 0..8 {
-            l[i] = C0[(state[(0 + i) % 8] >> 56) as usize]
+            l[i] = C0[(state[(i) % 8] >> 56) as usize]
                 ^ C1[((state[(7 + i) % 8] >> 48) & 0xff) as usize]
                 ^ C2[((state[(6 + i) % 8] >> 40) & 0xff) as usize]
                 ^ C3[((state[(5 + i) % 8] >> 32) & 0xff) as usize]

--- a/whirlpool/tests/lib.rs
+++ b/whirlpool/tests/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #[macro_use]
 extern crate digest;
-use whirlpool;
 
 use digest::dev::{digest_test, one_million_a};
 


### PR DESCRIPTION
Allows clippy to pass on MSRV (1.41).

Adds clippy to the Workspace workflow for GitHub Actions.