### PR TITLE
streebog: fix Streebog512 doc typo, minor lib-level doc tweak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "streebog"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "block-buffer",
  "digest",

--- a/streebog/CHANGELOG.md
+++ b/streebog/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.2 (2020-08-12)
+## 0.9.2 (2020-08-13)
 ### Changed
 - Documentation update (#[185])
 

--- a/streebog/CHANGELOG.md
+++ b/streebog/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.2 (2020-08-12)
+### Changed
+- Documentation update (#[185])
+
+[#185]: https://github.com/RustCrypto/hashes/pull/185
+
 ## 0.9.1 (2020-08-10)
 ### Changed
 - Documentation update (#[184])

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.9.1"
+version = "0.9.2"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/streebog/src/lib.rs
+++ b/streebog/src/lib.rs
@@ -1,7 +1,9 @@
 //! An implementation of the [Streebog] cryptographic hash function defined
 //! in GOST R 34.11-2012.
 //!
-//! # Example
+//! # Usage
+//! Hasher functionality is expressed via traits defined in the [`digest`]
+//! crate.
 //!
 //! ```rust
 //! use streebog::{Digest, Streebog256, Streebog512};
@@ -10,7 +12,9 @@
 //! // create a hasher object, to use it do not forget to import `Digest` trait
 //! let mut hasher = Streebog256::new();
 //! // write input message
-//! hasher.update(b"my message");
+//! hasher.update(b"my");
+//! hasher.update(b" ");
+//! hasher.update(b"message");
 //! // read hash digest (it will consume hasher)
 //! let result = hasher.finalize();
 //!
@@ -29,10 +33,10 @@
 //! ")[..]);
 //! ```
 //!
-//! Also see [RustCrypto/hashes][1] readme.
+//! See [RustCrypto/hashes][1] readme for additional examples.
 //!
 //! [Streebog]: https://en.wikipedia.org/wiki/Streebog
-//! [1]: https://github.com/RustCrypto/hashes
+//! [1]: https://github.com/RustCrypto/hashes/blob/master/README.md#usage
 
 #![no_std]
 #![doc(
@@ -58,7 +62,7 @@ use digest::Update;
 /// Streebog-256 cryptographic hash function
 pub type Streebog256 = streebog::Streebog<U32>;
 
-/// Streebog-256 cryptographic hash function
+/// Streebog-512 cryptographic hash function
 pub type Streebog512 = streebog::Streebog<U64>;
 
 opaque_debug::implement!(Streebog512);


### PR DESCRIPTION
The typo was noticed [here](https://github.com/RustCrypto/hashes/pull/184#discussion_r468568511).