### PR TITLE
blake2 v0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "blake2"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "crypto-mac",
  "digest",

--- a/blake2/CHANGELOG.md
+++ b/blake2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.2 (2021-08-25)
+### Fixed
+- Building with `simd_opt` on recent nightlies ([#301]) 
+
+[#301]: https://github.com/RustCrypto/hashes/pull/301
+
 ## 0.9.1 (2020-10-26)
 ### Changed
 - Bump `opaque-debug` to v0.3 ([#168])

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.9.1"
+version = "0.9.2"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Fixed
- Building with `simd_opt` on recent nightlies ([#301]) 

[#301]: https://github.com/RustCrypto/hashes/pull/301