### PR TITLE
Fix `ripemd160/examples/ripemd160sum.rs` to digest correct bytes.

### DIFF
--- a/ripemd160/examples/ripemd160sum.rs
+++ b/ripemd160/examples/ripemd160sum.rs
@@ -23,7 +23,7 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.update(&buffer[..n]);
+        sh.update(&buffer[..n - 1]);
         if n == 0 || n < BUFFER_SIZE {
             break;
         }

--- a/ripemd160/examples/ripemd160sum.rs
+++ b/ripemd160/examples/ripemd160sum.rs
@@ -23,7 +23,9 @@ fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
             Ok(n) => n,
             Err(_) => return,
         };
-        sh.update(&buffer[..n - 1]);
+        if n > 0 {
+            sh.update(&buffer[..n - 1]);
+        }
         if n == 0 || n < BUFFER_SIZE {
             break;
         }


### PR DESCRIPTION
Seemed digesting incorrect byte count.