### PR TITLE
Release sha2 v0.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "block-buffer",
  "cfg-if",

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.8 (2021-09-09)
+### Fixed
+- Bug in the AVX2 backend ([#314])
+
+[#314]: https://github.com/RustCrypto/hashes/pull/314
+
 ## 0.9.7 (2021-09-08) [YANKED]
 ### Added
 - x86 intrinsics support for SHA-512 ([#312])

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.9.7"
+version = "0.9.8"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.


### PR DESCRIPTION
### Fixed
- Bug in the AVX2 backend ([#314])

[#314]: https://github.com/RustCrypto/hashes/pull/314