### PR TITLE
Bump opaque-debug to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "proc-macro-hack"

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 crypto-mac = "0.8"
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/blake2/src/blake2.rs
+++ b/blake2/src/blake2.rs
@@ -12,7 +12,6 @@ macro_rules! blake2_impl {
         use digest::InvalidOutputSize;
         use digest::generic_array::GenericArray;
         use digest::generic_array::typenum::{U4, Unsigned};
-        use digest::impl_write;
         use core::{cmp, convert::TryInto, ops::Div};
         use crypto_mac::{InvalidKeyLength, Mac, NewMac};
 
@@ -302,8 +301,8 @@ macro_rules! blake2_impl {
             }
         }
 
-        impl_opaque_debug!($state);
-        impl_write!($state);
+        opaque_debug::implement!($state);
+        digest::impl_write!($state);
 
 
         #[derive(Clone)]
@@ -383,8 +382,8 @@ macro_rules! blake2_impl {
             }
         }
 
-        impl_opaque_debug!($fix_state);
-        impl_write!($fix_state);
+        opaque_debug::implement!($fix_state);
+        digest::impl_write!($fix_state);
 
         fn copy(src: &[u8], dst: &mut [u8]) {
             assert!(dst.len() >= src.len());

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -87,9 +87,6 @@
 #![cfg_attr(feature = "simd", feature(platform_intrinsics, repr_simd))]
 #![cfg_attr(feature = "simd_asm", feature(asm))]
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = { version = "0.9", features = ["block-padding"] }
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/gost94/src/gost94.rs
+++ b/gost94/src/gost94.rs
@@ -2,7 +2,6 @@
 use block_buffer::block_padding::ZeroPadding;
 use block_buffer::BlockBuffer;
 use core::convert::TryInto;
-use digest::impl_write;
 use digest::{consts::U32, generic_array::GenericArray};
 use digest::{BlockInput, FixedOutputDirty, Reset, Update};
 
@@ -280,5 +279,5 @@ impl Reset for Gost94 {
     }
 }
 
-impl_opaque_debug!(Gost94);
-impl_write!(Gost94);
+opaque_debug::implement!(Gost94);
+digest::impl_write!(Gost94);

--- a/gost94/src/lib.rs
+++ b/gost94/src/lib.rs
@@ -29,8 +29,6 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[macro_use]
-extern crate opaque_debug;
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/gost94/src/macros.rs
+++ b/gost94/src/macros.rs
@@ -1,6 +1,6 @@
 macro_rules! gost94_impl {
     ($state:ident, $sbox:expr) => {
-        use digest::{consts::U32, impl_write, BlockInput, FixedOutputDirty, Reset, Update};
+        use digest::{consts::U32, BlockInput, FixedOutputDirty, Reset, Update};
         use $crate::gost94::{Block, Gost94, SBox};
 
         /// GOST94 state
@@ -42,7 +42,7 @@ macro_rules! gost94_impl {
             }
         }
 
-        impl_opaque_debug!($state);
-        impl_write!($state);
+        opaque_debug::implement!($state);
+        digest::impl_write!($state);
     };
 }

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = "0.9"
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/groestl/src/lib.rs
+++ b/groestl/src/lib.rs
@@ -37,9 +37,6 @@
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -55,7 +52,6 @@ mod macros;
 use crate::groestl::Groestl;
 use digest::consts::{U128, U28, U32, U48, U64};
 use digest::generic_array::typenum::Unsigned;
-use digest::impl_write;
 use digest::{BlockInput, FixedOutputDirty, InvalidOutputSize, Reset, Update, VariableOutputDirty};
 
 impl_groestl!(Groestl512, U64, U128);

--- a/groestl/src/macros.rs
+++ b/groestl/src/macros.rs
@@ -40,8 +40,8 @@ macro_rules! impl_groestl {
             }
         }
 
-        impl_opaque_debug!($state);
-        impl_write!($state);
+        opaque_debug::implement!($state);
+        digest::impl_write!($state);
     };
 }
 
@@ -89,7 +89,7 @@ macro_rules! impl_variable_groestl {
             }
         }
 
-        impl_opaque_debug!($state);
-        impl_write!($state);
+        opaque_debug::implement!($state);
+        digest::impl_write!($state);
     };
 }

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = { version = "0.9", features = ["block-padding"] }
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/md2/src/lib.rs
+++ b/md2/src/lib.rs
@@ -28,16 +28,12 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "std")]
 extern crate std;
 
 pub use digest::{self, Digest};
 
 use block_buffer::{block_padding::Pkcs7, BlockBuffer};
-use digest::impl_write;
 use digest::{consts::U16, generic_array::GenericArray};
 use digest::{BlockInput, FixedOutputDirty, Reset, Update};
 
@@ -130,5 +126,5 @@ impl Reset for Md2 {
     }
 }
 
-impl_opaque_debug!(Md2);
-impl_write!(Md2);
+opaque_debug::implement!(Md2);
+digest::impl_write!(Md2);

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = "0.9"
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/md4/src/lib.rs
+++ b/md4/src/lib.rs
@@ -29,9 +29,6 @@
 #![warn(rust_2018_idioms)]
 #![allow(clippy::many_single_char_names)]
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -39,7 +36,6 @@ use core::convert::TryInto;
 pub use digest::{self, Digest};
 
 use block_buffer::BlockBuffer;
-use digest::impl_write;
 use digest::{
     consts::{U16, U64},
     generic_array::GenericArray,
@@ -187,5 +183,5 @@ impl Reset for Md4 {
     }
 }
 
-impl_opaque_debug!(Md4);
-impl_write!(Md4);
+opaque_debug::implement!(Md4);
+digest::impl_write!(Md4);

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -18,7 +18,7 @@ name = "md5"
 digest = "0.9"
 block-buffer = "0.9"
 md5-asm = { version = "0.4", optional = true}
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -28,9 +28,6 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "asm")]
 extern crate md5_asm as utils;
 
@@ -47,7 +44,6 @@ use crate::utils::compress;
 use block_buffer::BlockBuffer;
 use digest::generic_array::typenum::{U16, U64};
 use digest::generic_array::GenericArray;
-use digest::impl_write;
 use digest::{BlockInput, FixedOutputDirty, Reset, Update};
 
 mod consts;
@@ -123,5 +119,5 @@ impl Reset for Md5 {
     }
 }
 
-impl_opaque_debug!(Md5);
-impl_write!(Md5);
+opaque_debug::implement!(Md5);
+digest::impl_write!(Md5);

--- a/ripemd160/Cargo.toml
+++ b/ripemd160/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = "0.9"
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/ripemd160/src/lib.rs
+++ b/ripemd160/src/lib.rs
@@ -28,9 +28,6 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -41,7 +38,6 @@ pub use digest::{self, Digest};
 use crate::block::{process_msg_block, DIGEST_BUF_LEN, H0};
 use block_buffer::BlockBuffer;
 use digest::consts::{U20, U64};
-use digest::impl_write;
 use digest::{BlockInput, FixedOutputDirty, Reset, Update};
 
 /// Structure representing the state of a Ripemd160 computation
@@ -98,5 +94,5 @@ impl Reset for Ripemd160 {
     }
 }
 
-impl_opaque_debug!(Ripemd160);
-impl_write!(Ripemd160);
+opaque_debug::implement!(Ripemd160);
+digest::impl_write!(Ripemd160);

--- a/ripemd320/Cargo.toml
+++ b/ripemd320/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = "0.9"
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/ripemd320/src/lib.rs
+++ b/ripemd320/src/lib.rs
@@ -29,9 +29,6 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -43,7 +40,6 @@ use crate::block::{process_msg_block, DIGEST_BUF_LEN, H0};
 
 use block_buffer::BlockBuffer;
 use digest::consts::{U40, U64};
-use digest::impl_write;
 use digest::{BlockInput, FixedOutputDirty, Reset, Update};
 
 /// Structure representing the state of a ripemd320 computation
@@ -99,5 +95,5 @@ impl Reset for Ripemd320 {
     }
 }
 
-impl_opaque_debug!(Ripemd320);
-impl_write!(Ripemd320);
+opaque_debug::implement!(Ripemd320);
+digest::impl_write!(Ripemd320);

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -17,7 +17,7 @@ name = "sha1"
 [dependencies]
 digest = "0.9"
 block-buffer = "0.9"
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 sha1-asm = { version = "0.4", optional = true }
 libc = { version = "0.2.68", optional = true }
 

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -54,8 +54,6 @@ compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" when build
 ))]
 compile_error!("Enable the \"asm-aarch64\" feature on AArch64 if you want to use asm detected at runtime, or build with the crypto extensions support, for instance with RUSTFLAGS='-C target-cpu=native' on a compatible CPU.");
 
-#[macro_use]
-extern crate opaque_debug;
 #[cfg(feature = "asm")]
 extern crate sha1_asm;
 #[cfg(feature = "std")]
@@ -72,7 +70,6 @@ pub use digest::{self, Digest};
 use crate::consts::{H, STATE_LEN};
 use block_buffer::BlockBuffer;
 use digest::consts::{U20, U64};
-use digest::impl_write;
 use digest::{BlockInput, FixedOutputDirty, Reset, Update};
 
 #[cfg(not(feature = "asm"))]
@@ -157,5 +154,5 @@ fn compress(state: &mut [u32; 5], block: &GenericArray<u8, U64>) {
     }
 }
 
-impl_opaque_debug!(Sha1);
-impl_write!(Sha1);
+opaque_debug::implement!(Sha1);
+digest::impl_write!(Sha1);

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = "0.9"
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 sha2-asm = { version = "0.5", optional = true }
 libc = { version = "0.2.68", optional = true }
 

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -80,9 +80,6 @@ compile_error!("Enable the \"asm\" feature instead of \"asm-aarch64\" when build
 ))]
 compile_error!("Enable the \"asm-aarch64\" feature on AArch64 if you want to use asm detected at runtime, or build with the crypto extensions support, for instance with RUSTFLAGS='-C target-cpu=native' on a compatible CPU.");
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -2,7 +2,6 @@
 
 use crate::consts::{H224, H256, STATE_LEN};
 use block_buffer::BlockBuffer;
-use digest::impl_write;
 use digest::{
     consts::{U28, U32, U64},
     generic_array::GenericArray,
@@ -173,8 +172,8 @@ impl Reset for Sha224 {
     }
 }
 
-impl_opaque_debug!(Sha224);
-impl_opaque_debug!(Sha256);
+opaque_debug::implement!(Sha224);
+opaque_debug::implement!(Sha256);
 
-impl_write!(Sha224);
-impl_write!(Sha256);
+digest::impl_write!(Sha224);
+digest::impl_write!(Sha256);

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -2,7 +2,6 @@
 
 use crate::consts::{H384, H512, H512_TRUNC_224, H512_TRUNC_256, STATE_LEN};
 use block_buffer::BlockBuffer;
-use digest::impl_write;
 use digest::{
     consts::{U128, U28, U32, U48, U64},
     generic_array::GenericArray,
@@ -245,12 +244,12 @@ impl Reset for Sha512Trunc224 {
     }
 }
 
-impl_opaque_debug!(Sha384);
-impl_opaque_debug!(Sha512);
-impl_opaque_debug!(Sha512Trunc224);
-impl_opaque_debug!(Sha512Trunc256);
+opaque_debug::implement!(Sha384);
+opaque_debug::implement!(Sha512);
+opaque_debug::implement!(Sha512Trunc224);
+opaque_debug::implement!(Sha512Trunc256);
 
-impl_write!(Sha384);
-impl_write!(Sha512);
-impl_write!(Sha512Trunc224);
-impl_write!(Sha512Trunc256);
+digest::impl_write!(Sha384);
+digest::impl_write!(Sha512);
+digest::impl_write!(Sha512Trunc224);
+digest::impl_write!(Sha512Trunc256);

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = { version = "0.9", features = ["block-padding"] }
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 keccak = "0.1"
 
 [dev-dependencies]

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -43,9 +43,6 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -54,7 +51,6 @@ pub use digest::{self, Digest};
 use block_buffer::BlockBuffer;
 use digest::consts::{U104, U136, U144, U168, U200, U28, U32, U48, U64, U72};
 use digest::generic_array::typenum::Unsigned;
-use digest::impl_write;
 use digest::{BlockInput, ExtendableOutputDirty, FixedOutputDirty, Reset, Update};
 
 mod paddings;

--- a/sha3/src/macros.rs
+++ b/sha3/src/macros.rs
@@ -58,8 +58,8 @@ macro_rules! sha3_impl {
             }
         }
 
-        impl_opaque_debug!($state);
-        impl_write!($state);
+        opaque_debug::implement!($state);
+        digest::impl_write!($state);
     };
 }
 
@@ -90,7 +90,7 @@ macro_rules! shake_impl {
             }
         }
 
-        impl_opaque_debug!($state);
-        impl_write!($state);
+        opaque_debug::implement!($state);
+        digest::impl_write!($state);
     };
 }

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = { version = "0.9", features = ["block-padding"] }
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/shabal/src/lib.rs
+++ b/shabal/src/lib.rs
@@ -39,8 +39,6 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[macro_use]
-extern crate opaque_debug;
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/shabal/src/shabal.rs
+++ b/shabal/src/shabal.rs
@@ -2,7 +2,6 @@
 use block_buffer::block_padding::Iso7816;
 use block_buffer::BlockBuffer;
 use core::convert::TryInto;
-use digest::impl_write;
 use digest::{
     consts::{U24, U28, U32, U48, U64},
     generic_array::GenericArray,
@@ -470,17 +469,17 @@ impl Reset for Shabal192 {
     }
 }
 
-impl_opaque_debug!(Shabal512);
-impl_opaque_debug!(Shabal384);
-impl_opaque_debug!(Shabal256);
-impl_opaque_debug!(Shabal224);
-impl_opaque_debug!(Shabal192);
+opaque_debug::implement!(Shabal512);
+opaque_debug::implement!(Shabal384);
+opaque_debug::implement!(Shabal256);
+opaque_debug::implement!(Shabal224);
+opaque_debug::implement!(Shabal192);
 
-impl_write!(Shabal512);
-impl_write!(Shabal384);
-impl_write!(Shabal256);
-impl_write!(Shabal224);
-impl_write!(Shabal192);
+digest::impl_write!(Shabal512);
+digest::impl_write!(Shabal384);
+digest::impl_write!(Shabal256);
+digest::impl_write!(Shabal224);
+digest::impl_write!(Shabal192);
 
 #[inline]
 fn read_m(input: &[u8; 64]) -> [u32; 16] {

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = { version = "0.9", features = ["block-padding"] }
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/streebog/src/lib.rs
+++ b/streebog/src/lib.rs
@@ -53,8 +53,8 @@ mod consts;
 mod streebog;
 mod table;
 
-pub use digest::{self, Digest};
 use digest::consts::{U32, U64};
+pub use digest::{self, Digest};
 
 #[cfg(feature = "std")]
 use digest::Update;

--- a/streebog/src/lib.rs
+++ b/streebog/src/lib.rs
@@ -46,9 +46,6 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -57,9 +54,7 @@ mod streebog;
 mod table;
 
 pub use digest::{self, Digest};
-
 use digest::consts::{U32, U64};
-use digest::impl_write;
 
 #[cfg(feature = "std")]
 use digest::Update;
@@ -70,8 +65,8 @@ pub type Streebog256 = streebog::Streebog<U32>;
 /// Streebog512
 pub type Streebog512 = streebog::Streebog<U64>;
 
-impl_opaque_debug!(Streebog512);
-impl_opaque_debug!(Streebog256);
+opaque_debug::implement!(Streebog512);
+opaque_debug::implement!(Streebog256);
 
-impl_write!(Streebog512);
-impl_write!(Streebog256);
+digest::impl_write!(Streebog512);
+digest::impl_write!(Streebog256);

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.9"
 block-buffer = { version = "0.9", features = ["block-padding"] }
-opaque-debug = "0.2"
+opaque-debug = "0.3"
 whirlpool-asm = { version = "0.5", optional = true }
 
 [dev-dependencies]

--- a/whirlpool/src/lib.rs
+++ b/whirlpool/src/lib.rs
@@ -40,9 +40,6 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-#[macro_use]
-extern crate opaque_debug;
-
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -60,7 +57,6 @@ pub use digest::Digest;
 use crate::utils::compress;
 
 use block_buffer::{block_padding::Iso7816, BlockBuffer};
-use digest::impl_write;
 use digest::{consts::U64, generic_array::GenericArray};
 use digest::{BlockInput, FixedOutputDirty, Reset, Update};
 
@@ -196,5 +192,5 @@ impl Reset for Whirlpool {
     }
 }
 
-impl_opaque_debug!(Whirlpool);
-impl_write!(Whirlpool);
+opaque_debug::implement!(Whirlpool);
+digest::impl_write!(Whirlpool);


### PR DESCRIPTION
Also instead of importing `impl_write!` code now uses `digest::impl_write!` directly.