### PR TITLE
Use minimal-versions from RustCrypto/actions

### DIFF
--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -3,6 +3,7 @@ name: blake2
 on:
   pull_request:
     paths:
+      - ".github/workflows/blake2.yml"
       - "blake2/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/fsb.yml
+++ b/.github/workflows/fsb.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/fsb.yml
+++ b/.github/workflows/fsb.yml
@@ -3,6 +3,7 @@ name: fsb
 on:
   pull_request:
     paths:
+      - ".github/workflows/fsb.yml"
       - "fsb/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/gost94.yml
+++ b/.github/workflows/gost94.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/gost94.yml
+++ b/.github/workflows/gost94.yml
@@ -3,6 +3,7 @@ name: gost94
 on:
   pull_request:
     paths:
+      - ".github/workflows/gost94.yml"
       - "gost94/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/groestl.yml
+++ b/.github/workflows/groestl.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/groestl.yml
+++ b/.github/workflows/groestl.yml
@@ -3,6 +3,7 @@ name: groestl
 on:
   pull_request:
     paths:
+      - ".github/workflows/groestl.yml"
       - "groestl/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/k12.yml
+++ b/.github/workflows/k12.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/k12.yml
+++ b/.github/workflows/k12.yml
@@ -3,6 +3,7 @@ name: k12
 on:
   pull_request:
     paths:
+      - ".github/workflows/k12.yml"
       - "k12/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/md2.yml
+++ b/.github/workflows/md2.yml
@@ -3,6 +3,7 @@ name: md2
 on:
   pull_request:
     paths:
+      - ".github/workflows/md2.yml"
       - "md2/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/md2.yml
+++ b/.github/workflows/md2.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/md4.yml
+++ b/.github/workflows/md4.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/md4.yml
+++ b/.github/workflows/md4.yml
@@ -3,6 +3,7 @@ name: md4
 on:
   pull_request:
     paths:
+      - ".github/workflows/md4.yml"
       - "md4/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -3,6 +3,7 @@ name: md5
 on:
   pull_request:
     paths:
+      - ".github/workflows/md5.yml"
       - "md5/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -41,18 +41,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ripemd.yml
+++ b/.github/workflows/ripemd.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ripemd.yml
+++ b/.github/workflows/ripemd.yml
@@ -3,6 +3,7 @@ name: ripemd
 on:
   pull_request:
     paths:
+      - ".github/workflows/ripemd.yml"
       - "ripemd/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -46,18 +46,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   # Linux tests
   linux:

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -46,18 +46,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   # Linux tests
   linux:

--- a/.github/workflows/sha3.yml
+++ b/.github/workflows/sha3.yml
@@ -45,18 +45,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     needs: set-msrv

--- a/.github/workflows/shabal.yml
+++ b/.github/workflows/shabal.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/shabal.yml
+++ b/.github/workflows/shabal.yml
@@ -3,6 +3,7 @@ name: shabal
 on:
   pull_request:
     paths:
+      - ".github/workflows/shabal.yml"
       - "shabal/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/sm3.yml
+++ b/.github/workflows/sm3.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/sm3.yml
+++ b/.github/workflows/sm3.yml
@@ -3,6 +3,7 @@ name: sm3
 on:
   pull_request:
     paths:
+      - ".github/workflows/sm3.yml"
       - "sm3/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/streebog.yml
+++ b/.github/workflows/streebog.yml
@@ -3,6 +3,7 @@ name: streebog
 on:
   pull_request:
     paths:
+      - ".github/workflows/streebog.yml"
       - "streebog/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/streebog.yml
+++ b/.github/workflows/streebog.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tiger.yml
+++ b/.github/workflows/tiger.yml
@@ -3,6 +3,7 @@ name: tiger
 on:
   pull_request:
     paths:
+      - ".github/workflows/tiger.yml"
       - "tiger/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/tiger.yml
+++ b/.github/workflows/tiger.yml
@@ -41,18 +41,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/whirlpool.yml
+++ b/.github/workflows/whirlpool.yml
@@ -3,6 +3,7 @@ name: whirlpool
 on:
   pull_request:
     paths:
+      - ".github/workflows/whirlpool.yml"
       - "whirlpool/**"
       - "Cargo.*"
   push:

--- a/.github/workflows/whirlpool.yml
+++ b/.github/workflows/whirlpool.yml
@@ -38,18 +38,9 @@ jobs:
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   minimal-versions:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-        profile: minimal
-    - run: rm ../Cargo.toml
-    - run: cargo update -Z minimal-versions
-    - run: cargo test --release
-    - run: cargo test --release --all-features
+    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+    with:
+        working-directory: ${{ github.workflow }}
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This uses `minimal-versions` added with https://github.com/RustCrypto/actions/pull/5.

I'll additionally added the workflow path as a trigger to execute the workflow. So changes only within the specific `*.yml's` will as well trigger them to run.