### PR TITLE
blake2 v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "blake2"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "crypto-mac",
  "digest",

--- a/blake2/CHANGELOG.md
+++ b/blake2/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.1 (2020-10-26)
+### Changed
+- Bump `opaque-debug` to v0.3 ([#168])
+- Bump `block-buffer` to v0.9 ([#164])
+
+[#168]: https://github.com/RustCrypto/hashes/pull/168
+[#164]: https://github.com/RustCrypto/hashes/pull/164
+
 ## 0.9.0 (2020-06-10)
 ### Added
 - Support for Persona and Salt ([#78]) 

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.9.0"
+version = "0.9.1"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha3/src/paddings.rs
+++ b/sha3/src/paddings.rs
@@ -11,7 +11,7 @@ macro_rules! impl_padding {
             #[inline(always)]
             fn pad_block(block: &mut [u8], pos: usize) -> Result<(), PadError> {
                 if pos >= block.len() {
-                    Err(PadError)?
+                    return Err(PadError);
                 }
                 block[pos] = $pad;
                 block[pos + 1..].iter_mut().for_each(|b| *b = 0);


### PR DESCRIPTION
Closes #200 

### Changed
- Bump `opaque-debug` to v0.3 ([#168])
- Bump `block-buffer` to v0.9 ([#164])

[#168]: https://github.com/RustCrypto/hashes/pull/168
[#164]: https://github.com/RustCrypto/hashes/pull/164