### PR TITLE
sha3 v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "block-buffer",
  "byte-tools",

--- a/sha3/CHANGELOG.md
+++ b/sha3/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-10)
+### Changed
+- Update to `digest` v0.9 release; MSRV 1.41+ ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Bump `block-buffer` to v0.8 release ([#151])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#134])
+
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#151]: https://github.com/RustCrypto/hashes/pull/151
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#134]: https://github.com/RustCrypto/hashes/pull/133
+
+## 0.8.2 (2019-04-24)
+
+## 0.8.1 (2018-11-14)
+
+## 0.8.0 (2018-10-02)
+
+## 0.7.3 (2018-03-27)
+
+## 0.7.2 (2017-11-18)
+
+## 0.7.1 (2017-11-17)
+
+## 0.7.0 (2017-11-15)
+
+## 0.6.0 (2017-06-12)
+
+## 0.5.3 (2017-05-31)
+
+## 0.5.2 (2017-05-30)
+
+## 0.5.1 (2017-05-02)
+
+## 0.5.0 (2017-04-06)
+
+## 0.4.1 (2017-01-20)
+
+## 0.4.0 (2016-12-25)
+
+## 0.3.0 (2016-11-17)
+
+## 0.2.0 (2016-10-14)
+
+## 0.1.0 (2016-10-13)

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "SHA-3 (Keccak) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Update to `digest` v0.9 release; MSRV 1.41+ ([#155])
- Use new `*Dirty` traits from the `digest` crate ([#153])
- Bump `block-buffer` to v0.8 release ([#151])
- Rename `*result*` to `finalize` ([#148])
- Upgrade to Rust 2018 edition ([#134])

[#155]: https://github.com/RustCrypto/hashes/pull/155
[#153]: https://github.com/RustCrypto/hashes/pull/153
[#151]: https://github.com/RustCrypto/hashes/pull/151
[#148]: https://github.com/RustCrypto/hashes/pull/148
[#134]: https://github.com/RustCrypto/hashes/pull/133