### PR TITLE
sha1: pass block slices to sha1_asm + remove cfg toggle for constants

### DIFF
--- a/sha1/src/compress.rs
+++ b/sha1/src/compress.rs
@@ -15,9 +15,7 @@ cfg_if::cfg_if! {
         #[cfg(feature = "asm")]
         mod soft {
             pub(crate) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
-                for block in blocks {
-                    sha1_asm::compress(state, block);
-                }
+                sha1_asm::compress(state, blocks);
             }
         }
         mod x86;

--- a/sha1/src/compress/aarch64.rs
+++ b/sha1/src/compress/aarch64.rs
@@ -7,13 +7,11 @@
 /// > Enable SHA1 and SHA256 support.
 cpufeatures::new!(sha2_hwcap, "sha2");
 
-pub fn compress(state: &mut [u32; 5], blocks: &[u8; 64]) {
+pub fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if sha2_hwcap::get() {
-        for block in blocks {
-            sha1_asm::compress(state, block);
-        }
+        sha1_asm::compress(state, blocks);
     } else {
         super::soft::compress(state, blocks);
     }

--- a/sha1/src/consts.rs
+++ b/sha1/src/consts.rs
@@ -1,17 +1,13 @@
 #![allow(clippy::unreadable_literal)]
 
 pub const STATE_LEN: usize = 5;
-
-#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 pub const BLOCK_LEN: usize = 16;
 
-#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
+/// Magic constants necessary for SHA-1.
 pub const K0: u32 = 0x5A827999u32;
-#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 pub const K1: u32 = 0x6ED9EBA1u32;
-#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 pub const K2: u32 = 0x8F1BBCDCu32;
-#[cfg(any(not(feature = "asm"), feature = "asm-aarch64"))]
 pub const K3: u32 = 0xCA62C1D6u32;
 
+/// Magic reset constants necessary for SHA-1.
 pub const H: [u32; STATE_LEN] = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0];


### PR DESCRIPTION
This doesn't really depend on RustCrypto/asm-hashes#38 but it is required to make it work for me on a M1 Mac.

As the title says i changed the (internal) API so that block slices instead of independent blocks are passes to `sha1_asm`.

I also removed the `cfg` toggles for `aarch64`, because they are required for the software-fallback and `asm-aarch64` is marked deprecated anyway.

Benchmarks on my M1 MacBookPro:

## Soft
```
test bench1_10    ... bench:          14 ns/iter (+/- 0) = 714 MB/s
test bench2_100   ... bench:         120 ns/iter (+/- 1) = 833 MB/s
test bench3_1000  ... bench:       1,151 ns/iter (+/- 4) = 868 MB/s
test bench4_10000 ... bench:      11,465 ns/iter (+/- 130) = 872 MB/s
```

## ASM
```
test bench1_10    ... bench:           7 ns/iter (+/- 0) = 1428 MB/s
test bench2_100   ... bench:          45 ns/iter (+/- 1) = 2222 MB/s
test bench3_1000  ... bench:         459 ns/iter (+/- 9) = 2178 MB/s
test bench4_10000 ... bench:       4,579 ns/iter (+/- 84) = 2183 MB/s
```