### PR TITLE
blake2 v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "blake2"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "byte-tools",
  "byteorder",

--- a/blake2/CHANGELOG.md
+++ b/blake2/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-10)
+### Added
+- Support for Persona and Salt ([#78]) 
+
+### Changed
+- Update to `digest` v0.9 release; MSRV 1.41+ ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Bump `crypto-mac` to v0.8 release ([#152])
+- Bump `block-buffer` to v0.8 release ([#151])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#119])
+
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#152]: https://github.com/RustCrypto/hashes/pull/152
+[#151]: https://github.com/RustCrypto/hashes/pull/151
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#119]: https://github.com/RustCrypto/hashes/pull/133
+[#78]: https://github.com/RustCrypto/hashes/pull/78
+
+## 0.8.1 (2019-08-25)
+
+## 0.8.0 (2018-10-11)
+
+## 0.7.1 (2018-04-30)
+
+## 0.7.0 (2017-11-15)
+
+## 0.6.1 (2017-07-24)
+
+## 0.6.0 (2017-06-12)
+
+## 0.5.2 (2017-05-17)
+
+## 0.5.1 (2017-05-02)
+
+## 0.5.0 (2017-04-06)
+
+## 0.4.0 (2017-03-06)
+
+## 0.3.0 (2016-11-17)
+
+## 0.2.0 (2016-10-14)
+
+## 0.1.1 (2016-10-11)
+
+## 0.1.0 (2016-10-09)

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- Support for Persona and Salt ([#78]) 

### Changed
- Update to `digest` v0.9 release; MSRV 1.41+ ([#155])
- Use new `*Dirty` traits from the `digest` crate ([#153])
- Bump `crypto-mac` to v0.8 release ([#152])
- Bump `block-buffer` to v0.8 release ([#151])
- Rename `*result*` to `finalize` ([#148])
- Upgrade to Rust 2018 edition ([#119])

[#155]: https://github.com/RustCrypto/hashes/pull/155
[#153]: https://github.com/RustCrypto/hashes/pull/153
[#152]: https://github.com/RustCrypto/hashes/pull/152
[#151]: https://github.com/RustCrypto/hashes/pull/151
[#148]: https://github.com/RustCrypto/hashes/pull/148
[#119]: https://github.com/RustCrypto/hashes/pull/133
[#78]: https://github.com/RustCrypto/hashes/pull/78