### PR TITLE
k12 v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "k12"
-version = "0.1.0-pre"
+version = "0.1.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/k12/CHANGELOG.md
+++ b/k12/CHANGELOG.md
@@ -5,5 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 (2020-06-09)
+### Changed
+- Update to `digest` v0.9 release; MSRV 1.41+ ([#155])
+- Use `digest` crate's `alloc` feature ([#150])
+- Impl the `ExtendableOutput` trait ([#149])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#123])
+
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#150]: https://github.com/RustCrypto/hashes/pull/150
+[#149]: https://github.com/RustCrypto/hashes/pull/149
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#123]: https://github.com/RustCrypto/hashes/pull/123
+
 ## 0.0.1 (2020-05-24)
 - Initial release

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k12"
-version = "0.1.0-pre"
+version = "0.1.0"
 description = "Experimental pure Rust implementation of the KangarooTwelve hash function"
 authors = ["Diggory Hardy <github1@dhardy.name>"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
### Changed
- Update to `digest` v0.9 release; MSRV 1.41+ ([#155])
- Use `digest` crate's `alloc` feature ([#150])
- Impl the `ExtendableOutput` trait ([#149])
- Rename `*result*` to `finalize` ([#148])
- Upgrade to Rust 2018 edition ([#123])

[#155]: https://github.com/RustCrypto/hashes/pull/155
[#150]: https://github.com/RustCrypto/hashes/pull/150
[#149]: https://github.com/RustCrypto/hashes/pull/149
[#148]: https://github.com/RustCrypto/hashes/pull/148
[#123]: https://github.com/RustCrypto/hashes/pull/123
