### PR TITLE
blake2.rs: remove unnecessary `unsafe`

### DIFF
--- a/blake2/src/blake2.rs
+++ b/blake2/src/blake2.rs
@@ -386,10 +386,7 @@ macro_rules! blake2_impl {
         digest::impl_write!($fix_state);
 
         fn copy(src: &[u8], dst: &mut [u8]) {
-            assert!(dst.len() >= src.len());
-            unsafe {
-                core::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), src.len());
-            }
+            dst[..src.len()].copy_from_slice(src);
         }
     }
 }


### PR DESCRIPTION
`.copy_from_slice()` is mildly annoying to use since it panics if the slices aren't the same length but using `ptr::copy_nonoverlapping()` is also a code smell.

This should perform the same as the previous version (including the `assert!()`) as the optimizer should be able to see that the internal assert in `copy_from_slice()` is always satisfied.