### PR TITLE
Use new `*Dirty` traits from the `digest` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.9.0-pre"
-source = "git+https://github.com/rustcrypto/traits#7f2b98d31f704b55c502a685632bd2ea4bd5dd6c"
+source = "git+https://github.com/RustCrypto/traits#b6c5fad59c4079b915a1df20c47bf3154b3612b1"
 dependencies = [
  "blobby",
  "generic-array",

--- a/gost94/src/macros.rs
+++ b/gost94/src/macros.rs
@@ -1,9 +1,8 @@
 macro_rules! gost94_impl {
     ($state:ident, $sbox:expr) => {
-        use digest::generic_array::typenum::U32;
-        use digest::generic_array::GenericArray;
         use digest::impl_write;
-        use digest::{BlockInput, FixedOutput, Reset, Update};
+        use digest::{consts::U32, generic_array::GenericArray};
+        use digest::{BlockInput, FixedOutputDirty, Reset, Update};
         use $crate::gost94::{Block, Gost94, SBox};
 
         /// GOST94 state
@@ -31,11 +30,11 @@ macro_rules! gost94_impl {
             }
         }
 
-        impl FixedOutput for $state {
+        impl FixedOutputDirty for $state {
             type OutputSize = U32;
 
-            fn finalize_fixed(self) -> GenericArray<u8, Self::OutputSize> {
-                self.sh.finalize_fixed()
+            fn finalize_into_dirty(&mut self, out: &mut GenericArray<u8, U32>) {
+                self.sh.finalize_into_dirty(out)
             }
         }
 

--- a/groestl/src/lib.rs
+++ b/groestl/src/lib.rs
@@ -45,12 +45,6 @@ extern crate std;
 
 pub use digest::{self, Digest};
 
-use digest::generic_array::typenum::{Unsigned, U128, U28, U32, U48, U64};
-use digest::generic_array::GenericArray;
-use digest::impl_write;
-use digest::InvalidOutputSize;
-use digest::{BlockInput, FixedOutput, Reset, Update, VariableOutput};
-
 mod consts;
 mod groestl;
 mod matrix;
@@ -59,6 +53,10 @@ mod state;
 mod macros;
 
 use crate::groestl::Groestl;
+use digest::consts::{U128, U28, U32, U48, U64};
+use digest::generic_array::typenum::Unsigned;
+use digest::impl_write;
+use digest::{BlockInput, FixedOutputDirty, InvalidOutputSize, Reset, Update, VariableOutputDirty};
 
 impl_groestl!(Groestl512, U64, U128);
 impl_groestl!(Groestl384, U48, U128);

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 digest = { version = "= 0.9.0-pre", features = ["alloc"] }
 
 [dev-dependencies]
-digest = { version = "= 0.9.0-pre", features = ["dev"] }
+digest = { version = "= 0.9.0-pre", features = ["alloc", "dev"] }
 hex-literal = "0.2"
 
 [features]

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -49,7 +49,7 @@ use block_buffer::BlockBuffer;
 use digest::generic_array::typenum::{U16, U64};
 use digest::generic_array::GenericArray;
 use digest::impl_write;
-use digest::{BlockInput, FixedOutput, Reset, Update};
+use digest::{BlockInput, FixedOutputDirty, Reset, Update};
 
 mod consts;
 
@@ -106,15 +106,13 @@ impl Update for Md5 {
     }
 }
 
-impl FixedOutput for Md5 {
+impl FixedOutputDirty for Md5 {
     type OutputSize = U16;
 
     #[inline]
-    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
-        let mut out = GenericArray::default();
+    fn finalize_into_dirty(&mut self, out: &mut GenericArray<u8, U16>) {
         self.finalize_inner();
-        LE::write_u32_into(&self.state, &mut out);
-        out
+        LE::write_u32_into(&self.state, out);
     }
 }
 

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -52,12 +52,10 @@ extern crate std;
 pub use digest::{self, Digest};
 
 use block_buffer::BlockBuffer;
-use digest::generic_array::typenum::{
-    Unsigned, U104, U136, U144, U168, U200, U28, U32, U48, U64, U72,
-};
-use digest::generic_array::GenericArray;
+use digest::consts::{U104, U136, U144, U168, U200, U28, U32, U48, U64, U72};
+use digest::generic_array::typenum::Unsigned;
 use digest::impl_write;
-use digest::{BlockInput, ExtendableOutput, FixedOutput, Reset, Update};
+use digest::{BlockInput, ExtendableOutputDirty, FixedOutputDirty, Reset, Update};
 
 mod paddings;
 #[macro_use]

--- a/sha3/src/macros.rs
+++ b/sha3/src/macros.rs
@@ -38,18 +38,16 @@ macro_rules! sha3_impl {
             }
         }
 
-        impl FixedOutput for $state {
+        impl FixedOutputDirty for $state {
             type OutputSize = $output_size;
 
-            fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
+            fn finalize_into_dirty(&mut self, out: &mut digest::Output<Self>) {
                 self.apply_padding();
 
-                let mut out = GenericArray::default();
                 let n = out.len();
                 self.state.as_bytes(|state| {
                     out.copy_from_slice(&state[..n]);
                 });
-                out
             }
         }
 
@@ -75,10 +73,10 @@ macro_rules! shake_impl {
             }
         }
 
-        impl ExtendableOutput for $state {
+        impl ExtendableOutputDirty for $state {
             type Reader = Sha3XofReader;
 
-            fn finalize_xof(mut self) -> Sha3XofReader {
+            fn finalize_xof_dirty(&mut self) -> Sha3XofReader {
                 self.apply_padding();
                 let r = $rate::to_usize();
                 Sha3XofReader::new(self.state.clone(), r)

--- a/shabal/src/shabal.rs
+++ b/shabal/src/shabal.rs
@@ -1,10 +1,14 @@
+//! Shabal
+
 use block_buffer::block_padding::Iso7816;
 use block_buffer::byteorder::{ByteOrder, LE};
 use block_buffer::BlockBuffer;
-use digest::generic_array::typenum::{U24, U28, U32, U48, U64};
-use digest::generic_array::GenericArray;
 use digest::impl_write;
-use digest::{BlockInput, FixedOutput, Reset, Update};
+use digest::{
+    consts::{U24, U28, U32, U48, U64},
+    generic_array::GenericArray,
+};
+use digest::{BlockInput, FixedOutputDirty, Reset, Update};
 
 use crate::consts::{
     A_INIT_192, A_INIT_224, A_INIT_256, A_INIT_384, A_INIT_512, B_INIT_192, B_INIT_224, B_INIT_256,
@@ -277,14 +281,12 @@ impl Update for Shabal512 {
     }
 }
 
-impl FixedOutput for Shabal512 {
+impl FixedOutputDirty for Shabal512 {
     type OutputSize = U64;
 
-    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_into_dirty(&mut self, out: &mut digest::Output<Self>) {
         self.engine.finish();
-        let mut out = GenericArray::default();
         LE::write_u32_into(&self.engine.state.b[0..16], out.as_mut_slice());
-        out
     }
 }
 
@@ -319,14 +321,12 @@ impl Update for Shabal384 {
     }
 }
 
-impl FixedOutput for Shabal384 {
+impl FixedOutputDirty for Shabal384 {
     type OutputSize = U48;
 
-    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_into_dirty(&mut self, out: &mut digest::Output<Self>) {
         self.engine.finish();
-        let mut out = GenericArray::default();
         LE::write_u32_into(&self.engine.state.b[4..16], out.as_mut_slice());
-        out
     }
 }
 
@@ -361,14 +361,12 @@ impl Update for Shabal256 {
     }
 }
 
-impl FixedOutput for Shabal256 {
+impl FixedOutputDirty for Shabal256 {
     type OutputSize = U32;
 
-    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_into_dirty(&mut self, out: &mut digest::Output<Self>) {
         self.engine.finish();
-        let mut out = GenericArray::default();
-        LE::write_u32_into(&self.engine.state.b[8..16], out.as_mut_slice());
-        out
+        LE::write_u32_into(&self.engine.state.b[8..16], out);
     }
 }
 
@@ -403,14 +401,12 @@ impl Update for Shabal224 {
     }
 }
 
-impl FixedOutput for Shabal224 {
+impl FixedOutputDirty for Shabal224 {
     type OutputSize = U28;
 
-    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_into_dirty(&mut self, out: &mut digest::Output<Self>) {
         self.engine.finish();
-        let mut out = GenericArray::default();
-        LE::write_u32_into(&self.engine.state.b[9..16], out.as_mut_slice());
-        out
+        LE::write_u32_into(&self.engine.state.b[9..16], out);
     }
 }
 
@@ -445,14 +441,12 @@ impl Update for Shabal192 {
     }
 }
 
-impl FixedOutput for Shabal192 {
+impl FixedOutputDirty for Shabal192 {
     type OutputSize = U24;
 
-    fn finalize_fixed(mut self) -> GenericArray<u8, Self::OutputSize> {
+    fn finalize_into_dirty(&mut self, out: &mut digest::Output<Self>) {
         self.engine.finish();
-        let mut out = GenericArray::default();
-        LE::write_u32_into(&self.engine.state.b[10..16], out.as_mut_slice());
-        out
+        LE::write_u32_into(&self.engine.state.b[10..16], out);
     }
 }
 

--- a/streebog/src/lib.rs
+++ b/streebog/src/lib.rs
@@ -58,8 +58,9 @@ mod table;
 
 pub use digest::{self, Digest};
 
-use digest::generic_array::typenum::{U32, U64};
+use digest::consts::{U32, U64};
 use digest::impl_write;
+
 #[cfg(feature = "std")]
 use digest::Update;
 


### PR DESCRIPTION
Updates all of the hash implementations in this repo to use the new `*Dirty` traits which support blanket impls of the original traits, which either consume the hasher instance or can be reset.

This will also provide a marginal efficiency boost, at least until placement return lands (which, as it were, may be soon).