### PR TITLE
sha2: bump `sha2-asm` to v0.6.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,8 +261,9 @@ dependencies = [
 
 [[package]]
 name = "sha2-asm"
-version = "0.6.0"
-source = "git+https://github.com/dignifiedquire/asm-hashes?branch=arm-m1#8f5a9eb13e01220ce861225fa4e5c803d4749098"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c397a68de3079fa40e34eba871bea7f10de663f27f4c8b865c89ab47f103723"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-sha2-asm = { git = "https://github.com/RustCrypto/asm-hashes" }

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -19,7 +19,7 @@ digest = "0.9"
 block-buffer = "0.9"
 opaque-debug = "0.3"
 cfg-if = "1.0"
-sha2-asm = { version = "0.6", optional = true }
+sha2-asm = { version = "0.6.1", optional = true }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 cpuid-bool = "0.2"


### PR DESCRIPTION
This release includes support for Apple M1 CPUs:

https://github.com/RustCrypto/asm-hashes/pull/35