### PR TITLE
sha2: use `cpufeatures` to detect `sha2` on `aarch64`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
 
 [[package]]
+name = "cpufeatures"
+version = "0.1.0"
+source = "git+https://github.com/rustcrypto/utils.git#fd95867b114152b75ef12271199976902698e3bd"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,7 +236,7 @@ version = "0.9.5"
 dependencies = [
  "block-buffer",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest",
  "hex-literal",
  "libc",
@@ -251,10 +259,9 @@ version = "0.9.4"
 dependencies = [
  "block-buffer",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.1.0 (git+https://github.com/rustcrypto/utils.git)",
  "digest",
  "hex-literal",
- "libc",
  "opaque-debug",
  "sha2-asm",
 ]

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -21,11 +21,12 @@ opaque-debug = "0.3"
 cfg-if = "1.0"
 sha2-asm = { version = "0.6.1", optional = true }
 
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-cpufeatures = "0.1"
-
+[target.aarch64-apple-darwin.dependencies]
+cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
-libc = { version = "0.2.93", optional = true }
+cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }
@@ -34,7 +35,7 @@ hex-literal = "0.2"
 [features]
 default = ["std"]
 std = ["digest/std"]
-asm = ["sha2-asm", "libc"]
+asm = ["sha2-asm"]
 compress = [] # Expose compress function
 force-soft = [] # Force software implementation
 asm-aarch64 = ["asm"] # DEPRECATED: use `asm` instead

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -1,23 +1,13 @@
-#[cfg(target_os = "linux")]
-#[inline(always)]
-pub fn sha2_supported() -> bool {
-    use libc::{getauxval, AT_HWCAP, HWCAP_SHA2};
+//! SHA-256 `aarch64` backend.
 
-    let hwcaps: u64 = unsafe { getauxval(AT_HWCAP) };
-    (hwcaps & HWCAP_SHA2) != 0
-}
+// TODO: stdarch intrinsics: RustCrypto/hashes#257
 
-#[cfg(target_os = "macos")]
-#[inline(always)]
-pub fn sha2_supported() -> bool {
-    // TODO: Use cpufeatures once support lands
-    true
-}
+cpufeatures::new!(sha2_hwcap, "sha2");
 
 pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
-    if sha2_supported() {
+    if sha2_hwcap::get() {
         sha2_asm::compress256(state, blocks);
     } else {
         super::soft::compress(state, blocks);

--- a/sha2/src/sha256/x86.rs
+++ b/sha2/src/sha256/x86.rs
@@ -1,3 +1,5 @@
+//! SHA-256 `x86`/`x86_64` backend
+
 #![allow(clippy::many_single_char_names)]
 
 #[cfg(target_arch = "x86")]


### PR DESCRIPTION
Uses the newly added `aarch64` support in the `cpufeatures` crate for `sha2` CPU feature detection on Linux and macOS/M1.