### PR TITLE
blake2: release v0.10.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "blake2"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "digest",
  "hex-literal",
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "md-5"
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "version_check"

--- a/blake2/CHANGELOG.md
+++ b/blake2/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNREALEASED
+## 0.10.6 (2022-12-16)
+### Added
+- `size_opt` Cargo feature ([#440])
+
 ### Changed
 - Implement `KeyInit::new` in terms of `KeyInit::new_from_slice` ([#435])
 
 [#435]: https://github.com/RustCrypto/hashes/pull/435
+[#440]: https://github.com/RustCrypto/hashes/pull/440
 
 ## 0.10.5 (2022-11-11)
 ### Fixed

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.10.5"
+version = "0.10.6"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Added
- `size_opt` Cargo feature ([#440])

### Changed
- Implement `KeyInit::new` in terms of `KeyInit::new_from_slice` ([#435])

[#435]: https://github.com/RustCrypto/hashes/pull/435
[#440]: https://github.com/RustCrypto/hashes/pull/440