### PR TITLE
shabal v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "shabal"
-version = "0.3.0-pre"
+version = "0.3.0"
 dependencies = [
  "block-buffer",
  "digest",

--- a/shabal/CHANGELOG.md
+++ b/shabal/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.3.0 (2020-06-12)
+### Changed
+- Bump `opaque-debug` to v0.3.0 ([#168])
+- Bump `block-buffer` to v0.9 release ([#164])
+- Bump `digest` to v0.9 release; MSRV 1.41 ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#135])
+
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+[#164]: https://github.com/RustCrypto/hashes/pull/151
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#135]: https://github.com/RustCrypto/hashes/pull/135
+
+## 0.2.0 (2019-02-26)
+
+## 0.1.0 (2019-02-25)

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shabal"
-version = "0.3.0-pre"
+version = "0.3.0"
 description = "Shabal hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Bump `opaque-debug` to v0.3.0 ([#168])
- Bump `block-buffer` to v0.9 release ([#164])
- Bump `digest` to v0.9 release; MSRV 1.41 ([#155])
- Use new `*Dirty` traits from the `digest` crate ([#153])
- Rename `*result*` to `finalize` ([#148])
- Upgrade to Rust 2018 edition ([#135])

[#168]: https://github.com/RustCrypto/hashes/pull/168
[#164]: https://github.com/RustCrypto/hashes/pull/151
[#155]: https://github.com/RustCrypto/hashes/pull/155
[#153]: https://github.com/RustCrypto/hashes/pull/153
[#148]: https://github.com/RustCrypto/hashes/pull/148
[#135]: https://github.com/RustCrypto/hashes/pull/135