### PR TITLE
sha-1 v0.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "block-buffer",
  "cfg-if",

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.8 (2021-08-27)
+### Changed
+- Bump `cpufeatures` dependency to 0.2 ([#306])
+
+[#306]: https://github.com/RustCrypto/hashes/pull/306
+
 ## 0.9.7 (2021-07-18)
 ### Changed
 - Make `aarch64` CPU feature detection OS-independent ([#276])

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha-1"
-version = "0.9.7"
+version = "0.9.8"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 sha1-asm = { version = "0.5", optional = true }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-cpufeatures = "0.2.1"
+cpufeatures = "0.2"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }


### PR DESCRIPTION
### Changed
- Bump `cpufeatures` dependency to 0.2 ([#306])

[#306]: https://github.com/RustCrypto/hashes/pull/306