### PR TITLE
Fix MSRV issues by re-releasing sha1, sha2, sha3, md5, and whirlpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "md-5"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "digest",
  "hex-literal",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "digest",
  "hex-literal",
@@ -291,7 +291,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "whirlpool"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "digest",
  "hex-literal",

--- a/md5/CHANGELOG.md
+++ b/md5/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.3 (2022-09-02)
+### Fixed
+- MSRV issue caused by publishing v0.10.2 using a buggy Nightly toolchain ([#399])
+
+[#399]: https://github.com/RustCrypto/hashes/pull/399
+
 ## 0.10.2 (2022-08-30)
 ### Changed
 - Ignore `asm` feature on unsupported targets ([#388])

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.10.2"
+version = "0.10.3"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.3 (2022-09-02)
+### Fixed
+- MSRV issue caused by publishing v0.10.2 using a buggy Nightly toolchain ([#399])
+
+[#399]: https://github.com/RustCrypto/hashes/pull/399
+
 ## 0.10.2 (2022-08-30)
 ### Changed
 - Ignore `asm` feature on unsupported targets ([#388])

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1"
-version = "0.10.2" # on v0.10.x releases also release the sha-1 crate as well
+version = "0.10.3" # on v0.10.x releases also release the sha-1 crate as well
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.4 (2022-09-02)
+### Fixed
+- MSRV issue caused by publishing v0.10.3 using a buggy Nightly toolchain ([#399])
+
+[#399]: https://github.com/RustCrypto/hashes/pull/399
+
 ## 0.10.3 (2022-08-30)
 ### Changed
 - Ignore `asm` feature on unsupported targets ([#388])

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.10.3"
+version = "0.10.4"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.

--- a/sha3/CHANGELOG.md
+++ b/sha3/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.3 (2022-09-02)
+### Fixed
+- MSRV issue caused by publishing v0.10.2 using a buggy Nightly toolchain ([#399])
+
+[#399]: https://github.com/RustCrypto/hashes/pull/399
+
 ## 0.10.2 (2022-07-30)
 ### Added
 - cSHAKE128 and cSHAKE256 implementations ([#355])

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.10.2"
+version = "0.10.3"
 description = "SHA-3 (Keccak) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/whirlpool/CHANGELOG.md
+++ b/whirlpool/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.3 (2022-09-02)
+### Fixed
+- MSRV issue caused by publishing v0.10.2 using a buggy Nightly toolchain ([#399])
+
+[#399]: https://github.com/RustCrypto/hashes/pull/399
+
 ## 0.10.2 (2022-08-30)
 ### Changed
 - Ignore `asm` feature on unsupported targets ([#388])

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whirlpool"
-version = "0.10.2"
+version = "0.10.3"
 description = "Whirlpool hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Closes #394
Closes #395
Closes #396
Closes #397
Closes #398