### PR TITLE
sha2 v0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "block-buffer",
  "cfg-if",

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.5 (2021-05-11)
+### Changed
+- Use `cpufeatures` to detect intrinsics support on `aarch64` targets ([#267])
+
+[#267]: https://github.com/RustCrypto/hashes/pull/267
+
 ## 0.9.4 (2021-05-05)
 ### Added
 - Hardware accelerated SHA-256 for Apple M1 CPUs with `asm` feature ([#262])

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.9.4"
+version = "0.9.5"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.


### PR DESCRIPTION
### Changed
- Use `cpufeatures` to detect intrinsics support on `aarch64` targets ([#267])

[#267]: https://github.com/RustCrypto/hashes/pull/267