### PR TITLE
sha3: Add cross tests

### DIFF
--- a/.github/actions/cross-tests/action.yml
+++ b/.github/actions/cross-tests/action.yml
@@ -1,0 +1,35 @@
+name: "cross-tests"
+
+inputs:
+  rust:
+    required: true
+  package:
+    required: true
+  target:
+    required: true
+  features:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ inputs.rust }}
+          target: ${{ inputs.target }}
+          override: true
+      - name: Install precompiled cross
+        run: |
+          export URL=$(curl -s https://api.github.com/repos/rust-embedded/cross/releases/latest | \
+            jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
+          wget -O /tmp/binaries.tar.gz $URL
+          tar -C /tmp -xzf /tmp/binaries.tar.gz
+          mv /tmp/cross ~/.cargo/bin
+        shell: bash
+      - run: |
+          cd ${{ inputs.package }}
+          cross test --target ${{ inputs.target }} --no-default-features \
+            --features ${{ inputs.features }}
+        shell: bash

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -3,6 +3,7 @@ name: sha1
 on:
   pull_request:
     paths:
+      - ".github/workflows/sha1.yml"
       - "sha1/**"
       - "Cargo.*"
   push:
@@ -13,17 +14,28 @@ defaults:
     working-directory: sha1
 
 env:
-  CARGO_INCREMENTAL: 0
+  MSRV: 1.41.0
   RUSTFLAGS: "-Dwarnings"
+  CARGO_INCREMENTAL: 0
 
 jobs:
+  set-msrv:
+    runs-on: ubuntu-latest
+    outputs:
+      msrv: ${{ steps.msrv.outputs.msrv }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: msrv
+        run: echo "::set-output name=msrv::$(echo $MSRV)"
+
   # Builds for no_std platforms
   build:
+    needs: set-msrv
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - ${{needs.set-msrv.outputs.msrv}}
           - stable
         target:
           - thumbv7em-none-eabi
@@ -40,6 +52,7 @@ jobs:
 
   # Linux tests
   linux:
+    needs: set-msrv
     strategy:
       matrix:
         include:
@@ -47,7 +60,7 @@ jobs:
           # *** NOTE: Currently broken with `asm` feature enabled! See:
           #     https://github.com/RustCrypto/hashes/issues/251
           #- target: i686-unknown-linux-gnu
-          #  rust: 1.41.0 # MSRV
+          #  rust: ${{needs.set-msrv.outputs.msrv}}
           #  deps: sudo apt update && sudo apt install gcc-multilib
           #- target: i686-unknown-linux-gnu
           #  rust: stable
@@ -55,13 +68,13 @@ jobs:
 
           # 64-bit Linux/x86_64
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: ${{needs.set-msrv.outputs.msrv}}
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -76,15 +89,16 @@ jobs:
 
   # macOS tests
   macos:
+    needs: set-msrv
     strategy:
       matrix:
         toolchain:
-          - 1.41.0 # MSRV
+          - ${{needs.set-msrv.outputs.msrv}}
           - stable
 
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -98,19 +112,20 @@ jobs:
 
   # Windows tests
   windows:
+    needs: set-msrv
     strategy:
       matrix:
         include:
           # 64-bit Windows (GNU)
           # TODO(tarcieri): try re-enabling this when we bump MSRV
           #- target: x86_64-pc-windows-gnu
-          #  toolchain: 1.41.0 # MSRV
+          #  toolchain: ${{needs.set-msrv.outputs.msrv}}
           - target: x86_64-pc-windows-gnu
             toolchain: stable
 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -121,28 +136,35 @@ jobs:
       - run: cargo test --target ${{ matrix.target }}
 
   # Cross-compiled tests
-  # *** NOTE: Currently broken with `asm` feature enabled! See:
-  #     https://github.com/RustCrypto/hashes/issues/251
-  #
-  #  cross:
-  #    strategy:
-  #      matrix:
-  #        include:
-  #          # ARM64
-  #          - target: aarch64-unknown-linux-gnu
-  #            rust: 1.41.0 # MSRV
-  #          - target: aarch64-unknown-linux-gnu
-  #            rust: stable
-  #
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #      - uses: actions/checkout@v1
-  #      - uses: actions-rs/toolchain@v1
-  #        with:
-  #          profile: minimal
-  #          toolchain: ${{ matrix.rust }}
-  #          target: ${{ matrix.target }}
-  #          override: true
-  #      - run: cargo install cross
-  #      - run: cross test --target ${{ matrix.target }}
-  #      - run: cross test --target ${{ matrix.target }} --features asm
+  cross:
+    needs: set-msrv
+    strategy:
+      matrix:
+        rust:
+          - ${{needs.set-msrv.outputs.msrv}}
+          - stable
+        target:
+          - aarch64-unknown-linux-gnu
+          - mips-unknown-linux-gnu
+        features:
+          - default
+  # **** NOTE: Currently broken with `asm` feature enabled! See:
+  #      https://github.com/RustCrypto/hashes/issues/251
+  #      include:
+  #          - rust: stable
+  #            target: aarch64-unknown-linux-gnu
+  #            features: asm
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+      # Cross mounts only current package, i.e. by default it ignores workspace's Cargo.toml
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/cross-tests
+        with:
+          rust: ${{ matrix.rust }}
+          package: ${{ github.workflow }}
+          target: ${{ matrix.target }}
+          features: ${{ matrix.features }}

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -3,6 +3,7 @@ name: sha2
 on:
   pull_request:
     paths:
+      - ".github/workflows/sha2.yml"
       - "sha2/**"
       - "Cargo.*"
   push:
@@ -13,23 +14,34 @@ defaults:
     working-directory: sha2
 
 env:
-  CARGO_INCREMENTAL: 0
+  MSRV: 1.41.0
   RUSTFLAGS: "-Dwarnings"
+  CARGO_INCREMENTAL: 0
 
 jobs:
+  set-msrv:
+    runs-on: ubuntu-latest
+    outputs:
+      msrv: ${{ steps.msrv.outputs.msrv }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: msrv
+        run: echo "::set-output name=msrv::$(echo $MSRV)"
+
   # Builds for no_std platforms
   build:
+    needs: set-msrv
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - ${{needs.set-msrv.outputs.msrv}}
           - stable
         target:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -40,12 +52,13 @@ jobs:
 
   # Linux tests
   linux:
+    needs: set-msrv
     strategy:
       matrix:
         include:
           # 32-bit Linux/x86
           - target: i686-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: ${{needs.set-msrv.outputs.msrv}}
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -53,13 +66,13 @@ jobs:
 
           # 64-bit Linux/x86_64
           - target: x86_64-unknown-linux-gnu
-            rust: 1.41.0 # MSRV
+            rust: ${{needs.set-msrv.outputs.msrv}}
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -74,15 +87,16 @@ jobs:
 
   # macOS tests
   macos:
+    needs: set-msrv
     strategy:
       matrix:
         toolchain:
-          - 1.41.0 # MSRV
+          - ${{needs.set-msrv.outputs.msrv}}
           - stable
 
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -95,6 +109,7 @@ jobs:
 
   # Windows tests
   windows:
+    needs: set-msrv
     strategy:
       matrix:
         include:
@@ -107,7 +122,7 @@ jobs:
 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -119,14 +134,21 @@ jobs:
 
   # Cross-compiled tests
   cross:
+    needs: set-msrv
     strategy:
       matrix:
+        rust:
+          - ${{needs.set-msrv.outputs.msrv}}
+          - stable
+        target:
+          - aarch64-unknown-linux-gnu
+          - mips-unknown-linux-gnu
+        features:
+          - default
         include:
-          # ARM64
-          #- target: aarch64-unknown-linux-gnu
-          #  rust: 1.41.0 # MSRV
-          - target: aarch64-unknown-linux-gnu
-            rust: stable
+            - rust: stable
+              target: aarch64-unknown-linux-gnu
+              features: asm
 
     runs-on: ubuntu-latest
     defaults:
@@ -134,18 +156,10 @@ jobs:
       # Cross mounts only current package, i.e. by default it ignores workspace's Cargo.toml
         working-directory: .
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/cross-tests
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
+          rust: ${{ matrix.rust }}
+          package: ${{ github.workflow }}
           target: ${{ matrix.target }}
-          override: true
-      - name: Install precompiled cross
-        run: |
-          export URL=$(curl -s https://api.github.com/repos/rust-embedded/cross/releases/latest | jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
-          wget -O /tmp/binaries.tar.gz $URL
-          tar -C /tmp -xzf /tmp/binaries.tar.gz
-          mv /tmp/cross ~/.cargo/bin
-      - run: cross test --package sha2 --target ${{ matrix.target }}
-      - run: cross test --package sha2 --target ${{ matrix.target }} --features asm
+          features: ${{ matrix.features }}

--- a/.github/workflows/sha3.yml
+++ b/.github/workflows/sha3.yml
@@ -3,6 +3,7 @@ name: sha3
 on:
   pull_request:
     paths:
+      - ".github/workflows/sha3.yml"
       - "sha3/**"
       - "Cargo.*"
   push:
@@ -13,22 +14,33 @@ defaults:
     working-directory: sha3
 
 env:
-  CARGO_INCREMENTAL: 0
+  MSRV: 1.41.0
   RUSTFLAGS: "-Dwarnings"
+  CARGO_INCREMENTAL: 0
 
 jobs:
+  set-msrv:
+    runs-on: ubuntu-latest
+    outputs:
+      msrv: ${{ steps.msrv.outputs.msrv }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: msrv
+        run: echo "::set-output name=msrv::$(echo $MSRV)"
+
   build:
+    needs: set-msrv
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - ${{needs.set-msrv.outputs.msrv}}
           - stable
         target:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -38,14 +50,15 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   test:
+    needs: set-msrv
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - ${{needs.set-msrv.outputs.msrv}}
           - stable
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -55,3 +68,31 @@ jobs:
       - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features
+
+  # Cross-compiled tests
+  cross:
+    needs: set-msrv
+    strategy:
+      matrix:
+        rust:
+          - ${{needs.set-msrv.outputs.msrv}}
+          - stable
+        target:
+          - aarch64-unknown-linux-gnu
+          - mips-unknown-linux-gnu
+        features:
+          - default
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+      # Cross mounts only current package, i.e. by default it ignores workspace's Cargo.toml
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/cross-tests
+        with:
+          rust: ${{ matrix.rust }}
+          package: ${{ github.workflow }}
+          target: ${{ matrix.target }}
+          features: ${{ matrix.features }}


### PR DESCRIPTION
Well, that escalated quickly... Sorry for any noise! 

This PR adds cross-tests to `sha3` crate. It does so by using the composite action named `cross-tests`, which can be found in `.github/actions/cross-tests/action.yml`

Inputs to the `cross-tests` actions are: Rust Version, Package, Target & Features

I adapted the `sha1` & `sha2` crate to use the same composite action to reduce duplicated code (other crates seemed not to use any cross-tests).

Further I changed the place where `MSRV` is defined. It now can be set in the `env` section in the beginning of the `.yml` file at a single place.
Disadvantage: It needs one job run before anything else to distribute it. But that could also be used in the future to create the Strategy Matrix at a single place and distribute it to the jobs. 

Issue came up in https://github.com/RustCrypto/hashes/pull/338