### PR TITLE
gost94: add OID support

### DIFF
--- a/.github/workflows/gost94.yml
+++ b/.github/workflows/gost94.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.57.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3
@@ -63,3 +63,21 @@ jobs:
       - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features
+
+  # TODO: merge with test on MSRV bump to 1.57 or higher
+  test-msrv-41:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.41.0 # MSRV
+    steps:
+      - uses: actions/checkout@v3
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: cargo test
+      - run: cargo test --no-default-features

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -15,9 +15,10 @@ categories = ["cryptography", "no-std"]
 digest = "0.10.3"
 
 [dev-dependencies]
-digest = { version = "0.10.3", features = ["dev"] }
+digest = { version = "0.10.4", features = ["dev"] }
 hex-literal = "0.2.2"
 
 [features]
 default = ["std"]
 std = ["digest/std"]
+oid = ["digest/oid"] # Enable OID support. WARNING: Bumps MSRV to 1.57

--- a/gost94/src/lib.rs
+++ b/gost94/src/lib.rs
@@ -21,8 +21,17 @@
 //!
 //! Also see [RustCrypto/hashes][2] readme.
 //!
+//! # Associated OIDs.
+//! There can be a confusion regarding OIDs associated with declared types. According to the
+//! [RFC 4357][3], the OIDs 1.2.643.2.2.30.1 and 1.2.643.2.2.30.0 are used to identify the hash
+//! function parameter sets (CryptoPro vs Test ones). According to [RFC 4490][4] the OID
+//! 1.2.643.2.2.9 identifies the GOST 34.311-95 (former GOST R 34.11-94) function, but then it
+//! continues that this function MUST be used only with the CryptoPro parameter set.
+//!
 //! [1]: https://en.wikipedia.org/wiki/GOST_(hash_function)
 //! [2]: https://github.com/RustCrypto/hashes
+//! [3]: https://www.rfc-editor.org/rfc/rfc4357
+//! [4]: https://www.rfc-editor.org/rfc/rfc4490
 
 #![no_std]
 #![doc(
@@ -35,6 +44,8 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "oid")]
+use digest::const_oid::{AssociatedOid, ObjectIdentifier};
 use digest::core_api::CoreWrapper;
 
 mod gost94_core;
@@ -44,6 +55,17 @@ pub mod params;
 pub use digest::{self, Digest};
 
 pub use gost94_core::Gost94Core;
+
+#[cfg(feature = "oid")]
+impl AssociatedOid for Gost94Core<params::CryptoProParam> {
+    /// Per RFC 4490
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.643.2.2.9");
+}
+
+#[cfg(feature = "oid")]
+impl AssociatedOid for Gost94Core<params::GOST28147UAParam> {
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.804.2.1.1.1.1.2.1");
+}
 
 /// GOST94 hash function with CryptoPro parameters.
 pub type Gost94CryptoPro = CoreWrapper<Gost94Core<params::CryptoProParam>>;

--- a/gost94/src/params.rs
+++ b/gost94/src/params.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "oid")]
+use digest::const_oid::{AssociatedOid, ObjectIdentifier};
+
 pub(crate) type Block = [u8; 32];
 pub(crate) type SBox = [[u8; 16]; 8];
 
@@ -29,6 +32,12 @@ impl Gost94Params for CryptoProParam {
     ];
     const H0: Block = [0; 32];
     const NAME: &'static str = "Gost94CryptoPro";
+}
+
+#[cfg(feature = "oid")]
+impl AssociatedOid for CryptoProParam {
+    /// Per RFC 4357
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.643.2.2.30.1");
 }
 
 /// S-Box defined in GOST R 34.12-2015.
@@ -67,6 +76,12 @@ impl Gost94Params for TestParam {
     ];
     const H0: Block = [0; 32];
     const NAME: &'static str = "Gost94Test";
+}
+
+#[cfg(feature = "oid")]
+impl AssociatedOid for TestParam {
+    /// Per RFC 4357
+    const OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.643.2.2.30.0");
 }
 
 /// S-Box defined in GOST 34.311-95 & GOST 28147:2009.

--- a/gost94/tests/mod.rs
+++ b/gost94/tests/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "oid")]
+use digest::const_oid::{AssociatedOid, ObjectIdentifier};
 use digest::dev::{feed_rand_16mib, fixed_reset_test};
 use digest::new_test;
 use gost94::{Digest, Gost94CryptoPro, Gost94Test, Gost94UA};
@@ -89,5 +91,18 @@ fn gost_ua_engine_tests() {
     assert_eq!(
         h.finalize_reset().as_slice(),
         hex!("7c536414f8b5b9cc649fdf3cccb2685c1a12622956308e34f31c50ed7b3af56c"),
+    );
+}
+
+#[cfg(feature = "oid")]
+#[test]
+fn gost_oid_tests() {
+    assert_eq!(
+        Gost94CryptoPro::OID,
+        ObjectIdentifier::new_unwrap("1.2.643.2.2.9")
+    );
+    assert_eq!(
+        Gost94UA::OID,
+        ObjectIdentifier::new_unwrap("1.2.804.2.1.1.1.1.2.1")
     );
 }


### PR DESCRIPTION
This is an RFC for the 'oid' feature. I do not have example files with the DSTU usage, but hopefully @IvashchenkoSerhii can comment whether `1.2.804.2.1.1.1.1.2.1` is used as a separate digest parameter OID or if it is an OID of the GOST 34.311-95 with the DSTU sBox.

Additional notice. I have added `AssociatedOid` implementation for the individual params, howeve I do not see a way to get such OID given only the upper-level Gost94 type (`CoreWrapper<Gost945Core<Gost94Params>>`). Suggestions would be appreciated.