### PR TITLE
sha2: Fix bug in the AVX2 backend

### DIFF
--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.7 (2021-09-08)
+## 0.9.7 (2021-09-08) [YANKED]
 ### Added
 - x86 intrinsics support for SHA-512 ([#312])
 

--- a/sha2/src/sha512/x86.rs
+++ b/sha2/src/sha512/x86.rs
@@ -106,8 +106,8 @@ unsafe fn load_data_avx2(
 
     macro_rules! unrolled_iterations {
         ($($i:literal),*) => {$(
-            x[$i] = _mm256_insertf128_si256(x[$i], _mm_loadu_si128(data.add($i) as *const _), 1);
-            x[$i] = _mm256_insertf128_si256(x[$i], _mm_loadu_si128(data.add($i + 1) as *const _), 0);
+            x[$i] = _mm256_insertf128_si256(x[$i], _mm_loadu_si128(data.add(8 + $i) as *const _), 1);
+            x[$i] = _mm256_insertf128_si256(x[$i], _mm_loadu_si128(data.add($i) as *const _), 0);
 
             x[$i] = _mm256_shuffle_epi8(x[$i], MASK);
 

--- a/sha2/tests/lib.rs
+++ b/sha2/tests/lib.rs
@@ -25,6 +25,30 @@ fn sha256_1million_a() {
 }
 
 #[test]
+#[rustfmt::skip]
+fn sha512_avx2_bug() {
+    use sha2::Digest;
+    use hex_literal::hex;
+
+    let msg = hex!("
+        9427a68f37936803ae8209367ae0dfe3dd321f34c411db2649a5483a3aafc5eb
+        ba565496b174447dfcf21e49b9fab42ce056da049c17591dd399226af475a6dc
+        3178a12fc52b7e262652211b00fbe7749ac5012074fd8ad35714949474155d11
+        a7f34d07abd5eaa6ba6937f554cf3cc7728e3af7842739b8040efec89fd9e8d9
+        7db6641c959300b19b87175a06c3193890adfd1af5ec5e69306da9d992e134c7
+        6ae8d4b07e23c6bb0a354ff83eb97df3718ab8adb64e433683b3586ec8efc2af
+        d5b208ff2a65cce1b7c5a305f0a94ed554f3c0d4573d43685e09e26ff4ba3ace
+        93d2ff8d6d1161df5cf71048c08d516b6a9bbf4560a76e83bdc19cb7dbf4f5d6
+    ");
+    let expected = hex!("
+        f0b2ed4c82ec51d517e754eba03afc9b1e044695c44da5256608ad6e96e519b4
+        380deef1ec6b158426f754e0016d8a09e4a8311fa3b28c74f0ac2a48e963fb21
+    ");
+    let res = sha2::Sha512::digest(&msg);
+    assert_eq!(res[..], expected[..]);
+}
+
+#[test]
 fn sha512_1million_a() {
     let output = include_bytes!("data/sha512_one_million_a.bin");
     one_million_a::<sha2::Sha512>(output);

--- a/sha2/tests/lib.rs
+++ b/sha2/tests/lib.rs
@@ -30,19 +30,11 @@ fn sha512_avx2_bug() {
     use sha2::Digest;
     use hex_literal::hex;
 
-    let msg = hex!("
-        9427a68f37936803ae8209367ae0dfe3dd321f34c411db2649a5483a3aafc5eb
-        ba565496b174447dfcf21e49b9fab42ce056da049c17591dd399226af475a6dc
-        3178a12fc52b7e262652211b00fbe7749ac5012074fd8ad35714949474155d11
-        a7f34d07abd5eaa6ba6937f554cf3cc7728e3af7842739b8040efec89fd9e8d9
-        7db6641c959300b19b87175a06c3193890adfd1af5ec5e69306da9d992e134c7
-        6ae8d4b07e23c6bb0a354ff83eb97df3718ab8adb64e433683b3586ec8efc2af
-        d5b208ff2a65cce1b7c5a305f0a94ed554f3c0d4573d43685e09e26ff4ba3ace
-        93d2ff8d6d1161df5cf71048c08d516b6a9bbf4560a76e83bdc19cb7dbf4f5d6
-    ");
+    let mut msg = [0u8; 256];
+    msg[0] = 42;
     let expected = hex!("
-        f0b2ed4c82ec51d517e754eba03afc9b1e044695c44da5256608ad6e96e519b4
-        380deef1ec6b158426f754e0016d8a09e4a8311fa3b28c74f0ac2a48e963fb21
+        2a3e943072f30afa45f2bf57ccd386f29b76dbcdb3a861224ca0b77bc3f55c7a
+        d3880a49c0c9c166eedf7f209c41b380896886155acb8f6c7c07044343a3e692
     ");
     let res = sha2::Sha512::digest(&msg);
     assert_eq!(res[..], expected[..]);


### PR DESCRIPTION
The backend was introduced in #312. The bug was reported in https://github.com/RustCrypto/hashes/pull/313#issuecomment-915666732.

AVX part of the backend works correctly, the issue arises only in the AVX2 part (i.e. when we process two blocks at once). Interestingly enough this bug was not caught by the "1 million a" test for SHA-512, so this bug requires two different blocks. Our tests for SHA-384 and SHA-512 are probably too short for exposing this bug (we need a message of at least 256 bytes for that). 

For now I only added a reproduction test. I will try to fix this bug a bit later.

cc @jplatte @Rexagon