### PR TITLE
.github: fix missing `override: true` on clippy check

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: 1.41.0 # MSRV
           components: clippy
+          profile: minimal
+          override: true
       - run: cargo clippy --all -- -D warnings
 
   rustfmt:
@@ -30,9 +31,10 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           components: rustfmt
+          profile: minimal
+          override: true
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/tiger/src/lib.rs
+++ b/tiger/src/lib.rs
@@ -120,6 +120,7 @@ impl Tiger {
     }
 
     #[inline]
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     fn round(a: &mut u64, b: &mut u64, c: &mut u64, x: &u64, mul: u8) {
         *c ^= *x;
         let mut c_: [u8; 8] = Default::default();

--- a/whirlpool/src/lib.rs
+++ b/whirlpool/src/lib.rs
@@ -145,7 +145,7 @@ impl Whirlpool {
 
         if pos + 1 > self.bit_length.len() {
             compress(hash, convert(buf));
-            buf[..(pos + 1)].iter_mut().for_each(|b| *b = 0);
+            buf[..=pos].iter_mut().for_each(|b| *b = 0);
         }
 
         buf[32..].copy_from_slice(&self.bit_length);

--- a/whirlpool/src/utils.rs
+++ b/whirlpool/src/utils.rs
@@ -17,7 +17,7 @@ pub fn compress(hash: &mut [u64; 8], buffer: &[u8; 64]) {
     }
 
     #[allow(clippy::needless_range_loop)]
-    for r in 1..(R + 1) {
+    for r in 1..=R {
         for i in 0..8 {
             l[i] = C0[(k[(i) % 8] >> 56) as usize]
                 ^ C1[((k[(7 + i) % 8] >> 48) & 0xff) as usize]


### PR DESCRIPTION
Wasn't respecting the pinned MSRV, causing an error on #240 since a new lint was introduced.