### PR TITLE
Release `groestl`, `md2`, `md4`, `ripemd320`, `whirlpool` v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "groestl"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "md2"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "md4"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "ripemd320"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",
@@ -295,7 +295,7 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "whirlpool"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",

--- a/groestl/CHANGELOG.md
+++ b/groestl/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-12)
+### Changed
+- Bump `opaque-debug` to v0.3.0 ([#168])
+- Bump `digest` to v0.9 release; MSRV 1.41 ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Bump `block-buffer` to v0.8 release ([#151])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#122])
+
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#151]: https://github.com/RustCrypto/hashes/pull/151
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#122]: https://github.com/RustCrypto/hashes/pull/148
+
+## 0.8.0 (2018-10-02)
+
+## 0.7.0 (2017-11-15)
+
+## 0.3.0 (2017-06-12)
+
+## 0.2.2 (2017-06-04)
+
+## 0.2.1 (2017-05-02)
+
+## 0.2.0 (2017-04-06)
+
+## 0.1.0 (2017-01-23)

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "groestl"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "Grøstl hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/md2/CHANGELOG.md
+++ b/md2/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-12)
+### Changed
+- Bump `opaque-debug` to v0.3.0 ([#168])
+- Bump `digest` to v0.9 release; MSRV 1.41 ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Bump `block-buffer` to v0.8 release ([#151])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#125])
+
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#151]: https://github.com/RustCrypto/hashes/pull/151
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#125]: https://github.com/RustCrypto/hashes/pull/125
+
+## 0.8.0 (2018-10-02)
+
+## 0.7.0 (2017-11-15)
+
+## 0.3.0 (2017-06-12)
+
+## 0.2.1 (2017-05-02)
+
+## 0.2.0 (2017-04-06)
+
+## 0.1.2 (2017-01-20)
+
+## 0.1.1 (2017-01-12)
+
+## 0.1.0 (2017-01-09)

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md2"
-version = "0.9.0-pre"
+version = "0.9.0"
 license = "MIT OR Apache-2.0"
 authors = ["RustCrypto Developers"]
 description = "MD2 hash function"

--- a/md4/CHANGELOG.md
+++ b/md4/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-12)
+### Changed
+- Bump `opaque-debug` to v0.3.0 ([#168])
+- Bump `digest` to v0.9 release; MSRV 1.41 ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Bump `block-buffer` to v0.8 release ([#151])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#127])
+
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#151]: https://github.com/RustCrypto/hashes/pull/151
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#127]: https://github.com/RustCrypto/hashes/pull/127
+
+## 0.8.0 (2018-10-02)
+
+## 0.7.0 (2017-11-15)
+
+## 0.6.0 (2017-06-12)
+
+## 0.5.0 (2017-04-06)
+
+## 0.4.1 (2017-01-20)
+
+## 0.4.0 (2016-12-25)
+
+## 0.3.1 (2016-11-17)
+
+## 0.3.0 (2016-11-17)
+
+## 0.2.0 (2016-11-03)
+
+## 0.1.0 (2016-10-13)

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md4"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "MD4 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ripemd320/CHANGELOG.md
+++ b/ripemd320/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-12)
+### Changed
+- Bump `opaque-debug` to v0.3.0 ([#168])
+- Bump `digest` to v0.9 release; MSRV 1.41 ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Bump `block-buffer` to v0.8 release ([#151])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#130])
+
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#151]: https://github.com/RustCrypto/hashes/pull/151
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#130]: https://github.com/RustCrypto/hashes/pull/130
+
+## 0.8.0 (2019-02-11)
+- Initial release

--- a/ripemd320/Cargo.toml
+++ b/ripemd320/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ripemd320"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "RIPEMD-320 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/whirlpool/CHANGELOG.md
+++ b/whirlpool/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-12)
+### Changed
+- Bump `opaque-debug` to v0.3.0 ([#168])
+- Bump `digest` to v0.9 release; MSRV 1.41 ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Bump `block-buffer` to v0.8 release ([#151])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#137])
+
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#151]: https://github.com/RustCrypto/hashes/pull/151
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#137]: https://github.com/RustCrypto/hashes/pull/148
+
+## 0.8.1 (2018-11-14)
+
+## 0.8.0 (2018-10-02)
+
+## 0.7.1 (2018-04-27)
+
+## 0.7.0 (2017-11-15)
+
+## 0.6.0 (2017-06-12)
+
+## 0.5.3 (2017-06-04)
+
+## 0.5.2 (2017-05-09)
+
+## 0.5.1 (2017-05-02)
+
+## 0.5.0 (2017-04-06)
+
+## 0.4.1 (2017-01-20)
+
+## 0.4.0 (2016-12-25)
+
+## 0.3.0 (2016-11-17)
+
+## 0.2.0 (2016-10-14)
+
+## 0.1.0 (2016-10-06

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whirlpool"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "Whirlpool hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases the following new versions after the `digest` v0.9 (MSRV 1.41+) and 2018 edition upgrade:

- `groestl` v0.9.0
- `md2` v0.9.0
- `md4` v0.9.0
- `ripemd320` v0.9.0
- `whirlpool` v0.9.0