### PR TITLE
blake2: implement KeyInit::new in terms of KeyInit::new_from_slice

### DIFF
--- a/blake2/CHANGELOG.md
+++ b/blake2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNREALEASED
+### Changed
+- Implement `KeyInit::new` in terms of `KeyInit::new_from_slice` ([#435])
+
+[#435]: https://github.com/RustCrypto/hashes/pull/435
+
 ## 0.10.5 (2022-11-11)
 ### Fixed
 - Implementation of the `KeyInit::new` method for MAC types ([#432])

--- a/blake2/src/macros.rs
+++ b/blake2/src/macros.rs
@@ -320,19 +320,12 @@ macro_rules! blake2_mac_impl {
             OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size>,
             LeEq<OutSize, $max_size>: NonZero,
         {
+            #[inline]
             fn new(key: &Key<Self>) -> Self {
-                let kl = key.len();
-                let mut padded_key = Block::<$hash>::default();
-                padded_key[..kl].copy_from_slice(key);
-                Self {
-                    core: <$hash>::new_with_params(&[], &[], key.len(), OutSize::USIZE),
-                    buffer: LazyBuffer::new(&padded_key),
-                    #[cfg(feature = "reset")]
-                    key_block: key.clone(),
-                    _out: PhantomData,
-                }
+                Self::new_from_slice(key).expect("Key has correct length")
             }
 
+            #[inline]
             fn new_from_slice(key: &[u8]) -> Result<Self, InvalidLength> {
                 let kl = key.len();
                 if kl > <Self as KeySizeUser>::KeySize::USIZE {

--- a/blake2/tests/mac.rs
+++ b/blake2/tests/mac.rs
@@ -11,14 +11,14 @@ fn blake2b_new_test() {
     use blake2::digest::{generic_array::GenericArray, KeyInit, Mac};
 
     fn run<T: Mac + KeyInit>(key: &[u8]) {
-        let data = [42; 300];
+        const DATA: &[u8] = &[42; 300];
         let res1 = <T as Mac>::new(GenericArray::from_slice(key))
-            .chain_update(&data)
+            .chain_update(DATA)
             .finalize()
             .into_bytes();
         let res2 = <T as Mac>::new_from_slice(&key)
             .unwrap()
-            .chain_update(&data)
+            .chain_update(DATA)
             .finalize()
             .into_bytes();
         assert_eq!(res1, res2);

--- a/blake2/tests/mac.rs
+++ b/blake2/tests/mac.rs
@@ -5,3 +5,25 @@ use digest::new_resettable_mac_test as new_test;
 
 new_test!(blake2b_mac, "blake2b/mac", blake2::Blake2bMac512);
 new_test!(blake2s_mac, "blake2s/mac", blake2::Blake2sMac256);
+
+#[test]
+fn blake2b_new_test() {
+    use blake2::digest::{generic_array::GenericArray, KeyInit, Mac};
+
+    fn run<T: Mac + KeyInit>(key: &[u8]) {
+        let data = [42; 300];
+        let res1 = <T as Mac>::new(GenericArray::from_slice(key))
+            .chain_update(&data)
+            .finalize()
+            .into_bytes();
+        let res2 = <T as Mac>::new_from_slice(&key)
+            .unwrap()
+            .chain_update(&data)
+            .finalize()
+            .into_bytes();
+        assert_eq!(res1, res2);
+    }
+
+    run::<blake2::Blake2sMac256>(&[0x42; 32]);
+    run::<blake2::Blake2bMac512>(&[0x42; 64]);
+}


### PR DESCRIPTION
Compiler should be able to remove the `expect` branch.

Closes #433