### PR TITLE
sha1+sha2: make aarch64 CPU feature detection OS-independent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281f563b2c3a0e535ab12d81d3c5859045795256ad269afa7c19542585b68f93"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
 dependencies = [
  "libc",
 ]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -21,12 +21,8 @@ opaque-debug = "0.3"
 cfg-if = "1.0"
 sha1-asm = { version = "0.4", optional = true }
 
-[target.aarch64-apple-darwin.dependencies]
-cpufeatures = "0.1.3"
-[target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
-cpufeatures = "0.1.3"
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-cpufeatures = "0.1.3"
+[target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
+cpufeatures = "0.1.4"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/sha1/src/compress.rs
+++ b/sha1/src/compress.rs
@@ -5,7 +5,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "force-soft")] {
         mod soft;
         use soft::compress as compress_inner;
-    } else if #[cfg(all(feature = "asm", target_arch = "aarch64", target_os = "linux"))] {
+    } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
         mod soft;
         mod aarch64;
         use aarch64::compress as compress_inner;

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -21,12 +21,8 @@ opaque-debug = "0.3"
 cfg-if = "1.0"
 sha2-asm = { version = "0.6.1", optional = true }
 
-[target.aarch64-apple-darwin.dependencies]
-cpufeatures = "0.1.3"
-[target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dependencies]
-cpufeatures = "0.1.3"
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-cpufeatures = "0.1.3"
+[target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
+cpufeatures = "0.1.4"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -153,7 +153,7 @@ cfg_if::cfg_if! {
         }
         mod x86;
         use x86::compress;
-    } else if #[cfg(all(feature = "asm", target_arch = "aarch64", any(target_os = "macos", target_os = "linux")))] {
+    } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
         mod soft;
         mod aarch64;
         use aarch64::compress;


### PR DESCRIPTION
`cpufeatures` v0.1.4 can build on any `aarch64` target, not just Linux/macOS ones:

https://github.com/RustCrypto/utils/pull/40

This PR bumps the minimum `cpufeatures` requirement to v0.1.4 and removes the OS-specifisms on `aarch64` targets.

On platforms other than Linux/macOS, CPU features are always detected as `false` unless the corresponding `target_feature`s have been enabled via `RUSTFLAGS`. But in the future, we can add new platform support to `cpufeatures` without changing all of its downstream consumers.