### PR TITLE
Update workspace feature resolver version to 2

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.47.0
+          toolchain: 1.60.0
           components: clippy
           profile: minimal
           override: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "blake2",
     "fsb",

--- a/blake2/src/as_bytes.rs
+++ b/blake2/src/as_bytes.rs
@@ -8,6 +8,7 @@
 use core::mem;
 use core::slice;
 
+#[allow(clippy::missing_safety_doc)]
 pub unsafe trait Safe {}
 
 pub trait AsBytes {

--- a/blake2/src/simd.rs
+++ b/blake2/src/simd.rs
@@ -15,6 +15,7 @@ pub use self::simdty::{u32x4, u64x4};
 pub trait Vector4<T>: Copy {
     fn gather(src: &[T], i0: usize, i1: usize, i2: usize, i3: usize) -> Self;
 
+    #[allow(clippy::wrong_self_convention)]
     fn from_le(self) -> Self;
     fn to_le(self) -> Self;
 

--- a/sha1/src/compress/soft.rs
+++ b/sha1/src/compress/soft.rs
@@ -201,6 +201,7 @@ fn sha1_digest_block_u32(state: &mut [u32; 5], block: &[u32; 16]) {
     let mut w1 = [block[4], block[5], block[6], block[7]];
     let mut w2 = [block[8], block[9], block[10], block[11]];
     let mut w3 = [block[12], block[13], block[14], block[15]];
+    #[allow(clippy::needless_late_init)]
     let mut w4;
 
     let mut h0 = [state[0], state[1], state[2], state[3]];

--- a/sha1/src/compress/x86.rs
+++ b/sha1/src/compress/x86.rs
@@ -52,6 +52,7 @@ unsafe fn digest_blocks(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
         let mut w1 = _mm_shuffle_epi8(_mm_loadu_si128(block_ptr.offset(1)), MASK);
         let mut w2 = _mm_shuffle_epi8(_mm_loadu_si128(block_ptr.offset(2)), MASK);
         let mut w3 = _mm_shuffle_epi8(_mm_loadu_si128(block_ptr.offset(3)), MASK);
+        #[allow(clippy::needless_late_init)]
         let mut w4;
 
         let mut h0 = state_abcd;

--- a/whirlpool/src/lib.rs
+++ b/whirlpool/src/lib.rs
@@ -126,6 +126,8 @@ impl WhirlpoolCore {
     }
 }
 
+// derivable impl does not inline
+#[allow(clippy::derivable_impls)]
 impl Default for WhirlpoolCore {
     #[inline]
     fn default() -> Self {


### PR DESCRIPTION
Version 1 of feature resolver always causes features unification of
build and dev dependencies, which is unwanted in some circumstances.
For example, the `dev` feature of the `digest` crate always depends on
`alloc` which requires to define a global allocator in static libs
even though that is never used by library code.

This might be useful in other repos as well