### PR TITLE
RIPEMD-256 implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = "0.9.1"
 dependencies = [
  "crypto-mac",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
 ]
 
@@ -99,7 +99,7 @@ version = "0.9.1"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
 ]
 
@@ -109,7 +109,7 @@ version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
 ]
 
@@ -122,6 +122,12 @@ dependencies = [
  "hex-literal-impl",
  "proc-macro-hack",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
 name = "hex-literal-impl"
@@ -137,7 +143,7 @@ name = "k12"
 version = "0.1.0"
 dependencies = [
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
 ]
 
 [[package]]
@@ -158,7 +164,7 @@ version = "0.9.1"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "md5-asm",
  "opaque-debug",
 ]
@@ -169,7 +175,7 @@ version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
 ]
 
@@ -179,7 +185,7 @@ version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
 ]
 
@@ -210,7 +216,17 @@ version = "0.9.1"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
+ "opaque-debug",
+]
+
+[[package]]
+name = "ripemd256"
+version = "0.1.0"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "hex-literal 0.3.1",
  "opaque-debug",
 ]
 
@@ -220,7 +236,7 @@ version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
 ]
 
@@ -232,7 +248,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
  "sha1-asm",
 ]
@@ -254,7 +270,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
  "sha2-asm",
 ]
@@ -274,7 +290,7 @@ version = "0.9.1"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "keccak",
  "opaque-debug",
 ]
@@ -285,7 +301,7 @@ version = "0.3.0"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
 ]
 
@@ -295,7 +311,7 @@ version = "0.9.2"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
 ]
 
@@ -312,7 +328,7 @@ dependencies = [
  "block-buffer",
  "byteorder",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
 ]
 
 [[package]]
@@ -333,7 +349,7 @@ version = "0.9.0"
 dependencies = [
  "block-buffer",
  "digest",
- "hex-literal",
+ "hex-literal 0.2.1",
  "opaque-debug",
  "whirlpool-asm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "md4",
     "md5",
     "ripemd160",
+    "ripemd256",
     "ripemd320",
     "sha1",
     "sha2",

--- a/ripemd256/.gitignore
+++ b/ripemd256/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/ripemd256/Cargo.toml
+++ b/ripemd256/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "ripemd256"
+version = "0.1.0"
+authors = ["RustCrypto Developers"]
+license = "MIT OR Apache-2.0"
+edition = "2018"
+readme = "README.md"
+keywords = ["crypto", "ripemd320", "hash", "digest"]
+categories = ["cryptography", "no-std"]
+description = "RIPEMD-256 hash function"
+repository = "https://github.com/RustCrypto/hashes"
+
+
+[dependencies]
+block-buffer = "0.9"
+digest = "0.9"
+opaque-debug = "0.3"
+
+[dev-dependencies]
+digest = { version = "0.9", features = ["dev"] }
+hex-literal = "0.3"
+
+[features]
+default = ["std"]
+std = ["digest/std"]

--- a/ripemd256/LICENSE-APACHE
+++ b/ripemd256/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ripemd256/LICENSE-MIT
+++ b/ripemd256/LICENSE-MIT
@@ -1,0 +1,27 @@
+Copyright (c) 2006-2009 Graydon Hoare
+Copyright (c) 2009-2013 Mozilla Foundation
+Copyright (c) 2016 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/ripemd256/README.md
+++ b/ripemd256/README.md
@@ -1,0 +1,31 @@
+# RustCrypto: RIPEMD256
+Pure Rust implementation of the [RIPEMD256 hash function][1].
+
+## Minimum Supported Rust Version
+
+Rust **1.41** or higher.
+
+Minimum supported Rust version can be changed in the future, but it will be
+done with a minor version bump.
+
+## SemVer Policy
+
+- All on-by-default features of this library are covered by SemVer
+- MSRV is considered exempt from SemVer as noted above
+
+## License
+
+Licensed under either of:
+
+ * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+ * [MIT license](http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions
+
+[1]: https://en.wikipedia.org/wiki/RIPEMD

--- a/ripemd256/examples/ripemd256sum.rs
+++ b/ripemd256/examples/ripemd256sum.rs
@@ -1,0 +1,47 @@
+use ripemd256::{Digest, Ripemd256};
+use std::env;
+use std::fs;
+use std::io::{self, Read};
+
+const BUFFER_SIZE: usize = 1024;
+
+/// Print digest result as hex string and name pair
+fn print_result(sum: &[u8], name: &str) {
+    for byte in sum {
+        print!("{:02x}", byte);
+    }
+    println!("\t{}", name);
+}
+
+/// Compute digest value for given `Reader` and print it
+/// On any error simply return without doing anything
+fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
+    let mut sh = D::default();
+    let mut buffer = [0u8; BUFFER_SIZE];
+    loop {
+        let n = match reader.read(&mut buffer) {
+            Ok(n) => n,
+            Err(_) => return,
+        };
+        sh.update(&buffer[..n]);
+        if n == 0 || n < BUFFER_SIZE {
+            break;
+        }
+    }
+    print_result(&sh.finalize(), name);
+}
+
+fn main() {
+    let args = env::args();
+    // Process files listed in command line arguments one by one
+    // If no files provided process input from stdin
+    if args.len() > 1 {
+        for path in args.skip(1) {
+            if let Ok(mut file) = fs::File::open(&path) {
+                process::<Ripemd256, _>(&mut file, &path);
+            }
+        }
+    } else {
+        process::<Ripemd256, _>(&mut io::stdin(), "-");
+    }
+}

--- a/ripemd256/src/block.rs
+++ b/ripemd256/src/block.rs
@@ -1,0 +1,277 @@
+use core::{convert::TryInto, mem::swap};
+use digest::generic_array::typenum::U64;
+use digest::generic_array::GenericArray;
+
+pub const DIGEST_BUF_LEN: usize = 8;
+pub const HALF_DIGEST_BUF_LEN: usize = DIGEST_BUF_LEN / 2;
+pub const WORK_BUF_LEN: usize = 16;
+
+pub const H0: [u32; DIGEST_BUF_LEN] = [
+    0x6745_2301,
+    0xefcd_ab89,
+    0x98ba_dcfe,
+    0x1032_5476,
+    0x7654_3210,
+    0xfedc_ba98,
+    0x89ab_cdef,
+    0x0123_4567,
+];
+
+type Block = GenericArray<u8, U64>;
+
+macro_rules! round(
+    ($a:expr, $b:expr, $c:expr, $d:expr,
+     $x:expr, $bits:expr, $add:expr, $round:expr) => ({
+        $a = $a.wrapping_add($round).wrapping_add($x).wrapping_add($add);
+        $a = $a.rotate_left($bits);
+    });
+);
+
+#[inline(always)]
+fn swap_idx(bb: &mut [u32; HALF_DIGEST_BUF_LEN], bbb: &mut [u32; HALF_DIGEST_BUF_LEN], idx: usize) {
+    swap(&mut bb[idx], &mut bbb[idx]);
+}
+
+macro_rules! process_block(
+    ($h:ident, $data:expr,
+    $( round1: h_ordering $f0:expr, $f1:expr, $f2:expr, $f3:expr;
+            data_index $data_index1:expr; roll_shift $bits1:expr )*;
+    $( round2: h_ordering $g0:expr, $g1:expr, $g2:expr, $g3:expr;
+            data_index $data_index2:expr; roll_shift $bits2:expr )*;
+    $( round3: h_ordering $h0:expr, $h1:expr, $h2:expr, $h3:expr;
+            data_index $data_index3:expr; roll_shift $bits3:expr )*;
+    $( round4: h_ordering $i0:expr, $i1:expr, $i2:expr, $i3:expr;
+            data_index $data_index4:expr; roll_shift $bits4:expr )*;
+    $( par_round1: h_ordering $pi0:expr, $pi1:expr, $pi2:expr, $pi3:expr;
+            data_index $pdata_index1:expr; roll_shift $pbits1:expr )*;
+    $( par_round2: h_ordering $ph0:expr, $ph1:expr, $ph2:expr, $ph3:expr;
+            data_index $pdata_index2:expr; roll_shift $pbits2:expr )*;
+    $( par_round3: h_ordering $pg0:expr, $pg1:expr, $pg2:expr, $pg3:expr;
+            data_index $pdata_index3:expr; roll_shift $pbits3:expr )*;
+    $( par_round4: h_ordering $pf0:expr, $pf1:expr, $pf2:expr, $pf3:expr;
+            data_index $pdata_index4:expr; roll_shift $pbits4:expr )*;
+    ) => ({
+        let mut bb = [0u32; HALF_DIGEST_BUF_LEN];
+        bb.copy_from_slice(&$h[..HALF_DIGEST_BUF_LEN]);
+
+        let mut bbb = [0u32; HALF_DIGEST_BUF_LEN];
+        bbb.copy_from_slice(&$h[HALF_DIGEST_BUF_LEN..]);
+
+
+        // Round 1
+        $( round!(bb[$f0], bb[$f1], bb[$f2], bb[$f3],
+            $data[$data_index1], $bits1, 0x0000_0000,
+            bb[$f1] ^ bb[$f2] ^ bb[$f3]); )*
+
+        // Parallel Round 1
+        $( round!(bbb[$pi0], bbb[$pi1], bbb[$pi2], bbb[$pi3],
+            $data[$pdata_index1], $pbits1, 0x50a2_8be6,
+            (bbb[$pi1] & bbb[$pi3]) | (bbb[$pi2] & !bbb[$pi3])); )*
+
+        swap_idx(&mut bb, &mut bbb, 0);
+
+
+        // Round 2
+        $( round!(bb[$g0], bb[$g1], bb[$g2], bb[$g3],
+            $data[$data_index2], $bits2, 0x5a82_7999,
+            (bb[$g1] & bb[$g2]) | (!bb[$g1] & bb[$g3])); )*
+
+        // Parallel Round 2
+        $( round!(bbb[$ph0], bbb[$ph1], bbb[$ph2], bbb[$ph3],
+            $data[$pdata_index2], $pbits2, 0x5c4d_d124,
+            (bbb[$ph1] | !bbb[$ph2]) ^ bbb[$ph3]); )*
+
+
+        swap_idx(&mut bb, &mut bbb, 1);
+
+
+        // Round 3
+        $( round!(bb[$h0], bb[$h1], bb[$h2], bb[$h3],
+            $data[$data_index3], $bits3, 0x6ed9_eba1,
+            (bb[$h1] | !bb[$h2]) ^ bb[$h3]); )*
+
+        // Parallel Round 3
+        $( round!(bbb[$pg0], bbb[$pg1], bbb[$pg2], bbb[$pg3],
+            $data[$pdata_index3], $pbits3, 0x6d70_3ef3,
+            (bbb[$pg1] & bbb[$pg2]) | (!bbb[$pg1] & bbb[$pg3])); )*
+
+        swap_idx(&mut bb, &mut bbb, 2);
+
+
+        // Round 4
+        $( round!(bb[$i0], bb[$i1], bb[$i2], bb[$i3],
+            $data[$data_index4], $bits4, 0x8f1b_bcdc,
+            (bb[$i1] & bb[$i3]) | (bb[$i2] & !bb[$i3])); )*
+
+
+        // Parallel Round 4
+        $( round!(bbb[$pf0], bbb[$pf1], bbb[$pf2], bbb[$pf3],
+            $data[$pdata_index4], $pbits4, 0x0000_0000,
+            bbb[$pf1] ^ bbb[$pf2] ^ bbb[$pf3]); )*
+
+        swap_idx(&mut bb,  &mut bbb, 3);
+
+        $h[0] = $h[0].wrapping_add(bb[0]);
+        $h[1] = $h[1].wrapping_add(bb[1]);
+        $h[2] = $h[2].wrapping_add(bb[2]);
+        $h[3] = $h[3].wrapping_add(bb[3]);
+        $h[4] = $h[4].wrapping_add(bbb[0]);
+        $h[5] = $h[5].wrapping_add(bbb[1]);
+        $h[6] = $h[6].wrapping_add(bbb[2]);
+        $h[7] = $h[7].wrapping_add(bbb[3]);
+    });
+);
+
+pub fn process_msg_block(h: &mut [u32; DIGEST_BUF_LEN], data: &Block) {
+    let mut w = [0u32; WORK_BUF_LEN];
+    for (o, chunk) in w.iter_mut().zip(data.chunks_exact(4)) {
+        *o = u32::from_le_bytes(chunk.try_into().unwrap());
+    }
+
+    process_block!(h, w[..],
+
+    // Round 1
+        round1: h_ordering 0, 1, 2, 3; data_index  0; roll_shift 11
+        round1: h_ordering 3, 0, 1, 2; data_index  1; roll_shift 14
+        round1: h_ordering 2, 3, 0, 1; data_index  2; roll_shift 15
+        round1: h_ordering 1, 2, 3, 0; data_index  3; roll_shift 12
+        round1: h_ordering 0, 1, 2, 3; data_index  4; roll_shift  5
+        round1: h_ordering 3, 0, 1, 2; data_index  5; roll_shift  8
+        round1: h_ordering 2, 3, 0, 1; data_index  6; roll_shift  7
+        round1: h_ordering 1, 2, 3, 0; data_index  7; roll_shift  9
+        round1: h_ordering 0, 1, 2, 3; data_index  8; roll_shift 11
+        round1: h_ordering 3, 0, 1, 2; data_index  9; roll_shift 13
+        round1: h_ordering 2, 3, 0, 1; data_index 10; roll_shift 14
+        round1: h_ordering 1, 2, 3, 0; data_index 11; roll_shift 15
+        round1: h_ordering 0, 1, 2, 3; data_index 12; roll_shift  6
+        round1: h_ordering 3, 0, 1, 2; data_index 13; roll_shift  7
+        round1: h_ordering 2, 3, 0, 1; data_index 14; roll_shift  9
+        round1: h_ordering 1, 2, 3, 0; data_index 15; roll_shift  8;
+
+    // Round 2
+        round2: h_ordering 0, 1, 2, 3; data_index  7; roll_shift  7
+        round2: h_ordering 3, 0, 1, 2; data_index  4; roll_shift  6
+        round2: h_ordering 2, 3, 0, 1; data_index 13; roll_shift  8
+        round2: h_ordering 1, 2, 3, 0; data_index  1; roll_shift 13
+        round2: h_ordering 0, 1, 2, 3; data_index 10; roll_shift 11
+        round2: h_ordering 3, 0, 1, 2; data_index  6; roll_shift  9
+        round2: h_ordering 2, 3, 0, 1; data_index 15; roll_shift  7
+        round2: h_ordering 1, 2, 3, 0; data_index  3; roll_shift 15
+        round2: h_ordering 0, 1, 2, 3; data_index 12; roll_shift  7
+        round2: h_ordering 3, 0, 1, 2; data_index  0; roll_shift 12
+        round2: h_ordering 2, 3, 0, 1; data_index  9; roll_shift 15
+        round2: h_ordering 1, 2, 3, 0; data_index  5; roll_shift  9
+        round2: h_ordering 0, 1, 2, 3; data_index  2; roll_shift 11
+        round2: h_ordering 3, 0, 1, 2; data_index 14; roll_shift  7
+        round2: h_ordering 2, 3, 0, 1; data_index 11; roll_shift 13
+        round2: h_ordering 1, 2, 3, 0; data_index  8; roll_shift 12;
+
+    // Round 3
+        round3: h_ordering 0, 1, 2, 3; data_index  3; roll_shift 11
+        round3: h_ordering 3, 0, 1, 2; data_index 10; roll_shift 13
+        round3: h_ordering 2, 3, 0, 1; data_index 14; roll_shift  6
+        round3: h_ordering 1, 2, 3, 0; data_index  4; roll_shift  7
+        round3: h_ordering 0, 1, 2, 3; data_index  9; roll_shift 14
+        round3: h_ordering 3, 0, 1, 2; data_index 15; roll_shift  9
+        round3: h_ordering 2, 3, 0, 1; data_index  8; roll_shift 13
+        round3: h_ordering 1, 2, 3, 0; data_index  1; roll_shift 15
+        round3: h_ordering 0, 1, 2, 3; data_index  2; roll_shift 14
+        round3: h_ordering 3, 0, 1, 2; data_index  7; roll_shift  8
+        round3: h_ordering 2, 3, 0, 1; data_index  0; roll_shift 13
+        round3: h_ordering 1, 2, 3, 0; data_index  6; roll_shift  6
+        round3: h_ordering 0, 1, 2, 3; data_index 13; roll_shift  5
+        round3: h_ordering 3, 0, 1, 2; data_index 11; roll_shift 12
+        round3: h_ordering 2, 3, 0, 1; data_index  5; roll_shift  7
+        round3: h_ordering 1, 2, 3, 0; data_index 12; roll_shift  5;
+
+    // Round 4
+        round4: h_ordering 0, 1, 2, 3; data_index  1; roll_shift 11
+        round4: h_ordering 3, 0, 1, 2; data_index  9; roll_shift 12
+        round4: h_ordering 2, 3, 0, 1; data_index 11; roll_shift 14
+        round4: h_ordering 1, 2, 3, 0; data_index 10; roll_shift 15
+        round4: h_ordering 0, 1, 2, 3; data_index  0; roll_shift 14
+        round4: h_ordering 3, 0, 1, 2; data_index  8; roll_shift 15
+        round4: h_ordering 2, 3, 0, 1; data_index 12; roll_shift  9
+        round4: h_ordering 1, 2, 3, 0; data_index  4; roll_shift  8
+        round4: h_ordering 0, 1, 2, 3; data_index 13; roll_shift  9
+        round4: h_ordering 3, 0, 1, 2; data_index  3; roll_shift 14
+        round4: h_ordering 2, 3, 0, 1; data_index  7; roll_shift  5
+        round4: h_ordering 1, 2, 3, 0; data_index 15; roll_shift  6
+        round4: h_ordering 0, 1, 2, 3; data_index 14; roll_shift  8
+        round4: h_ordering 3, 0, 1, 2; data_index  5; roll_shift  6
+        round4: h_ordering 2, 3, 0, 1; data_index  6; roll_shift  5
+        round4: h_ordering 1, 2, 3, 0; data_index  2; roll_shift 12;
+
+    // Parallel Round 1
+        par_round1: h_ordering 0, 1, 2, 3; data_index  5; roll_shift  8
+        par_round1: h_ordering 3, 0, 1, 2; data_index 14; roll_shift  9
+        par_round1: h_ordering 2, 3, 0, 1; data_index  7; roll_shift  9
+        par_round1: h_ordering 1, 2, 3, 0; data_index  0; roll_shift 11
+        par_round1: h_ordering 0, 1, 2, 3; data_index  9; roll_shift 13
+        par_round1: h_ordering 3, 0, 1, 2; data_index  2; roll_shift 15
+        par_round1: h_ordering 2, 3, 0, 1; data_index 11; roll_shift 15
+        par_round1: h_ordering 1, 2, 3, 0; data_index  4; roll_shift  5
+        par_round1: h_ordering 0, 1, 2, 3; data_index 13; roll_shift  7
+        par_round1: h_ordering 3, 0, 1, 2; data_index  6; roll_shift  7
+        par_round1: h_ordering 2, 3, 0, 1; data_index 15; roll_shift  8
+        par_round1: h_ordering 1, 2, 3, 0; data_index  8; roll_shift 11
+        par_round1: h_ordering 0, 1, 2, 3; data_index  1; roll_shift 14
+        par_round1: h_ordering 3, 0, 1, 2; data_index 10; roll_shift 14
+        par_round1: h_ordering 2, 3, 0, 1; data_index  3; roll_shift 12
+        par_round1: h_ordering 1, 2, 3, 0; data_index 12; roll_shift  6;
+
+    // Parallel Round 2
+        par_round2: h_ordering 0, 1, 2, 3; data_index  6; roll_shift  9
+        par_round2: h_ordering 3, 0, 1, 2; data_index 11; roll_shift 13
+        par_round2: h_ordering 2, 3, 0, 1; data_index  3; roll_shift 15
+        par_round2: h_ordering 1, 2, 3, 0; data_index  7; roll_shift  7
+        par_round2: h_ordering 0, 1, 2, 3; data_index  0; roll_shift 12
+        par_round2: h_ordering 3, 0, 1, 2; data_index 13; roll_shift  8
+        par_round2: h_ordering 2, 3, 0, 1; data_index  5; roll_shift  9
+        par_round2: h_ordering 1, 2, 3, 0; data_index 10; roll_shift 11
+        par_round2: h_ordering 0, 1, 2, 3; data_index 14; roll_shift  7
+        par_round2: h_ordering 3, 0, 1, 2; data_index 15; roll_shift  7
+        par_round2: h_ordering 2, 3, 0, 1; data_index  8; roll_shift 12
+        par_round2: h_ordering 1, 2, 3, 0; data_index 12; roll_shift  7
+        par_round2: h_ordering 0, 1, 2, 3; data_index  4; roll_shift  6
+        par_round2: h_ordering 3, 0, 1, 2; data_index  9; roll_shift 15
+        par_round2: h_ordering 2, 3, 0, 1; data_index  1; roll_shift 13
+        par_round2: h_ordering 1, 2, 3, 0; data_index  2; roll_shift 11;
+
+    // Parallel Round 3
+        par_round3: h_ordering 0, 1, 2, 3; data_index 15; roll_shift  9
+        par_round3: h_ordering 3, 0, 1, 2; data_index  5; roll_shift  7
+        par_round3: h_ordering 2, 3, 0, 1; data_index  1; roll_shift 15
+        par_round3: h_ordering 1, 2, 3, 0; data_index  3; roll_shift 11
+        par_round3: h_ordering 0, 1, 2, 3; data_index  7; roll_shift  8
+        par_round3: h_ordering 3, 0, 1, 2; data_index 14; roll_shift  6
+        par_round3: h_ordering 2, 3, 0, 1; data_index  6; roll_shift  6
+        par_round3: h_ordering 1, 2, 3, 0; data_index  9; roll_shift 14
+        par_round3: h_ordering 0, 1, 2, 3; data_index 11; roll_shift 12
+        par_round3: h_ordering 3, 0, 1, 2; data_index  8; roll_shift 13
+        par_round3: h_ordering 2, 3, 0, 1; data_index 12; roll_shift  5
+        par_round3: h_ordering 1, 2, 3, 0; data_index  2; roll_shift 14
+        par_round3: h_ordering 0, 1, 2, 3; data_index 10; roll_shift 13
+        par_round3: h_ordering 3, 0, 1, 2; data_index  0; roll_shift 13
+        par_round3: h_ordering 2, 3, 0, 1; data_index  4; roll_shift  7
+        par_round3: h_ordering 1, 2, 3, 0; data_index 13; roll_shift  5;
+
+    // Parallel Round 4
+        par_round4: h_ordering 0, 1, 2, 3; data_index  8; roll_shift 15
+        par_round4: h_ordering 3, 0, 1, 2; data_index  6; roll_shift  5
+        par_round4: h_ordering 2, 3, 0, 1; data_index  4; roll_shift  8
+        par_round4: h_ordering 1, 2, 3, 0; data_index  1; roll_shift 11
+        par_round4: h_ordering 0, 1, 2, 3; data_index  3; roll_shift 14
+        par_round4: h_ordering 3, 0, 1, 2; data_index 11; roll_shift 14
+        par_round4: h_ordering 2, 3, 0, 1; data_index 15; roll_shift  6
+        par_round4: h_ordering 1, 2, 3, 0; data_index  0; roll_shift 14
+        par_round4: h_ordering 0, 1, 2, 3; data_index  5; roll_shift  6
+        par_round4: h_ordering 3, 0, 1, 2; data_index 12; roll_shift  9
+        par_round4: h_ordering 2, 3, 0, 1; data_index  2; roll_shift 12
+        par_round4: h_ordering 1, 2, 3, 0; data_index 13; roll_shift  9
+        par_round4: h_ordering 0, 1, 2, 3; data_index  9; roll_shift 12
+        par_round4: h_ordering 3, 0, 1, 2; data_index  7; roll_shift  5
+        par_round4: h_ordering 2, 3, 0, 1; data_index 10; roll_shift 15
+        par_round4: h_ordering 1, 2, 3, 0; data_index 14; roll_shift  8;
+    );
+}

--- a/ripemd256/src/lib.rs
+++ b/ripemd256/src/lib.rs
@@ -1,0 +1,96 @@
+//! An implementation of the [RIPEMD-256][1] cryptographic hash.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use hex_literal::hex;
+//! use ripemd256::{Ripemd256, Digest};
+//!
+//! // create a RIPEMD-256 hasher instance
+//! let mut hasher = Ripemd256::new();
+//!
+//! // process input message
+//! hasher.update(b"Hello world!");
+//!
+//! // acquire hash digest in the form of GenericArray,
+//! // which in this case is equivalent to [u8; 32]
+//! let expected = hex!("2700f1122c7bd5df165b0615efbbbc54f551aef2401738811a5aea19ccb9233a");
+//! let result = hasher.finalize();
+//! assert_eq!(&result[..], &expected[..]);
+//! ```
+//!
+//! [1]: https://en.wikipedia.org/wiki/RIPEMD
+
+#![no_std]
+#![deny(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+mod block;
+
+pub use digest::{self, Digest};
+
+use block::{process_msg_block, DIGEST_BUF_LEN, H0};
+use block_buffer::BlockBuffer;
+use digest::{
+    consts::{U32, U64},
+    BlockInput, FixedOutputDirty, Reset, Update,
+};
+
+/// Structure representing the state of a Ripemd256 computation
+#[derive(Clone)]
+pub struct Ripemd256 {
+    h: [u32; DIGEST_BUF_LEN],
+    len: u64,
+    buffer: BlockBuffer<U64>,
+}
+
+impl Default for Ripemd256 {
+    fn default() -> Self {
+        Ripemd256 {
+            h: H0,
+            len: 0,
+            buffer: Default::default(),
+        }
+    }
+}
+
+impl BlockInput for Ripemd256 {
+    type BlockSize = U64;
+}
+
+impl Update for Ripemd256 {
+    fn update(&mut self, input: impl AsRef<[u8]>) {
+        let input = input.as_ref();
+        // Assumes that input.len() can be converted to u64 without overflow
+        self.len += input.len() as u64;
+        let h = &mut self.h;
+        self.buffer.input_block(input, |b| process_msg_block(h, b));
+    }
+}
+
+impl FixedOutputDirty for Ripemd256 {
+    type OutputSize = U32;
+
+    fn finalize_into_dirty(&mut self, out: &mut digest::Output<Self>) {
+        let h = &mut self.h;
+        let l = self.len << 3;
+        self.buffer.len64_padding_le(l, |b| process_msg_block(h, b));
+        for (chunk, v) in out.chunks_exact_mut(4).zip(self.h.iter()) {
+            chunk.copy_from_slice(&v.to_le_bytes());
+        }
+    }
+}
+
+impl Reset for Ripemd256 {
+    fn reset(&mut self) {
+        self.buffer.reset();
+        self.len = 0;
+        self.h = H0;
+    }
+}
+
+opaque_debug::implement!(Ripemd256);
+digest::impl_write!(Ripemd256);

--- a/ripemd256/tests/lib.rs
+++ b/ripemd256/tests/lib.rs
@@ -1,0 +1,53 @@
+use digest::dev::one_million_a;
+use hex_literal::hex;
+use ripemd256::{Digest, Ripemd256};
+
+fn hash_test(msg: &str, expected: [u8; 32]) {
+    let mut hasher = Ripemd256::new();
+    hasher.update(msg.as_bytes());
+    let result = hasher.finalize();
+    assert_eq!(result[..], expected);
+}
+
+#[test]
+fn ripemd256_messages() {
+    hash_test(
+        "",
+        hex!("02ba4c4e5f8ecd1877fc52d64d30e37a2d9774fb1e5d026380ae0168e3c5522d"),
+    );
+    hash_test(
+        "a",
+        hex!("f9333e45d857f5d90a91bab70a1eba0cfb1be4b0783c9acfcd883a9134692925"),
+    );
+    hash_test(
+        "abc",
+        hex!("afbd6e228b9d8cbbcef5ca2d03e6dba10ac0bc7dcbe4680e1e42d2e975459b65"),
+    );
+    hash_test(
+        "message digest",
+        hex!("87e971759a1ce47a514d5c914c392c9018c7c46bc14465554afcdf54a5070c0e"),
+    );
+    hash_test(
+        "abcdefghijklmnopqrstuvwxyz",
+        hex!("649d3034751ea216776bf9a18acc81bc7896118a5197968782dd1fd97d8d5133"),
+    );
+    hash_test(
+        "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+        hex!("3843045583aac6c8c8d9128573e7a9809afb2a0f34ccc36ea9e72f16f6368e3f"),
+    );
+    hash_test(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+        hex!("5740a408ac16b720b84424ae931cbb1fe363d1d0bf4017f1a89f7ea6de77a0b8"),
+    );
+    hash_test(
+        "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+        hex!("06fdcc7a409548aaf91368c06a6275b553e3f099bf0ea4edfd6778df89a890dd"),
+    );
+}
+
+#[test]
+fn ripemd256_1million_a() {
+    one_million_a::<ripemd256::Ripemd256>(&hex!(
+        "ac953744e10e31514c150d4d8d7b677342e33399788296e43ae4850ce4f97978"
+    ));
+}


### PR DESCRIPTION
Partially addresses #1 

A RIPEMD-256 implementation based on the existing RIPEMD-320 implementation and https://android.googlesource.com/kernel/common/+/07e6124a1a46/crypto/rmd256.c. 

The test values come from - https://homes.esat.kuleuven.be/~bosselae/ripemd160.html