### PR TITLE
To use avx2, both avx and avx2 must be checked.

### DIFF
--- a/sha2/src/sha512/x86.rs
+++ b/sha2/src/sha512/x86.rs
@@ -11,13 +11,14 @@ use core::arch::x86_64::*;
 
 use crate::consts::K64;
 
-cpufeatures::new!(avx_cpuid, "avx");
-cpufeatures::new!(avx2_cpuid, "avx2");
+// We need to check availability of both AVX and AVX2, see:
+// https://github.com/RustCrypto/hashes/pull/386
+cpufeatures::new!(avx2_cpuid, "avx", "avx2");
 
 pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
-    if avx_cpuid::get() && avx2_cpuid::get() {
+    if avx2_cpuid::get() {
         unsafe {
             sha512_compress_x86_64_avx2(state, blocks);
         }

--- a/sha2/src/sha512/x86.rs
+++ b/sha2/src/sha512/x86.rs
@@ -11,12 +11,13 @@ use core::arch::x86_64::*;
 
 use crate::consts::K64;
 
+cpufeatures::new!(avx_cpuid, "avx");
 cpufeatures::new!(avx2_cpuid, "avx2");
 
 pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
-    if avx2_cpuid::get() {
+    if avx_cpuid::get() && avx2_cpuid::get() {
         unsafe {
             sha512_compress_x86_64_avx2(state, blocks);
         }


### PR DESCRIPTION
Please see the Intel note about detecting the `avx2` extension:

![image](https://user-images.githubusercontent.com/165497/184846210-97148b99-318f-4491-83ac-a211f7117c53.png)

https://www.intel.com/content/dam/develop/external/us/en/documents/36945

It states that both the support for AVX and AVX2 must be detected.

---

Some context:

I had a bug report that trying to login caused the application (ChirpStack) to panic. After a deep dive, it turned out that the host (Qemu CPU) does not support these instructions, but `avx2_cpuid::get()` returns true.

Then I noticed that the Intel docs state that both `AVX` and `AVX2` must be checked. Running this application on this specific Qemu CPU returns:

```
Supports avx: false
Supports avx2: true
```

```rust
cpufeatures::new!(avx_cpuid, "avx");
cpufeatures::new!(avx2_cpuid, "avx2");

fn main() {
    println!("Supports avx: {}", avx_cpuid::get());
    println!("Supports avx2: {}", avx2_cpuid::get());
}
```

As reference, this is the content of `/proc/cpuinfo`:


```text
processor       : 0
vendor_id       : AuthenticAMD
cpu family      : 6
model           : 13
model name      : QEMU Virtual CPU version (cpu64-rhel6)
stepping        : 3
microcode       : 0x1000065
cpu MHz         : 3393.624
cache size      : 512 KB
physical id     : 0
siblings        : 1
core id         : 0
cpu cores       : 1
apicid          : 0
initial apicid  : 0
fpu             : yes
fpu_exception   : yes
cpuid level     : 4
wp              : yes
flags           : fpu de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 syscall nx lm nopl cpuid tsc_known_freq pni cx16 hypervisor lahf_lm abm sse4a 3dnowprefetch vmmcall
bugs            : fxsave_leak sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass
bogomips        : 6787.24
TLB size        : 1024 4K pages
clflush size    : 64
cache_alignment : 64
address sizes   : 48 bits physical, 48 bits virtual
power management:

processor       : 1
vendor_id       : AuthenticAMD
cpu family      : 6
model           : 13
model name      : QEMU Virtual CPU version (cpu64-rhel6)
stepping        : 3
microcode       : 0x1000065
cpu MHz         : 3393.624
cache size      : 512 KB
physical id     : 1
siblings        : 1
core id         : 0
cpu cores       : 1
apicid          : 1
initial apicid  : 1
fpu             : yes
fpu_exception   : yes
cpuid level     : 4
wp              : yes
flags           : fpu de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 syscall nx lm nopl cpuid tsc_known_freq pni cx16 hypervisor lahf_lm abm sse4a 3dnowprefetch vmmcall
bugs            : fxsave_leak sysret_ss_attrs null_seg spectre_v1 spectre_v2 spec_store_bypass
bogomips        : 6787.24
TLB size        : 1024 4K pages
clflush size    : 64
cache_alignment : 64
address sizes   : 48 bits physical, 48 bits virtual
power management:

```