### PR TITLE
blake2: Fix bug on BE machines

### DIFF
--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -72,3 +72,30 @@ jobs:
       - run: cargo test --features simd
       - run: cargo test --features simd_opt
       - run: cargo test --features simd_asm
+
+  # Cross-compiled tests
+  cross:
+    strategy:
+      matrix:
+        rust:
+          - 1.51 # 1.41-1.50 `--features` can't be used inside virtual manifest
+          - stable
+        target:
+          - aarch64-unknown-linux-gnu
+          - mips-unknown-linux-gnu
+        features:
+          - default
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+      # Cross mounts only current package, i.e. by default it ignores workspace's Cargo.toml
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/cross-tests
+        with:
+          rust: ${{ matrix.rust }}
+          package: ${{ github.workflow }}
+          target: ${{ matrix.target }}
+          features: ${{ matrix.features }}

--- a/blake2/src/macros.rs
+++ b/blake2/src/macros.rs
@@ -143,7 +143,7 @@ macro_rules! blake2_impl {
                 let mut m: [$word; 16] = Default::default();
                 let n = core::mem::size_of::<$word>();
                 for (v, chunk) in m.iter_mut().zip(block.chunks_exact(n)) {
-                    *v = $word::from_le_bytes(chunk.try_into().unwrap());
+                    *v = $word::from_ne_bytes(chunk.try_into().unwrap());
                 }
                 let h = &mut self.h;
 


### PR DESCRIPTION
This PR addresses https://github.com/RustCrypto/hashes/issues/356. Additionally, it adds a cross job to the blake2 workflow with a LE & BE machine.