### PR TITLE
Fix using sha2_asm on aarch64.

### DIFF
--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -12,9 +12,9 @@ pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     if sha2_supported() {
         // TODO: replace after sha2-asm rework
         for block in blocks {
-            sha2_asm::compress256(&mut self.h, block);
+            sha2_asm::compress256(state, block);
         }
     } else {
-        super::soft::compress(&mut self.h, block);
+        super::soft::compress(state, blocks);
     }
 }


### PR DESCRIPTION
The code doesn't compile before.
Can use `cargo test --features asm` to verify (on an aarch64 machine).
Tested on AWS Graviton2 server.

Btw, the current GitHub Action testing scripts failed to cover this case. Because GitHub Actions are hosted on x86 machines.
If want to test on different architectures, maybe we need to setup QEMU to emulate.
