### PR TITLE
Fix sha2-512 avx2

### DIFF
--- a/sha2/src/sha512/x86.rs
+++ b/sha2/src/sha512/x86.rs
@@ -106,8 +106,8 @@ unsafe fn load_data_avx2(
 
     macro_rules! unrolled_iterations {
         ($($i:literal),*) => {$(
-            x[$i] = _mm256_insertf128_si256(x[$i], _mm_loadu_si128(data.add($i) as *const _), 1);
-            x[$i] = _mm256_insertf128_si256(x[$i], _mm_loadu_si128(data.add($i + 1) as *const _), 0);
+            x[$i] = _mm256_insertf128_si256(x[$i], _mm_loadu_si128(data.add(8 + $i) as *const _), 1);
+            x[$i] = _mm256_insertf128_si256(x[$i], _mm_loadu_si128(data.add($i) as *const _), 0);
 
             x[$i] = _mm256_shuffle_epi8(x[$i], MASK);
 


### PR DESCRIPTION
Fixes [#312 (comment)](https://github.com/RustCrypto/hashes/pull/313#issuecomment-915666732)

I am very sorry for that, thought that '1 million a' test is enough( Probably more tests could be added to find bugs like this