### PR TITLE
sha1 v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-09)
+### Changed
+- Update to `digest` v0.9 release; MSRV 1.41+ ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Bump `block-buffer` to v0.8 release ([#151])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#132])
+- Use `libc` for `aarch64` consts ([#94])
+- Allow compile-time detection of crypto on `aarch64` ([#94])
+
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#151]: https://github.com/RustCrypto/hashes/pull/151
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#132]: https://github.com/RustCrypto/hashes/pull/132
+[#94]: https://github.com/RustCrypto/hashes/pull/94
+
+## 0.8.2 (2020-01-06)
+
+## 0.8.1 (2018-11-14)
+
+## 0.8.0 (2018-10-02)
+
+## 0.7.0 (2017-11-15)
+
+## 0.4.1 (2017-06-13)
+
+## 0.4.0 (2017-06-12)
+
+## 0.3.4 (2017-06-04)
+
+## 0.3.3 (2017-05-09)
+
+## 0.3.2 (2017-05-02)
+
+## 0.3.1 (2017-04-18)
+
+## 0.3.0 (2017-04-06)

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-1"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Update to `digest` v0.9 release; MSRV 1.41+ ([#155])
- Use new `*Dirty` traits from the `digest` crate ([#153])
- Bump `block-buffer` to v0.8 release ([#151])
- Rename `*result*` to `finalize` ([#148])
- Upgrade to Rust 2018 edition ([#132])
- Use `libc` for `aarch64` consts ([#94])
- Allow compile-time detection of crypto on `aarch64` ([#94])

[#155]: https://github.com/RustCrypto/hashes/pull/155
[#153]: https://github.com/RustCrypto/hashes/pull/153
[#151]: https://github.com/RustCrypto/hashes/pull/151
[#148]: https://github.com/RustCrypto/hashes/pull/148
[#132]: https://github.com/RustCrypto/hashes/pull/132
[#94]: https://github.com/RustCrypto/hashes/pull/94