### PR TITLE
sha3 v0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "digest",
  "hex-literal",

--- a/sha3/CHANGELOG.md
+++ b/sha3/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.2 (2022-07-30)
+### Added
+- cSHAKE128 and cSHAKE256 implementations ([#355])
+
+[#355]: https://github.com/RustCrypto/hashes/pull/355
+
 ## 0.10.1 (2022-02-17)
 ### Fixed
 - Minimal versions build ([#363])

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.10.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.10.2" # Also update html_root_url in lib.rs when bumping this
 description = "SHA-3 (Keccak) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- cSHAKE128 and cSHAKE256 implementations ([#355])

[#355]: https://github.com/RustCrypto/hashes/pull/355