### PR TITLE
Rename `*result*` to `finalize`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 [[package]]
 name = "block-buffer"
 version = "0.8.0-pre"
-source = "git+https://github.com/RustCrypto/utils#a0e48018d38545935152cd1715382bc1984b5699"
+source = "git+https://github.com/RustCrypto/utils#2aae8a40556e166e9ca06aebc944091dda24b769"
 dependencies = [
  "block-padding",
  "byte-tools",
@@ -62,7 +62,7 @@ checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 [[package]]
 name = "crypto-mac"
 version = "0.8.0-pre"
-source = "git+https://github.com/rustcrypto/traits#f1ae0b0bf1187f0c0a90bd07caa66710240daca5"
+source = "git+https://github.com/rustcrypto/traits#88bdef68d6b8da01249391b74b265499dfd76a37"
 dependencies = [
  "blobby",
  "generic-array",
@@ -72,7 +72,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.9.0-pre"
-source = "git+https://github.com/rustcrypto/traits#f1ae0b0bf1187f0c0a90bd07caa66710240daca5"
+source = "git+https://github.com/rustcrypto/traits#88bdef68d6b8da01249391b74b265499dfd76a37"
 dependencies = [
  "blobby",
  "generic-array",
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "hex-literal-impl"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4c5c844e2fee0bf673d54c2c177f1713b3d2af2ff6e666b49cb7572e6cf42d"
+checksum = "853f769599eb31de176303197b7ba4973299c38c7a7604a6bc88c3eef05b9b46"
 dependencies = [
  "proc-macro-hack",
 ]

--- a/blake2/examples/blake2b_sum.rs
+++ b/blake2/examples/blake2b_sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/blake2/examples/blake2s_sum.rs
+++ b/blake2/examples/blake2s_sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/blake2/src/blake2.rs
+++ b/blake2/src/blake2.rs
@@ -290,7 +290,7 @@ macro_rules! blake2_impl {
                 self.n
             }
 
-            fn variable_result<F: FnOnce(&[u8])>(self, f: F) {
+            fn finalize_variable<F: FnOnce(&[u8])>(self, f: F) {
                 let n = self.n;
                 let res = self.finalize_with_flag(0);
                 f(&res[..n]);
@@ -343,7 +343,7 @@ macro_rules! blake2_impl {
         impl FixedOutput for $fix_state {
             type OutputSize = $bytes;
 
-            fn fixed_result(self) -> Output {
+            fn finalize_fixed(self) -> Output {
                 self.state.finalize_with_flag(0)
             }
         }
@@ -381,7 +381,7 @@ macro_rules! blake2_impl {
                 <Self as Reset>::reset(self)
             }
 
-            fn result(self) -> crypto_mac::Output<Self> {
+            fn finalize(self) -> crypto_mac::Output<Self> {
                 crypto_mac::Output::new(self.state.finalize_with_flag(0))
             }
         }

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -15,7 +15,7 @@
 //! hasher.update(b"hello world");
 //!
 //! // read hash digest and consume hasher
-//! let res = hasher.result();
+//! let res = hasher.finalize();
 //! assert_eq!(res[..], hex!("
 //!     021ced8799296ceca557832ab941a50b4a11f83478cf141f51f933f653ab9fbc
 //!     c05a037cddbed06e309bf334942c4e58cdf1a46e237911ccd7fcf9787cbc7fd0
@@ -24,7 +24,7 @@
 //! // same example for `Blake2s`:
 //! let mut hasher = Blake2s::new();
 //! hasher.update(b"hello world");
-//! let res = hasher.result();
+//! let res = hasher.finalize();
 //! assert_eq!(res[..], hex!("
 //!     9aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b
 //! ")[..]);
@@ -44,7 +44,7 @@
 //!
 //! let mut hasher = VarBlake2b::new(10).unwrap();
 //! hasher.update(b"my_input");
-//! hasher.variable_result(|res| {
+//! hasher.finalize_variable(|res| {
 //!     assert_eq!(res, [44, 197, 92, 132, 228, 22, 146, 78, 100, 0])
 //! })
 //! ```
@@ -62,7 +62,7 @@
 //!
 //! // `result` has type `crypto_mac::Output` which is a thin wrapper around
 //! // a byte array and provides a constant time equality check
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //! // To get underlying array use the `into_bytes` method, but be careful,
 //! // since incorrect use of the code value may permit timing attacks which
 //! // defeat the security provided by the `crypto_mac::Output`

--- a/blake2/tests/persona.rs
+++ b/blake2/tests/persona.rs
@@ -8,7 +8,7 @@ fn blake2s_persona() {
     let persona_bytes = persona.as_bytes();
     let ctx = Blake2s::with_params(&key_bytes, &[], persona_bytes);
     assert_eq!(
-        ctx.result().as_slice(),
+        ctx.finalize().as_slice(),
         &hex!("25a4ee63b594aed3f88a971e1877ef7099534f9097291f88fb86c79b5e70d022")[..]
     );
 }
@@ -19,5 +19,5 @@ fn blake2b_persona() {
     let persona = "personal";
     let persona_bytes = persona.as_bytes();
     let ctx = Blake2b::with_params(&key_bytes, &[], persona_bytes);
-    assert_eq!(ctx.result().as_slice(), &hex!("03de3b295dcfc3b25b05abb09bc95fe3e9ff3073638badc68101d1e42019d0771dd07525a3aae8318e92c5e5d967ba92e4810d0021d7bf3b49da0b4b4a8a4e1f")[..]);
+    assert_eq!(ctx.finalize().as_slice(), &hex!("03de3b295dcfc3b25b05abb09bc95fe3e9ff3073638badc68101d1e42019d0771dd07525a3aae8318e92c5e5d967ba92e4810d0021d7bf3b49da0b4b4a8a4e1f")[..]);
 }

--- a/gost94/examples/gost94_cryptopro_sum.rs
+++ b/gost94/examples/gost94_cryptopro_sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/gost94/examples/gost94_test_sum.rs
+++ b/gost94/examples/gost94_test_sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/gost94/src/gost94.rs
+++ b/gost94/src/gost94.rs
@@ -241,7 +241,7 @@ impl Update for Gost94 {
 impl FixedOutput for Gost94 {
     type OutputSize = U32;
 
-    fn fixed_result(mut self) -> GenericArray<u8, U32> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, U32> {
         {
             let self_state = &mut self.state;
 

--- a/gost94/src/lib.rs
+++ b/gost94/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 32]
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("
 //!     1bb6ce69d2e895a78489c87a0712a2f40258d1fae3a4666c23f8f487bef0e22a
 //! "));

--- a/gost94/src/macros.rs
+++ b/gost94/src/macros.rs
@@ -34,8 +34,8 @@ macro_rules! gost94_impl {
         impl FixedOutput for $state {
             type OutputSize = U32;
 
-            fn fixed_result(self) -> GenericArray<u8, Self::OutputSize> {
-                self.sh.fixed_result()
+            fn finalize_fixed(self) -> GenericArray<u8, Self::OutputSize> {
+                self.sh.finalize_fixed()
             }
         }
 

--- a/groestl/src/lib.rs
+++ b/groestl/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 32]
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("
 //!     dc0283ca481efa76b7c19dd5a0b763dff0e867451bd9488a9c59f6c8b8047a86
 //! "));

--- a/groestl/src/macros.rs
+++ b/groestl/src/macros.rs
@@ -27,7 +27,7 @@ macro_rules! impl_groestl {
         impl FixedOutput for $state {
             type OutputSize = $output;
 
-            fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+            fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
                 let block = self.groestl.finalize();
                 let n = block.len() - Self::OutputSize::to_usize();
                 GenericArray::clone_from_slice(&block[n..])
@@ -76,7 +76,7 @@ macro_rules! impl_variable_groestl {
                 self.groestl.output_size
             }
 
-            fn variable_result<F: FnOnce(&[u8])>(mut self, f: F) {
+            fn finalize_variable<F: FnOnce(&[u8])>(mut self, f: F) {
                 let block = self.groestl.finalize();
                 let n = block.len() - self.groestl.output_size;
                 f(&block[n..]);

--- a/k12/src/lib.rs
+++ b/k12/src/lib.rs
@@ -59,7 +59,7 @@ impl KangarooTwelve {
     }
 
     /// Get the result as a `Vec<u8>`
-    pub fn result_vec(mut self, length: usize) -> Vec<u8> {
+    pub fn finalize_vec(mut self, length: usize) -> Vec<u8> {
         let mut output = vec![0u8; length];
         self.read(&mut output);
         output

--- a/k12/tests/lib.rs
+++ b/k12/tests/lib.rs
@@ -30,7 +30,7 @@ fn read_bytes<T: AsRef<[u8]>>(s: T) -> Vec<u8> {
 fn empty() {
     // Source: reference paper
     assert_eq!(
-        KangarooTwelve::new().chain(b"").result_vec(32),
+        KangarooTwelve::new().chain(b"").finalize_vec(32),
         read_bytes(
             "1a c2 d4 50 fc 3b 42 05 d1 9d a7 bf ca
                 1b 37 51 3c 08 03 57 7a c7 16 7f 06 fe 2c e1 f0 ef 39 e5"
@@ -38,7 +38,7 @@ fn empty() {
     );
 
     assert_eq!(
-        KangarooTwelve::new().chain(b"").result_vec(64),
+        KangarooTwelve::new().chain(b"").finalize_vec(64),
         read_bytes(
             "1a c2 d4 50 fc 3b 42 05 d1 9d a7 bf ca
                 1b 37 51 3c 08 03 57 7a c7 16 7f 06 fe 2c e1 f0 ef 39 e5 42 69 c0 56 b8 c8 2e
@@ -47,7 +47,7 @@ fn empty() {
     );
 
     assert_eq!(
-        KangarooTwelve::new().chain(b"").result_vec(10032)[10000..],
+        KangarooTwelve::new().chain(b"").finalize_vec(10032)[10000..],
         read_bytes(
             "e8 dc 56 36 42 f7 22 8c 84
                 68 4c 89 84 05 d3 a8 34 79 91 58 c0 79 b1 28 80 27 7a 1d 28 e2 ff 6d"
@@ -78,7 +78,7 @@ fn pat_m() {
     {
         let len = 17usize.pow(i);
         let m: Vec<u8> = (0..len).map(|j| (j % 251) as u8).collect();
-        let result = KangarooTwelve::new().chain(&m).result_vec(32);
+        let result = KangarooTwelve::new().chain(&m).finalize_vec(32);
         assert_eq!(result, read_bytes(expected[i as usize]));
     }
 }
@@ -101,7 +101,7 @@ fn pat_c() {
         let c: Vec<u8> = (0..len).map(|j| (j % 251) as u8).collect();
         let result = KangarooTwelve::new_with_customization(c)
             .chain(&m)
-            .result_vec(32);
+            .finalize_vec(32);
         assert_eq!(result, read_bytes(expected[i as usize]));
     }
 }

--- a/md2/examples/md2sum.rs
+++ b/md2/examples/md2sum.rs
@@ -20,7 +20,7 @@ fn process<R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    println!("{:x}\t{}", &sh.result(), name);
+    println!("{:x}\t{}", &sh.finalize(), name);
 }
 
 fn main() {

--- a/md2/src/lib.rs
+++ b/md2/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 16]
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("d9cce882ee690a5c1ce70beff3a78c77"));
 //! ```
 //!
@@ -110,7 +110,7 @@ impl Update for Md2 {
 impl FixedOutput for Md2 {
     type OutputSize = U16;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         let buf = self
             .buffer
             .pad_with::<Pkcs7>()

--- a/md4/examples/md4sum.rs
+++ b/md4/examples/md4sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/md4/src/lib.rs
+++ b/md4/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 16]
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("aa010fbc1d14c795d86ef98c95479d17"));
 //! ```
 //!
@@ -140,7 +140,7 @@ impl Default for Md4State {
 }
 
 impl Md4 {
-    fn finalize(&mut self) {
+    fn finalize_inner(&mut self) {
         let state = &mut self.state;
         let l = (self.length_bytes << 3) as u64;
         self.buffer
@@ -167,8 +167,8 @@ impl Update for Md4 {
 impl FixedOutput for Md4 {
     type OutputSize = U16;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
-        self.finalize();
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
+        self.finalize_inner();
 
         let mut out = GenericArray::default();
         LE::write_u32(&mut out[0..4], self.state.s.0);

--- a/md5/examples/md5sum.rs
+++ b/md5/examples/md5sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 16]
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("5eb63bbbe01eeed093cb22bb8f5acdc3"));
 //! ```
 //!
@@ -81,7 +81,7 @@ fn convert(d: &GenericArray<u8, U64>) -> &[u8; 64] {
 
 impl Md5 {
     #[inline]
-    fn finalize(&mut self) {
+    fn finalize_inner(&mut self) {
         let state = &mut self.state;
         let l = (self.length_bytes << 3) as u64;
         self.buffer
@@ -110,9 +110,9 @@ impl FixedOutput for Md5 {
     type OutputSize = U16;
 
     #[inline]
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         let mut out = GenericArray::default();
-        self.finalize();
+        self.finalize_inner();
         LE::write_u32_into(&self.state, &mut out);
         out
     }

--- a/ripemd160/examples/ripemd160sum.rs
+++ b/ripemd160/examples/ripemd160sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/ripemd160/src/lib.rs
+++ b/ripemd160/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 20]
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("7f772647d88750add82d8e1a7a3e5c0902a346a3"));
 //! ```
 //!
@@ -80,7 +80,7 @@ impl Update for Ripemd160 {
 impl FixedOutput for Ripemd160 {
     type OutputSize = U20;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         {
             let h = &mut self.h;
             let l = self.len << 3;

--- a/ripemd320/examples/ripemd320sum.rs
+++ b/ripemd320/examples/ripemd320sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/ripemd320/src/lib.rs
+++ b/ripemd320/src/lib.rs
@@ -15,7 +15,7 @@
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 40]
 //! let expected = hex!("f1c1c231d301abcf2d7daae0269ff3e7bc68e623ad723aa068d316b056d26b7d1bb6f0cc0f28336d");
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //! assert_eq!(&result[..], &expected[..]);
 //! ```
 //!
@@ -83,7 +83,7 @@ impl Update for Ripemd320 {
 impl FixedOutput for Ripemd320 {
     type OutputSize = U40;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         {
             let h = &mut self.h;
             let l = self.len << 3;

--- a/sha1/examples/sha1sum.rs
+++ b/sha1/examples/sha1sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 20]
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"));
 //! ```
 //!
@@ -56,10 +56,6 @@ compile_error!("Enable the \"asm-aarch64\" feature on AArch64 if you want to use
 
 #[macro_use]
 extern crate opaque_debug;
-#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
-extern crate fake_simd as simd;
-#[cfg(feature = "asm-aarch64")]
-extern crate libc;
 #[cfg(feature = "asm")]
 extern crate sha1_asm;
 #[cfg(feature = "std")]
@@ -84,6 +80,9 @@ use digest::{BlockInput, FixedOutput, Reset, Update};
 
 #[cfg(not(feature = "asm"))]
 use crate::utils::compress;
+
+#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
+use fake_simd as simd;
 
 /// Structure representing the state of a SHA-1 computation
 #[derive(Clone)]
@@ -120,7 +119,7 @@ impl Update for Sha1 {
 impl FixedOutput for Sha1 {
     type OutputSize = U20;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         {
             let state = &mut self.h;
             let l = self.len << 3;

--- a/sha2/examples/sha256sum.rs
+++ b/sha2/examples/sha256sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/sha2/examples/sha512sum.rs
+++ b/sha2/examples/sha512sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -30,7 +30,7 @@
 //! hasher.update(b"hello world");
 //!
 //! // read hash digest and consume hasher
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //!
 //! assert_eq!(result[..], hex!("
 //!     b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
@@ -39,7 +39,7 @@
 //! // same for Sha512
 //! let mut hasher = Sha512::new();
 //! hasher.update(b"hello world");
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //!
 //! assert_eq!(result[..], hex!("
 //!     309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f
@@ -80,11 +80,9 @@ compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" when build
 ))]
 compile_error!("Enable the \"asm-aarch64\" feature on AArch64 if you want to use asm detected at runtime, or build with the crypto extensions support, for instance with RUSTFLAGS='-C target-cpu=native' on a compatible CPU.");
 
-extern crate fake_simd as simd;
 #[macro_use]
 extern crate opaque_debug;
-#[cfg(feature = "asm-aarch64")]
-extern crate libc;
+
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -105,3 +103,5 @@ pub use digest::{self, Digest};
 pub use sha256_utils::compress256;
 #[cfg(feature = "compress")]
 pub use sha512_utils::compress512;
+
+use fake_simd as simd;

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -114,7 +114,7 @@ impl Update for Sha256 {
 impl FixedOutput for Sha256 {
     type OutputSize = U32;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
         let mut out = GenericArray::default();
         BE::write_u32_into(&self.engine.state.h, out.as_mut_slice());
@@ -156,7 +156,7 @@ impl Update for Sha224 {
 impl FixedOutput for Sha224 {
     type OutputSize = U28;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
         let mut out = GenericArray::default();
         BE::write_u32_into(&self.engine.state.h[..7], out.as_mut_slice());

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -102,7 +102,7 @@ impl Update for Sha512 {
 impl FixedOutput for Sha512 {
     type OutputSize = U64;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
 
         let mut out = GenericArray::default();
@@ -145,7 +145,7 @@ impl Update for Sha384 {
 impl FixedOutput for Sha384 {
     type OutputSize = U48;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
 
         let mut out = GenericArray::default();
@@ -188,7 +188,7 @@ impl Update for Sha512Trunc256 {
 impl FixedOutput for Sha512Trunc256 {
     type OutputSize = U32;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
 
         let mut out = GenericArray::default();
@@ -231,7 +231,7 @@ impl Update for Sha512Trunc224 {
 impl FixedOutput for Sha512Trunc224 {
     type OutputSize = U28;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
 
         let mut out = GenericArray::default();

--- a/sha3/examples/sha3_256sum.rs
+++ b/sha3/examples/sha3_256sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/sha3/examples/sha3_512sum.rs
+++ b/sha3/examples/sha3_512sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -26,7 +26,7 @@
 //! hasher.update(b"abc");
 //!
 //! // read hash digest
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //!
 //! assert_eq!(result[..], hex!("
 //!     3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532

--- a/sha3/src/macros.rs
+++ b/sha3/src/macros.rs
@@ -41,7 +41,7 @@ macro_rules! sha3_impl {
         impl FixedOutput for $state {
             type OutputSize = $output_size;
 
-            fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+            fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
                 self.apply_padding();
 
                 let mut out = GenericArray::default();
@@ -78,7 +78,7 @@ macro_rules! shake_impl {
         impl ExtendableOutput for $state {
             type Reader = Sha3XofReader;
 
-            fn xof_result(mut self) -> Sha3XofReader {
+            fn finalize_xof(mut self) -> Sha3XofReader {
                 self.apply_padding();
                 let r = $rate::to_usize();
                 Sha3XofReader::new(self.state.clone(), r)

--- a/shabal/examples/shabal256sum.rs
+++ b/shabal/examples/shabal256sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/shabal/examples/shabal512sum.rs
+++ b/shabal/examples/shabal512sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/shabal/src/lib.rs
+++ b/shabal/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! // acquire hash digest in the form of GenericArray,
 //! // which in this case is equivalent to [u8; 32]
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("d945dee21ffca23ac232763aa9cac6c15805f144db9d6c97395437e01c8595a8"));
 //! ```
 //!

--- a/shabal/src/shabal.rs
+++ b/shabal/src/shabal.rs
@@ -280,7 +280,7 @@ impl Update for Shabal512 {
 impl FixedOutput for Shabal512 {
     type OutputSize = U64;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
         let mut out = GenericArray::default();
         LE::write_u32_into(&self.engine.state.b[0..16], out.as_mut_slice());
@@ -322,7 +322,7 @@ impl Update for Shabal384 {
 impl FixedOutput for Shabal384 {
     type OutputSize = U48;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
         let mut out = GenericArray::default();
         LE::write_u32_into(&self.engine.state.b[4..16], out.as_mut_slice());
@@ -364,7 +364,7 @@ impl Update for Shabal256 {
 impl FixedOutput for Shabal256 {
     type OutputSize = U32;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
         let mut out = GenericArray::default();
         LE::write_u32_into(&self.engine.state.b[8..16], out.as_mut_slice());
@@ -406,7 +406,7 @@ impl Update for Shabal224 {
 impl FixedOutput for Shabal224 {
     type OutputSize = U28;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
         let mut out = GenericArray::default();
         LE::write_u32_into(&self.engine.state.b[9..16], out.as_mut_slice());
@@ -448,7 +448,7 @@ impl Update for Shabal192 {
 impl FixedOutput for Shabal192 {
     type OutputSize = U24;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         self.engine.finish();
         let mut out = GenericArray::default();
         LE::write_u32_into(&self.engine.state.b[10..16], out.as_mut_slice());

--- a/streebog/examples/streebog256sum.rs
+++ b/streebog/examples/streebog256sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/streebog/examples/streebog512sum.rs
+++ b/streebog/examples/streebog512sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {

--- a/streebog/src/lib.rs
+++ b/streebog/src/lib.rs
@@ -19,7 +19,7 @@
 //! // write input message
 //! hasher.update(b"my message");
 //! // read hash digest (it will consume hasher)
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //!
 //! assert_eq!(result[..], hex!("
 //!     a47752ba9491bd1d52dd5dcea6d8c08e9b1ee70c42a2fc3e0d1a2852468c1329
@@ -28,7 +28,7 @@
 //! // same for Streebog512
 //! let mut hasher = Streebog512::new();
 //! hasher.update(b"my message");
-//! let result = hasher.result();
+//! let result = hasher.finalize();
 //!
 //! assert_eq!(result[..], hex!("
 //!     c40cc26c37a683c74459820d884b766d9c96697a8d168c0272db8f4ecca2935b

--- a/streebog/src/streebog.rs
+++ b/streebog/src/streebog.rs
@@ -149,7 +149,7 @@ where
 {
     type OutputSize = N;
 
-    fn fixed_result(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
         let mut self_state = self.state;
         let pos = self.buffer.position();
 

--- a/whirlpool/examples/whirlpool_sum.rs
+++ b/whirlpool/examples/whirlpool_sum.rs
@@ -28,7 +28,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             break;
         }
     }
-    print_result(&sh.result(), name);
+    print_result(&sh.finalize(), name);
 }
 
 fn main() {


### PR DESCRIPTION
Implements the API changes from:

https://github.com/RustCrypto/traits/pull/161

The `digest` crate now uses `update` and `finalize` nomenclature ala the Initialize-Update-Finalize (IUF) interface naming scheme.