### PR TITLE
Release `gost94` and `streebog`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "gost94"
-version = "0.9.0-pre"
+version = "0.8.0"
 dependencies = [
  "block-buffer",
  "digest",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.9.0-pre"
+version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",

--- a/gost94/CHANGELOG.md
+++ b/gost94/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-12)
+### Changed
+- Bump `opaque-debug` to v0.3.0 ([#168])
+- Bump `block-buffer` to v0.8 release ([#164])
+- Bump `digest` to v0.9 release; MSRV 1.41 ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#121])
+
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+[#164]: https://github.com/RustCrypto/hashes/pull/164
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#121]: https://github.com/RustCrypto/hashes/pull/148
+
+## 0.8.0 (skipped)
+- Skipped to sync versions with `digest`
+
+## 0.7.0 (2017-11-15)
+
+## 0.4.0 (2017-06-12)
+
+## 0.3.1 (2017-05-02)
+
+## 0.3.0 (2017-04-06)
+
+## 0.2.1 (2017-01-20)
+
+## 0.2.0 (2016-12-25)
+
+## 0.1.1 (2016-11-24)
+
+## 0.1.0 (2016-11-17)

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gost94"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "GOST R 34.11-94 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/streebog/CHANGELOG.md
+++ b/streebog/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.9.0 (2020-06-12)
+### Changed
+- Bump `opaque-debug` to v0.3.0 ([#168])
+- Bump `block-buffer` to v0.8 release ([#164])
+- Bump `digest` to v0.9 release; MSRV 1.41 ([#155])
+- Use new `*Dirty` traits from the `digest` crate ([#153])
+- Rename `*result*` to `finalize` ([#148])
+- Upgrade to Rust 2018 edition ([#136])
+
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+[#164]: https://github.com/RustCrypto/hashes/pull/164
+[#155]: https://github.com/RustCrypto/hashes/pull/155
+[#153]: https://github.com/RustCrypto/hashes/pull/153
+[#148]: https://github.com/RustCrypto/hashes/pull/148
+[#136]: https://github.com/RustCrypto/hashes/pull/148
+
+## 0.8.0 (2019-11-06)
+
+## 0.7.0 (2017-11-15)
+
+## 0.5.0 (2017-06-12)
+
+## 0.4.1 (2017-05-02)
+
+## 0.4.0 (2017-04-06)
+
+## 0.3.1 (2017-01-20)
+
+## 0.3.0 (2016-12-25)
+
+## 0.2.2 (2016-11-21)
+
+## 0.2.1 (2016-11-21)
+
+## 0.2.0 (2016-11-17)
+
+## 0.1.1 (2016-11-12)
+
+## 0.1.0 (2016-11-12)

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.9.0-pre"
+version = "0.9.0"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases the following versions:

- `gost94` v0.8.0
- `streebog` v0.9.0