### PR TITLE
Sha3 refactor unsafe

### DIFF
--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -62,7 +62,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_root_url = "https://docs.rs/sha3/0.10.0"
 )]
-#![deny(unsafe_code)]
+#![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
 pub use digest::{self, Digest};

--- a/sha3/src/macros.rs
+++ b/sha3/src/macros.rs
@@ -46,10 +46,7 @@ macro_rules! impl_sha3 {
 
                 self.state.absorb_block(block);
 
-                let n = out.len();
-                self.state.as_bytes(|state| {
-                    out.copy_from_slice(&state[..n]);
-                });
+                self.state.as_bytes(out);
             }
         }
 
@@ -183,10 +180,7 @@ macro_rules! impl_shake {
             #[inline]
             fn read_block(&mut self) -> Block<Self> {
                 let mut block = Block::<Self>::default();
-                let n = block.len();
-                self.state.as_bytes(|state| {
-                    block.copy_from_slice(&state[..n]);
-                });
+                self.state.as_bytes(&mut block);
                 self.state.apply_f();
                 block
             }

--- a/sha3/src/state.rs
+++ b/sha3/src/state.rs
@@ -12,22 +12,8 @@ impl Sha3State {
     pub(crate) fn absorb_block(&mut self, block: &[u8]) {
         debug_assert_eq!(block.len() % 8, 0);
 
-        if cfg!(target_endian = "little") {
-            #[allow(unsafe_code)]
-            let state = unsafe { &mut *(self.state.as_mut_ptr() as *mut [u8; 8 * PLEN]) };
-            for (d, i) in state.iter_mut().zip(block) {
-                *d ^= *i;
-            }
-        } else if cfg!(target_endian = "big") {
-            let n = block.len() / 8;
-            let mut buf = [0u64; 21];
-            let buf = &mut buf[..n];
-            for (o, chunk) in buf.iter_mut().zip(block.chunks_exact(8)) {
-                *o = u64::from_le_bytes(chunk.try_into().unwrap());
-            }
-            for (d, i) in self.state[..n].iter_mut().zip(buf) {
-                *d ^= *i;
-            }
+        for (b, s) in block.chunks_exact(8).zip(self.state.iter_mut()) {
+            *s ^= u64::from_le_bytes(b.try_into().unwrap());
         }
 
         keccak::f1600(&mut self.state);

--- a/sha3/src/state.rs
+++ b/sha3/src/state.rs
@@ -34,22 +34,10 @@ impl Sha3State {
     }
 
     #[inline(always)]
-    pub(crate) fn as_bytes<F: FnOnce(&[u8; 8 * PLEN])>(&self, f: F) {
-        let mut data_copy;
-        let data_ref: &[u8; 8 * PLEN] = if cfg!(target_endian = "little") {
-            #[allow(unsafe_code)]
-            unsafe {
-                &*(self.state.as_ptr() as *const [u8; 8 * PLEN])
-            }
-        } else {
-            data_copy = [0u8; 8 * PLEN];
-
-            for (chunk, v) in data_copy.chunks_exact_mut(8).zip(self.state.iter()) {
-                chunk.copy_from_slice(&v.to_le_bytes());
-            }
-            &data_copy
-        };
-        f(data_ref);
+    pub(crate) fn as_bytes(&self, out: &mut [u8]) {
+        for (o, s) in out.chunks_mut(8).zip(self.state.iter()) {
+            o.copy_from_slice(&s.to_le_bytes()[..o.len()]);
+        }
     }
 
     #[inline(always)]


### PR DESCRIPTION
I was looking into the sha3 implementation and would like to propose this PR to avoid the use of unsafe.

While the implementation differentiated between little & big endian, I ended for the little endian path with more or less similar code than it was existing in the big endian path already. Thus, I assume that there is no differentiation needed. Unfortunately, I could only test it on my machine, which is LE.

Performance-wise it does not really change anything, see below first without unsafe as it is now and second as it was before:

850bcc2 sha3: Add forbid(unsafe_code) crate attribute
```
test sha3_224_10    ... bench:          38 ns/iter (+/- 3) = 263 MB/s
test sha3_224_100   ... bench:         370 ns/iter (+/- 19) = 270 MB/s
test sha3_224_1000  ... bench:       3,706 ns/iter (+/- 582) = 269 MB/s
test sha3_224_10000 ... bench:      36,332 ns/iter (+/- 2,908) = 275 MB/s
test sha3_256_10    ... bench:          39 ns/iter (+/- 3) = 256 MB/s
test sha3_256_1000  ... bench:       3,894 ns/iter (+/- 125) = 256 MB/s
test sha3_256_10000 ... bench:      38,367 ns/iter (+/- 4,029) = 260 MB/s
test sha3_265_100   ... bench:         398 ns/iter (+/- 76) = 251 MB/s
test sha3_384_10    ... bench:          52 ns/iter (+/- 31) = 192 MB/s
test sha3_384_100   ... bench:         515 ns/iter (+/- 77) = 194 MB/s
test sha3_384_1000  ... bench:       5,151 ns/iter (+/- 1,037) = 194 MB/s
test sha3_384_10000 ... bench:      50,180 ns/iter (+/- 2,378) = 199 MB/s
test sha3_512_10    ... bench:          74 ns/iter (+/- 4) = 135 MB/s
test sha3_512_100   ... bench:         730 ns/iter (+/- 69) = 136 MB/s
test sha3_512_1000  ... bench:       7,212 ns/iter (+/- 269) = 138 MB/s
test sha3_512_10000 ... bench:      73,020 ns/iter (+/- 8,302) = 136 MB/s
test shake128_10    ... bench:          33 ns/iter (+/- 2) = 303 MB/s
test shake128_100   ... bench:         319 ns/iter (+/- 10) = 313 MB/s
test shake128_1000  ... bench:       3,234 ns/iter (+/- 187) = 309 MB/s
test shake128_10000 ... bench:      32,770 ns/iter (+/- 4,745) = 305 MB/s
test shake256_10    ... bench:          42 ns/iter (+/- 8) = 238 MB/s
test shake256_100   ... bench:         452 ns/iter (+/- 280) = 221 MB/s
test shake256_1000  ... bench:       4,175 ns/iter (+/- 2,144) = 239 MB/s
test shake256_10000 ... bench:      38,911 ns/iter (+/- 4,559) = 256 MB/s
```

894f62f build(deps): bump digest from 0.10.0 to 0.10.1 (#337
```
test sha3_224_10    ... bench:          37 ns/iter (+/- 1) = 270 MB/s       
test sha3_224_100   ... bench:         370 ns/iter (+/- 16) = 270 MB/s
test sha3_224_1000  ... bench:       3,776 ns/iter (+/- 702) = 264 MB/s
test sha3_224_10000 ... bench:      36,316 ns/iter (+/- 2,393) = 275 MB/s     
test sha3_256_10    ... bench:          40 ns/iter (+/- 1) = 250 MB/s
test sha3_256_1000  ... bench:       3,933 ns/iter (+/- 274) = 254 MB/s
test sha3_256_10000 ... bench:      38,828 ns/iter (+/- 4,400) = 257 MB/s
test sha3_265_100   ... bench:         391 ns/iter (+/- 14) = 255 MB/s
test sha3_384_10    ... bench:          52 ns/iter (+/- 2) = 192 MB/s
test sha3_384_100   ... bench:         510 ns/iter (+/- 17) = 196 MB/s                                   
test sha3_384_1000  ... bench:       5,088 ns/iter (+/- 271) = 196 MB/s
test sha3_384_10000 ... bench:      50,486 ns/iter (+/- 3,347) = 198 MB/s                                
test sha3_512_10    ... bench:          73 ns/iter (+/- 1) = 136 MB/s
test sha3_512_100   ... bench:         735 ns/iter (+/- 92) = 136 MB/s
test sha3_512_1000  ... bench:       7,297 ns/iter (+/- 261) = 137 MB/s
test sha3_512_10000 ... bench:      72,539 ns/iter (+/- 2,847) = 137 MB/s
test shake128_10    ... bench:          32 ns/iter (+/- 1) = 312 MB/s
test shake128_100   ... bench:         317 ns/iter (+/- 12) = 315 MB/s
test shake128_1000  ... bench:       3,189 ns/iter (+/- 316) = 313 MB/s                                  
test shake128_10000 ... bench:      31,223 ns/iter (+/- 1,740) = 320 MB/s
test shake256_10    ... bench:          40 ns/iter (+/- 1) = 250 MB/s                                    
test shake256_100   ... bench:         390 ns/iter (+/- 10) = 256 MB/s      
test shake256_1000  ... bench:       3,864 ns/iter (+/- 240) = 258 MB/s    
test shake256_10000 ... bench:      38,826 ns/iter (+/- 2,433) = 257 MB/s
```