### PR TITLE
Bump md5, ripemd160 and sha3 to v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "md-5"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "block-buffer",
  "digest",
@@ -202,7 +202,7 @@ checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "ripemd160"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "block-buffer",
  "digest",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "block-buffer",
  "digest",

--- a/md5/CHANGELOG.md
+++ b/md5/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.1 (2020-06-28)
+### Changed
+- Update to `block-buffer` v0.9 ([#164])
+- Update to `opaque-debug` v0.3 ([#168])
+
+[#164]: https://github.com/RustCrypto/hashes/pull/164
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+
 ## 0.9.0 (2020-06-09)
 ### Changed
 - Update to `digest` v0.9 release; MSRV 1.41+ ([#155])

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.9.0"
+version = "0.9.1"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ripemd160/CHANGELOG.md
+++ b/ripemd160/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.1 (2020-06-28)
+### Changed
+- Update to `block-buffer` v0.9 ([#164])
+- Update to `opaque-debug` v0.3 ([#168])
+
+[#164]: https://github.com/RustCrypto/hashes/pull/164
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+
 ## 0.9.0 (2020-06-10)
 ### Changed
 - Update to `digest` v0.9 release ([#155])

--- a/ripemd160/Cargo.toml
+++ b/ripemd160/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ripemd160"
-version = "0.9.0"
+version = "0.9.1"
 description = "RIPEMD-160 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha3/CHANGELOG.md
+++ b/sha3/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## 0.9.1 (2020-06-28)
+### Changed
+- Update to `block-buffer` v0.9 ([#164])
+- Update to `opaque-debug` v0.3 ([#168])
+
+[#164]: https://github.com/RustCrypto/hashes/pull/164
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+
 ## 0.9.0 (2020-06-10)
 ### Changed
 - Update to `digest` v0.9 release; MSRV 1.41+ ([#155])

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.9.0"
+version = "0.9.1"
 description = "SHA-3 (Keccak) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Closes #178.