### PR TITLE
sha1+sha2: use cpufeatures v0.1.1 crate release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,8 +56,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.0"
-source = "git+https://github.com/rustcrypto/utils.git#fd95867b114152b75ef12271199976902698e3bd"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
 dependencies = [
  "libc",
 ]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -22,11 +22,11 @@ cfg-if = "1.0"
 sha1-asm = { version = "0.4", optional = true }
 
 [target.aarch64-apple-darwin.dependencies]
-cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
+cpufeatures = "0.1.1"
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
-cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
+cpufeatures = "0.1.1"
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
+cpufeatures = "0.1.1"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -22,11 +22,11 @@ cfg-if = "1.0"
 sha2-asm = { version = "0.6.1", optional = true }
 
 [target.aarch64-apple-darwin.dependencies]
-cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
+cpufeatures = "0.1.1"
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
-cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
+cpufeatures = "0.1.1"
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-cpufeatures = { version = "0.1", git = "https://github.com/rustcrypto/utils.git" }
+cpufeatures = "0.1.1"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }


### PR DESCRIPTION
Will let @newpavlov review everything before cutting releases of `sha1`/`sha2` which use this, but as far as I can tell everything is working.