### PR TITLE
Fix MSRV issues by re-releasing gost94 and fsb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "fsb"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "digest",
  "hex-literal",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "gost94"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "digest",
  "hex-literal",

--- a/fsb/CHANGELOG.md
+++ b/fsb/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3 (2022-09-03)
+### Fixed
+- MSRV issue caused by `resolver = "2"` ([#402])
+
+[#402]: https://github.com/RustCrypto/hashes/pull/402
+
 ## 0.1.2 (2022-06-16)
 ### Fixed
 - Incorrect computation of hash on some inputs ([#379])

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsb"
-version = "0.1.2"
+version = "0.1.3"
 description = "FSB hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/gost94/CHANGELOG.md
+++ b/gost94/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.3 (2022-09-03)
+### Fixed
+- MSRV issue caused by `resolver = "2"` ([#402])
+
+[#402]: https://github.com/RustCrypto/hashes/pull/402
+
 ## 0.10.2 (2022-05-26)
 ### Added
 - Gost 34.311-95 28147-89 UA version 1.2.804.2.1.1.1.1.2.1 OID ([#377])

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gost94"
-version = "0.10.2"
+version = "0.10.3"
 description = "GOST R 34.11-94 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The crates were not covered by #401, but had the same issue.