### PR TITLE
sha2: test builds on 32-bit Linux and macOS/x86-64

### DIFF
--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -17,6 +17,7 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
+  # Builds for no_std platforms
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -37,20 +38,56 @@ jobs:
           override: true
       - run: cargo build --no-default-features --release --target ${{ matrix.target }}
 
-  test:
-    runs-on: ubuntu-latest
+  # Linux tests
+  linux:
     strategy:
       matrix:
-        rust:
-          - 1.41.0 # MSRV
-          - stable
+        include:
+          # 32-bit Linux/x86
+          - target: i686-unknown-linux-gnu
+            rust: 1.41.0 # MSRV
+            deps: sudo apt install gcc-multilib
+          - target: i686-unknown-linux-gnu
+            rust: stable
+            deps: sudo apt install gcc-multilib
+
+          # 64-bit Linux/x86_64
+          - target: x86_64-unknown-linux-gnu
+            rust: 1.41.0 # MSRV
+          - target: x86_64-unknown-linux-gnu
+            rust: stable
+
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
           override: true
-      - run: cargo test --no-default-features
-      - run: cargo test
-      - run: cargo test --features asm
+      - run: ${{ matrix.deps }}
+      - run: cargo test --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo test --target ${{ matrix.target }} --release
+      - run: cargo test --target ${{ matrix.target }} --release --features asm
+
+  # macOS tests
+  macos:
+    strategy:
+      matrix:
+        toolchain:
+          - 1.41.0 # MSRV
+          - stable
+
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          target: x86_64-apple-darwin
+          override: true
+      - run: cargo test --release --no-default-features
+      - run: cargo test --release
+      - run: cargo test --release --features asm

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -35,10 +35,6 @@ hex-literal = "0.2"
 default = ["std"]
 std = ["digest/std"]
 asm = ["sha2-asm", "libc"]
-# Expose compress function
-compress = []
-# Force software implementation
-force-soft = []
-
-# DEPRECATED: use `asm` instead
-asm-aarch64 = ["asm"]
+compress = [] # Expose compress function
+force-soft = [] # Force software implementation
+asm-aarch64 = ["asm"] # DEPRECATED: use `asm` instead


### PR DESCRIPTION
Per #207 it seems we aren't doing enough testing, particularly for the `asm` feature on various platforms.

This commit adds much more extensive testing for the `sha2` crate in particular, since it's one of the most important.