### PR TITLE
feat(sha2): use latest sha2-asm and enable M1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98bfd7c112b6399fef97cc0614af1cd375b27a112e552ce60f94c1b5f13cb74"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "byteorder"
@@ -44,9 +44,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.58"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -146,9 +146,9 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "md-5"
@@ -198,9 +198,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "ripemd160"
@@ -261,9 +261,8 @@ dependencies = [
 
 [[package]]
 name = "sha2-asm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c2f225be6502f2134e6bbb35bb5e2957e41ffa0495ed08bce2e2b4ca885da4"
+version = "0.6.0"
+source = "git+https://github.com/dignifiedquire/asm-hashes?branch=arm-m1#8f5a9eb13e01220ce861225fa4e5c803d4749098"
 dependencies = [
  "cc",
 ]
@@ -301,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "tiger"
@@ -317,15 +316,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "whirlpool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ members = [
 opt-level = 2
 
 [patch.crates-io]
-sha2-asm = { git = "https://github.com/dignifiedquire/asm-hashes", branch = "arm-m1" }
+sha2-asm = { git = "https://github.com/RustCrypto/asm-hashes" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+sha2-asm = { git = "https://github.com/dignifiedquire/asm-hashes", branch = "arm-m1" }

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -19,7 +19,7 @@ digest = "0.9"
 block-buffer = "0.9"
 opaque-debug = "0.3"
 cfg-if = "1.0"
-sha2-asm = { version = "0.5", optional = true }
+sha2-asm = { version = "0.6", optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 cpuid-bool = "0.2"
@@ -38,3 +38,4 @@ asm = ["sha2-asm", "libc"]
 compress = [] # Expose compress function
 force-soft = [] # Force software implementation
 asm-aarch64 = ["asm"] # DEPRECATED: use `asm` instead
+

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -148,9 +148,7 @@ cfg_if::cfg_if! {
         #[cfg(feature = "asm")]
         mod soft {
             pub(crate) fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
-                for block in blocks {
-                    sha2_asm::compress256(state, block);
-                }
+                sha2_asm::compress256(state, blocks);
             }
         }
         mod x86;

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -155,7 +155,7 @@ cfg_if::cfg_if! {
         }
         mod x86;
         use x86::compress;
-    } else if #[cfg(all(feature = "asm", target_arch = "aarch64", target_os = "linux"))] {
+    } else if #[cfg(all(feature = "asm", target_arch = "aarch64", any(target_os = "macos", target_os = "linux")))] {
         mod soft;
         mod aarch64;
         use aarch64::compress;

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -10,7 +10,7 @@ pub fn sha2_supported() -> bool {
 #[cfg(target_os = "macos")]
 #[inline(always)]
 pub fn sha2_supported() -> bool {
-    // TODO: Verify this is true for all available chips.
+    // TODO: Use cpufeatures once support lands
     true
 }
 

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -1,18 +1,24 @@
-use libc::{getauxval, AT_HWCAP, HWCAP_SHA2};
-
+#[cfg(target_os = "linux")]
 #[inline(always)]
 pub fn sha2_supported() -> bool {
+    use libc::{getauxval, AT_HWCAP, HWCAP_SHA2};
+
     let hwcaps: u64 = unsafe { getauxval(AT_HWCAP) };
     (hwcaps & HWCAP_SHA2) != 0
+}
+
+#[cfg(target_os = "macos")]
+#[inline(always)]
+pub fn sha2_supported() -> bool {
+    // TODO: Verify this is true for all available chips.
+    true
 }
 
 pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if sha2_supported() {
-        for block in blocks {
-            sha2_asm::compress256(state, block);
-        }
+        sha2_asm::compress256(state, blocks);
     } else {
         super::soft::compress(state, blocks);
     }

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -233,9 +233,7 @@ cfg_if::cfg_if! {
         use soft::compress;
     } else if #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))] {
         fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
-            for block in blocks {
-                sha2_asm::compress512(state, block);
-            }
+            sha2_asm::compress512(state, blocks);
         }
     } else {
         mod soft;


### PR DESCRIPTION
Depends on https://github.com/RustCrypto/asm-hashes/pull/35

Benchmarks on Mac Mini M1:

## Soft
```
test bench1_10    ... bench:          40 ns/iter (+/- 0) = 250 MB/s
test bench2_100   ... bench:         390 ns/iter (+/- 1) = 256 MB/s
test bench3_1000  ... bench:       3,869 ns/iter (+/- 8) = 258 MB/s
test bench4_10000 ... bench:      38,662 ns/iter (+/- 175) = 258 MB/s
```


## ASM
```
test bench1_10    ... bench:           6 ns/iter (+/- 0) = 1666 MB/s
test bench2_100   ... bench:          46 ns/iter (+/- 0) = 2173 MB/s
test bench3_1000  ... bench:         463 ns/iter (+/- 2) = 2159 MB/s
test bench4_10000 ... bench:       4,636 ns/iter (+/- 12) = 2157 MB/s
```