### PR TITLE
sha3: fix XOF reader type aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "md-5"
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "digest",
  "hex-literal",

--- a/sha3/CHANGELOG.md
+++ b/sha3/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.10.5 (2022-09-16)
+### Fixed
+- XOF reader type aliases ([#427])
+
+[#427]: https://github.com/RustCrypto/hashes/pull/427
+
+## 0.10.5 (2022-09-16)
 ### Added
 - Feature-gated OID support ([#405])
 

--- a/sha3/CHANGELOG.md
+++ b/sha3/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.10.5 (2022-09-16)
+## 0.10.6 (2022-10-19)
 ### Fixed
 - XOF reader type aliases ([#427])
 

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.10.5"
+version = "0.10.6"
 description = "SHA-3 (Keccak) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha3/src/macros.rs
+++ b/sha3/src/macros.rs
@@ -204,7 +204,7 @@ macro_rules! impl_shake {
 
         #[doc = $alg_name]
         #[doc = " reader state."]
-        pub type $reader_full = XofReaderCoreWrapper<$name>;
+        pub type $reader_full = XofReaderCoreWrapper<$reader>;
     };
     (
         $name:ident, $full_name:ident, $reader:ident, $reader_full:ident,
@@ -395,6 +395,6 @@ macro_rules! impl_cshake {
 
         #[doc = $alg_name]
         #[doc = " reader state."]
-        pub type $reader_full = XofReaderCoreWrapper<$name>;
+        pub type $reader_full = XofReaderCoreWrapper<$reader>;
     };
 }

--- a/sha3/tests/aliases.rs
+++ b/sha3/tests/aliases.rs
@@ -1,0 +1,19 @@
+//! Checks that we defined reader type aliases correctly
+#![allow(dead_code)]
+use sha3::digest::ExtendableOutput;
+
+fn shake128(v: sha3::Shake128) -> sha3::Shake128Reader {
+    v.finalize_xof()
+}
+
+fn shake256(v: sha3::Shake256) -> sha3::Shake256Reader {
+    v.finalize_xof()
+}
+
+fn cshake128(v: sha3::CShake128) -> sha3::CShake128Reader {
+    v.finalize_xof()
+}
+
+fn cshake256(v: sha3::CShake256) -> sha3::CShake256Reader {
+    v.finalize_xof()
+}


### PR DESCRIPTION
Closes #426 

The previous type aliases resulted in a compilation error, so I think this change can be considered backwards compatible.