### PR TITLE
sha-1 v0.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "block-buffer",
  "cfg-if",

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.6 (2021-05-11)
+### Changed
+- Use `cpufeatures` to detect intrinsics support on `aarch64` targets ([#268])
+
+[#268]: https://github.com/RustCrypto/hashes/pull/268
+
 ## 0.9.5 (2021-05-05)
 ### Changed
 - Switch from `cpuid-bool` to `cpufeatures` ([#263])

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-1"
-version = "0.9.5"
+version = "0.9.6"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- Use `cpufeatures` to detect intrinsics support on `aarch64` targets ([#268])

[#268]: https://github.com/RustCrypto/hashes/pull/268