### PR TITLE
Add GOST 34.311-95 28147-89 UA version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "gost94"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "gost94"
-version = "0.11.0"
+version = "0.10.2"
 dependencies = [
  "digest",
  "hex-literal",

--- a/gost94/CHANGELOG.md
+++ b/gost94/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.0 (2022-05-25)
+### Added
+- Gost 34.311-95 28147-89 UA version 1.2.804.2.1.1.1.1.2.1 OID
+
 ## 0.10.1 (2022-02-17)
 ### Fixed
 - Minimal versions build ([#363])

--- a/gost94/CHANGELOG.md
+++ b/gost94/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (2022-05-25)
+## 0.10.2 (2022-05-25)
 ### Added
 - Gost 34.311-95 28147-89 UA version 1.2.804.2.1.1.1.1.2.1 OID ([#377])
 

--- a/gost94/CHANGELOG.md
+++ b/gost94/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.11.0 (2022-05-25)
 ### Added
-- Gost 34.311-95 28147-89 UA version 1.2.804.2.1.1.1.1.2.1 OID
+- Gost 34.311-95 28147-89 UA version 1.2.804.2.1.1.1.1.2.1 OID ([#377])
+
+[#377]: https://github.com/RustCrypto/hashes/pull/377
 
 ## 0.10.1 (2022-02-17)
 ### Fixed

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gost94"
-version = "0.10.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.11.0" # Also update html_root_url in lib.rs when bumping this
 description = "GOST R 34.11-94 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gost94"
-version = "0.11.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.2" # Also update html_root_url in lib.rs when bumping this
 description = "GOST R 34.11-94 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/gost94/src/lib.rs
+++ b/gost94/src/lib.rs
@@ -28,7 +28,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/gost94/0.11.0"
+    html_root_url = "https://docs.rs/gost94/0.10.2"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]

--- a/gost94/src/lib.rs
+++ b/gost94/src/lib.rs
@@ -28,7 +28,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
-    html_root_url = "https://docs.rs/gost94/0.10.1"
+    html_root_url = "https://docs.rs/gost94/0.11.0"
 )]
 #![warn(missing_docs, rust_2018_idioms)]
 #![forbid(unsafe_code)]
@@ -52,3 +52,6 @@ pub type Gost94CryptoPro = CoreWrapper<Gost94Core<params::CryptoProParam>>;
 pub type Gost94s2015 = CoreWrapper<Gost94Core<params::S2015Param>>;
 /// GOST94 hash function with test parameters.
 pub type Gost94Test = CoreWrapper<Gost94Core<params::TestParam>>;
+/// GOST94 hash function with UAPKI GOST 34.311-95 parameters
+/// (1.2.804.2.1.1.1.1.2.1 OID).
+pub type Gost94UA = CoreWrapper<Gost94Core<params::GOST28147UAParam>>;

--- a/gost94/src/params.rs
+++ b/gost94/src/params.rs
@@ -68,3 +68,22 @@ impl Gost94Params for TestParam {
     const H0: Block = [0; 32];
     const NAME: &'static str = "Gost94Test";
 }
+
+/// S-Box defined in GOST 34.311-95 & GOST 28147:2009.
+#[derive(Copy, Clone, Default)]
+pub struct GOST28147UAParam;
+
+impl Gost94Params for GOST28147UAParam {
+    const S_BOX: SBox = [
+        [10, 9, 13, 6, 14, 11, 4, 5, 15, 1, 3, 12, 7, 0, 8, 2],
+        [8, 0, 12, 4, 9, 6, 7, 11, 2, 3, 1, 15, 5, 14, 10, 13],
+        [15, 6, 5, 8, 14, 11, 10, 4, 12, 0, 3, 7, 2, 9, 1, 13],
+        [3, 8, 13, 9, 6, 11, 15, 0, 2, 5, 12, 10, 4, 14, 1, 7],
+        [15, 8, 14, 9, 7, 2, 0, 13, 12, 6, 1, 5, 11, 4, 3, 10],
+        [2, 8, 9, 7, 5, 15, 0, 11, 12, 1, 13, 14, 10, 3, 6, 4],
+        [3, 8, 11, 5, 6, 4, 14, 10, 2, 12, 1, 7, 9, 15, 13, 0],
+        [1, 2, 3, 14, 6, 13, 11, 8, 15, 10, 12, 5, 7, 9, 0, 4],
+    ];
+    const H0: Block = [0; 32];
+    const NAME: &'static str = "Gost28147UA";
+}

--- a/gost94/tests/mod.rs
+++ b/gost94/tests/mod.rs
@@ -1,6 +1,6 @@
 use digest::dev::{feed_rand_16mib, fixed_reset_test};
 use digest::new_test;
-use gost94::{Digest, Gost94CryptoPro, Gost94Test};
+use gost94::{Digest, Gost94CryptoPro, Gost94Test, Gost94UA};
 use hex_literal::hex;
 
 new_test!(gost94_test_main, "test", Gost94Test, fixed_reset_test);
@@ -80,4 +80,14 @@ fn arithmetic_overflow_regression() {
     let mut h = Gost94Test::default();
     h.update(&include_bytes!("data/arithmetic_overflow.bin")[..]);
     h.finalize().as_slice();
+}
+
+#[test]
+fn gost_ua_engine_tests() {
+    let mut h = Gost94UA::new();
+    h.update(b"test");
+    assert_eq!(
+        h.finalize_reset().as_slice(),
+        hex!("7c536414f8b5b9cc649fdf3cccb2685c1a12622956308e34f31c50ed7b3af56c"),
+    );
 }


### PR DESCRIPTION
Added Ukrainian GOST [34.311-95](https://ru.wikipedia.org/wiki/%D0%93%D0%9E%D0%A1%D0%A2_34.311-95) (OID: `1.2.804.2.1.1.1.1.2.1`) , with SBox defined in GOST [28147:2009](https://ru.wikipedia.org/wiki/%D0%93%D0%9E%D0%A1%D0%A2_28147-89#%D0%A3%D0%B7%D0%B5%D0%BB_%D0%B7%D0%B0%D0%BC%D0%B5%D0%BD%D1%8B_%E2%84%96_1_%D0%B8%D0%B7_%D0%B8%D0%BD%D1%81%D1%82%D1%80%D1%83%D0%BA%D1%86%D0%B8%D0%B8_%E2%84%96_114) which is used for Digital signature [4145-2002](https://ru.wikipedia.org/wiki/%D0%94%D0%A1%D0%A2%D0%A3_4145-2002)