### PR TITLE
sha1: use `cpufeatures` to detect SHA-1 on `aarch64`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,12 +57,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cpufeatures"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd5a7748210e7ec1a9696610b1015e6e31fbf58f77a160801f124bd1c36592a"
-
-[[package]]
-name = "cpufeatures"
-version = "0.1.0"
 source = "git+https://github.com/rustcrypto/utils.git#fd95867b114152b75ef12271199976902698e3bd"
 dependencies = [
  "libc",
@@ -236,10 +230,9 @@ version = "0.9.5"
 dependencies = [
  "block-buffer",
  "cfg-if",
- "cpufeatures 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cpufeatures",
  "digest",
  "hex-literal",
- "libc",
  "opaque-debug",
  "sha1-asm",
 ]
@@ -259,7 +252,7 @@ version = "0.9.4"
 dependencies = [
  "block-buffer",
  "cfg-if",
- "cpufeatures 0.1.0 (git+https://github.com/rustcrypto/utils.git)",
+ "cpufeatures",
  "digest",
  "hex-literal",
  "opaque-debug",

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -21,11 +21,12 @@ opaque-debug = "0.3"
 cfg-if = "1.0"
 sha1-asm = { version = "0.4", optional = true }
 
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-cpufeatures = "0.1"
-
+[target.aarch64-apple-darwin.dependencies]
+cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
-libc = { version = "0.2.93", optional = true }
+cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }
@@ -34,7 +35,7 @@ hex-literal = "0.2"
 [features]
 default = ["std"]
 std = ["digest/std"]
-asm = ["sha1-asm", "libc"]
+asm = ["sha1-asm"]
 compress = [] # Expose compress function
 force-soft = [] # Force software implementation
 

--- a/sha1/src/compress/aarch64.rs
+++ b/sha1/src/compress/aarch64.rs
@@ -1,17 +1,16 @@
-#![cfg(feature = "asm-aarch64")]
-use libc::{getauxval, AT_HWCAP, HWCAP_SHA1};
+//! SHA-1 `aarch64` backend.
 
-fn sha1_supported() -> bool {
-    #[allow(unsafe_code)]
-    let hwcaps: u64 = unsafe { getauxval(AT_HWCAP) };
-    (hwcaps & HWCAP_SHA1) != 0
-}
+/// Per rustc target feature docs for `aarch64-unknown-linux-gnu` and
+/// `aarch64-apple-darwin` platforms, the `sha2` target feature enables
+/// SHA-1 as well:
+///
+/// > Enable SHA1 and SHA256 support.
+cpufeatures::new!(sha2_hwcap, "sha2");
 
 pub fn compress(state: &mut [u32; 5], blocks: &[u8; 64]) {
-    // TODO: Replace this platform-specific call with is_aarch64_feature_detected!("sha1") once
-    // that macro is stabilised and https://github.com/rust-lang/rfcs/pull/2725 is implemented
-    // to let us use it on no_std.
-    if sha1_supported() {
+    // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
+    // after stabilization
+    if sha2_hwcap::get() {
         for block in blocks {
             sha1_asm::compress(state, block);
         }

--- a/sha1/src/compress/x86.rs
+++ b/sha1/src/compress/x86.rs
@@ -1,3 +1,5 @@
+//! SHA-1 `x86`/`x86_64` backend
+
 #![cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #![allow(unsafe_code)]
 


### PR DESCRIPTION
Uses the newly added `aarch64` support in the `cpufeatures` crate for `sha1` CPU feature detection on Linux and macOS/M1.