### PR TITLE
Use the SHA-NI extension backend with enabled asm feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "block-buffer",
  "cfg-if",

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9.3 (2021-01-30)
 ### Changed
-- Use the SHA extension backend with enabled `asm` feature. ([#223])
+- Use the SHA extension backend with enabled `asm` feature. ([#224])
 
-[#223]: https://github.com/RustCrypto/hashes/pull/223
+[#224]: https://github.com/RustCrypto/hashes/pull/224
 
 ## 0.9.2 (2020-11-04)
 ### Added

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.3 (2021-01-30)
+### Changed
+- Use the SHA extension backend with enabled `asm` feature. ([#223])
+
+[#223]: https://github.com/RustCrypto/hashes/pull/223
+
 ## 0.9.2 (2020-11-04)
 ### Added
 - `force-soft` feature to enforce use of software implementation. ([#203])

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.9.2"
+version = "0.9.3"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.


### PR DESCRIPTION
The SHA extension backend is significantly faster then our ASM code, so with this change on x86 targets we first will check if CPU has the extension and only then we will fallback either to ASM or software implementation.

Closes #220.

cc @dgbo