### PR TITLE
Use SHA1 intrinsics when `asm` feature is enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "block-buffer",
  "cfg-if",

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.3 (2021-01-31)
+## 0.9.3 (2021-02-01)
 ### Changed
 - Use SHA1 intrinsics when `asm` feature is enabled. ([#225])
 

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.3 (2021-01-31)
+### Changed
+- Use SHA1 intrinsics when `asm` feature is enabled. ([#225])
+
+[#225]: https://github.com/RustCrypto/hashes/pull/225
+
 ## 0.9.2 (2020-11-04)
 ### Added
 - `force-soft` feature to enforce use of software implementation. ([#203])

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-1"
-version = "0.9.2"
+version = "0.9.3"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha1/src/compress.rs
+++ b/sha1/src/compress.rs
@@ -9,14 +9,17 @@ cfg_if::cfg_if! {
         mod soft;
         mod aarch64;
         use aarch64::compress as compress_inner;
-    } else if #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))] {
-        fn compress_inner(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
-            for block in blocks {
-                sha1_asm::compress(state, block);
+    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+        #[cfg(not(feature = "asm"))]
+        mod soft;
+        #[cfg(feature = "asm")]
+        mod soft {
+            pub(crate) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+                for block in blocks {
+                    sha1_asm::compress(state, block);
+                }
             }
         }
-    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-        mod soft;
         mod x86;
         use x86::compress as compress_inner;
     } else {


### PR DESCRIPTION
This applies the change from https://github.com/RustCrypto/hashes/pull/224 to the SHA1 crate (it was just added to the SHA2 crate before).