### PR TITLE
Use SVG logo

### DIFF
--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -82,7 +82,10 @@
 //! [2]: https://github.com/cesarb/blake2-rfc
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![warn(missing_docs, rust_2018_idioms)]
 #![cfg_attr(feature = "simd", feature(platform_intrinsics, repr_simd))]
 #![cfg_attr(feature = "simd_asm", feature(asm))]

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -84,7 +84,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 #![cfg_attr(feature = "simd", feature(platform_intrinsics, repr_simd))]

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -82,7 +82,7 @@
 //! [2]: https://github.com/cesarb/blake2-rfc
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![warn(missing_docs, rust_2018_idioms)]
 #![cfg_attr(feature = "simd", feature(platform_intrinsics, repr_simd))]
 #![cfg_attr(feature = "simd_asm", feature(asm))]

--- a/gost94/src/lib.rs
+++ b/gost94/src/lib.rs
@@ -28,7 +28,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/gost94/src/lib.rs
+++ b/gost94/src/lib.rs
@@ -26,7 +26,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]

--- a/gost94/src/lib.rs
+++ b/gost94/src/lib.rs
@@ -26,7 +26,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]

--- a/groestl/src/lib.rs
+++ b/groestl/src/lib.rs
@@ -33,7 +33,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 

--- a/groestl/src/lib.rs
+++ b/groestl/src/lib.rs
@@ -35,7 +35,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]

--- a/groestl/src/lib.rs
+++ b/groestl/src/lib.rs
@@ -33,7 +33,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 

--- a/k12/src/lib.rs
+++ b/k12/src/lib.rs
@@ -9,7 +9,10 @@
 // <https://github.com/dhardy/hash-bench/blob/master/src/k12.rs>
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/k12/src/lib.rs
+++ b/k12/src/lib.rs
@@ -9,7 +9,7 @@
 // <https://github.com/dhardy/hash-bench/blob/master/src/k12.rs>
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/k12/src/lib.rs
+++ b/k12/src/lib.rs
@@ -11,7 +11,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/md2/src/lib.rs
+++ b/md2/src/lib.rs
@@ -26,7 +26,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/md2/src/lib.rs
+++ b/md2/src/lib.rs
@@ -24,7 +24,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/md2/src/lib.rs
+++ b/md2/src/lib.rs
@@ -24,7 +24,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/md4/src/lib.rs
+++ b/md4/src/lib.rs
@@ -26,7 +26,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]

--- a/md4/src/lib.rs
+++ b/md4/src/lib.rs
@@ -24,7 +24,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 #![allow(clippy::many_single_char_names)]

--- a/md4/src/lib.rs
+++ b/md4/src/lib.rs
@@ -24,7 +24,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 #![allow(clippy::many_single_char_names)]

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -26,7 +26,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -24,7 +24,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -24,7 +24,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/ripemd160/src/lib.rs
+++ b/ripemd160/src/lib.rs
@@ -26,7 +26,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/ripemd160/src/lib.rs
+++ b/ripemd160/src/lib.rs
@@ -24,7 +24,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/ripemd160/src/lib.rs
+++ b/ripemd160/src/lib.rs
@@ -24,7 +24,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/ripemd320/src/lib.rs
+++ b/ripemd320/src/lib.rs
@@ -27,7 +27,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/ripemd320/src/lib.rs
+++ b/ripemd320/src/lib.rs
@@ -25,7 +25,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/ripemd320/src/lib.rs
+++ b/ripemd320/src/lib.rs
@@ -25,7 +25,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -26,7 +26,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -24,7 +24,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -24,7 +24,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -55,7 +55,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -53,7 +53,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -53,7 +53,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -41,7 +41,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -39,7 +39,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -39,7 +39,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/shabal/src/lib.rs
+++ b/shabal/src/lib.rs
@@ -37,7 +37,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/shabal/src/lib.rs
+++ b/shabal/src/lib.rs
@@ -35,7 +35,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/shabal/src/lib.rs
+++ b/shabal/src/lib.rs
@@ -35,7 +35,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/streebog/src/lib.rs
+++ b/streebog/src/lib.rs
@@ -42,7 +42,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/streebog/src/lib.rs
+++ b/streebog/src/lib.rs
@@ -44,7 +44,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/streebog/src/lib.rs
+++ b/streebog/src/lib.rs
@@ -42,7 +42,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/whirlpool/src/lib.rs
+++ b/whirlpool/src/lib.rs
@@ -36,7 +36,10 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+)]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 

--- a/whirlpool/src/lib.rs
+++ b/whirlpool/src/lib.rs
@@ -38,7 +38,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
-    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]

--- a/whirlpool/src/lib.rs
+++ b/whirlpool/src/lib.rs
@@ -36,7 +36,7 @@
 //! [2]: https://github.com/RustCrypto/hashes
 
 #![no_std]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg")]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 


### PR DESCRIPTION
Gzip compressed SVG logo is smaller than 200x200 PNG (3.3 KB vs 7 KB) and could result in a better rendering result. SVG rendering is a somewhat more complex process than plain image rendering, but I guess we can ignore it. :)

But it looks like `rust-lang` projects tend to use PNG logos, I wonder if there is a reason for that.