### PR TITLE
sha2 v0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "block-buffer",
  "cfg-if",

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -5,9 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.4 (2021-05-05)
+### Added
+- Hardware accelerated SHA-256 for Apple M1 CPUs with `asm` feature ([#262])
+
+### Changed
+- Bump `sha2-asm` to v0.6.1 release ([#262])
+- Switch from `cpuid-bool` to `cpufeatures` ([#263])
+
+[#262]: https://github.com/RustCrypto/hashes/pull/262
+[#263]: https://github.com/RustCrypto/hashes/pull/263
+
 ## 0.9.3 (2021-01-30)
 ### Changed
-- Use the SHA extension backend with enabled `asm` feature. ([#224])
+- Use the SHA-NI extension backend with enabled `asm` feature. ([#224])
 
 [#224]: https://github.com/RustCrypto/hashes/pull/224
 

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.4"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.


### PR DESCRIPTION
### Added
- Hardware accelerated SHA-256 for Apple M1 CPUs with `asm` feature ([#262])

### Changed
- Bump `sha2-asm` to v0.6.1 release ([#262])
- Switch from `cpuid-bool` to `cpufeatures` ([#263])

[#262]: https://github.com/RustCrypto/hashes/pull/262
[#263]: https://github.com/RustCrypto/hashes/pull/263