### PR TITLE
sha2 v0.9.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "block-buffer",
  "cfg-if",

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.6 (2021-08-27)
+### Changed
+- Bump `cpufeatures` dependency to 0.2 ([#306])
+
+[#306]: https://github.com/RustCrypto/hashes/pull/306
+
 ## 0.9.5 (2021-05-11)
 ### Changed
 - Use `cpufeatures` to detect intrinsics support on `aarch64` targets ([#267])

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.6"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 sha2-asm = { version = "0.6.1", optional = true }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
-cpufeatures = "0.2.1"
+cpufeatures = "0.2"
 
 [dev-dependencies]
 digest = { version = "0.9", features = ["dev"] }


### PR DESCRIPTION
### Changed
- Bump `cpufeatures` dependency to 0.2 ([#306])

[#306]: https://github.com/RustCrypto/hashes/pull/306
