### PR TITLE
ripemd160 v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "ripemd160"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",

--- a/ripemd160/CHANGELOG.md
+++ b/ripemd160/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-10)
+### Changed
+- Update to `digest` v0.9 release ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Bump `block-buffer` to v0.8 release ([#151])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#129])
+
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#151]: https://github.com/RustCrypto/hashes/pull/151
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#129]: https://github.com/RustCrypto/hashes/pull/129
+
+## 0.8.0 (2018-10-02)
+
+## 0.7.0 (2017-11-15)
+
+## 0.6.0 (2017-06-12)
+
+## 0.5.2 (2017-06-04)
+
+## 0.5.1 (2017-05-02)
+
+## 0.5.0 (2017-04-06)
+
+## 0.4.1 (2017-01-20)
+
+## 0.4.0 (2016-12-25)
+
+## 0.3.0 (2016-11-17)
+
+## 0.2.0 (2016-10-14)
+
+## 0.1.0 (2016-10-06)

--- a/ripemd160/Cargo.toml
+++ b/ripemd160/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ripemd160"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "RIPEMD-160 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Update to `digest` v0.9 release ([#155])
- Use new `*Dirty` traits from the `digest` crate ([#153])
- Bump `block-buffer` to v0.8 release ([#151])
- Rename `*result*` to `finalize` ([#148])
- Upgrade to Rust 2018 edition ([#129])

[#155]: https://github.com/RustCrypto/hashes/pull/155
[#153]: https://github.com/RustCrypto/hashes/pull/153
[#151]: https://github.com/RustCrypto/hashes/pull/151
[#148]: https://github.com/RustCrypto/hashes/pull/148
[#129]: https://github.com/RustCrypto/hashes/pull/129