### PR TITLE
sha-1 v0.9.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "block-buffer",
  "cfg-if",

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.7 (2021-07-18)
+### Changed
+- Make `aarch64` CPU feature detection OS-independent ([#276])
+- Bump `sha1-asm` to v0.5; support ARMv8 Crypto Extensions on Apple targets ([#289])
+
+[#276]: https://github.com/RustCrypto/hashes/pull/276
+[#289]: https://github.com/RustCrypto/hashes/pull/289
+
 ## 0.9.6 (2021-05-11)
 ### Changed
 - Use `cpufeatures` to detect intrinsics support on `aarch64` targets ([#268])

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-1"
-version = "0.9.6"
+version = "0.9.7"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha1/README.md
+++ b/sha1/README.md
@@ -11,6 +11,14 @@ Pure Rust implementation of the [SHA-1 hash function][1].
 
 [Documentation][docs-link]
 
+## 🚨 Warning: Cryptographically Broken 🚨
+
+The SHA-1 hash function should be considered cryptographically broken and
+unsuitable for further use in any security critical capacity, as it is
+[practically vulnerable to chosen-prefix collisions][2].
+
+We provide this crate for legacy interoperability purposes only.
+
 ## Minimum Supported Rust Version
 
 Rust **1.41** or higher.
@@ -54,3 +62,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [1]: https://en.wikipedia.org/wiki/SHA-1
+[2]: https://sha-mbles.github.io/

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -1,4 +1,13 @@
-//! An implementation of the [SHA-1][1] cryptographic hash algorithm.
+//! Pure Rust implementation of the [SHA-1][1] cryptographic hash algorithm
+//! with optional hardware-specific optimizations.
+//!
+//! # 🚨 Warning: Cryptographically Broken! 🚨
+//!
+//! The SHA-1 hash function should be considered cryptographically broken and
+//! unsuitable for further use in any security critical capacity, as it is
+//! [practically vulnerable to chosen-prefix collisions][2].
+//!
+//! We provide this crate for legacy interoperability purposes only.
 //!
 //! # Usage
 //!
@@ -18,10 +27,11 @@
 //! assert_eq!(result[..], hex!("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"));
 //! ```
 //!
-//! Also see [RustCrypto/hashes][2] readme.
+//! Also see [RustCrypto/hashes][3] readme.
 //!
 //! [1]: https://en.wikipedia.org/wiki/SHA-1
-//! [2]: https://github.com/RustCrypto/hashes
+//! [2]: https://sha-mbles.github.io/
+//! [3]: https://github.com/RustCrypto/hashes
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
### Changed
- Make `aarch64` CPU feature detection OS-independent ([#276])
- Bump `sha1-asm` to v0.5; support ARMv8 Crypto Extensions on Apple targets ([#289])

[#276]: https://github.com/RustCrypto/hashes/pull/276
[#289]: https://github.com/RustCrypto/hashes/pull/289