### PR TITLE
blake2: fix reset feature and test in ci

### DIFF
--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -45,14 +45,15 @@ jobs:
           - 1.41.0 # MSRV
           - stable
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.rust }}
-        override: true
-    - run: cargo test --no-default-features
-    - run: cargo test
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: cargo test --no-default-features
+      - run: cargo test
+      - run: cargo test --features reset
   simd:
     runs-on: ubuntu-latest
     steps:

--- a/blake2/CHANGELOG.md
+++ b/blake2/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Blake2b` and `Blake2s` renamed into `Blake2b512` and `Blake2s256` respectively.
   New `Blake2b` and `Blake2s` are generic over output size. `VarBlake2b` and `VarBlake2s`
   renamed into `Blake2bVar` and `Blake2sVar` respectively. ([#217])
+- Hasher reset functionality moved behind a new non-default feature, `reset`.
+  This must be enabled to use the methods `reset`, `finalize_reset` and `finalize_into_reset`.
 
 ### Removed
 - `Blake2b` and `Blake2s` no longer support MAC functionality. ([#217])

--- a/blake2/src/macros.rs
+++ b/blake2/src/macros.rs
@@ -404,7 +404,9 @@ macro_rules! blake2_mac_impl {
                     key_block,
                     ..
                 } = self;
-                core.finalize_variable_core(buffer, out);
+                let mut full_res = Default::default();
+                core.finalize_variable_core(buffer, &mut full_res);
+                out.copy_from_slice(&full_res[..OutSize::USIZE]);
                 core.reset();
                 *buffer = LazyBuffer::new(key_block);
             }


### PR DESCRIPTION
Fixes #341 

For the `blake2` crate:

- add CI for testing the newly introduced `reset` feature
- fix internal macro implementation that caused compilation failure when `reset` feature enabled
- retroactively update changelog to note new `reset` feature in `v0.10.0`