### PR TITLE
sm3 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "block-buffer",
  "digest",

--- a/sm3/CHANGELOG.md
+++ b/sm3/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 (2021-03-30)
+## 0.3.0 (2021-07-18)
 ### Changed
-- SM3 release ([#249])
+- RustCrypto SM3 release ([#249])
 
 [#249]: https://github.com/RustCrypto/hashes/pull/249
+
+## 0.2.0 (2020-01-23)
+
+## 0.1.0 (2020-01-14)

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm3"
-version = "0.1.0"
+version = "0.3.0"
 description = "SM3 (OSCCA GM/T 0004-2012) hash function"
 authors = ["Tianjia Zhang <tianjia.zhang@linux.alibaba.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Changed
- RustCrypto SM3 release ([#249])

[#249]: https://github.com/RustCrypto/hashes/pull/249