### PR TITLE
md5: add inline assembly support for `x86_64` and `x86`

### DIFF
--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -83,3 +83,20 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo test --features oid
+
+  # TODO: merge with test on MSRV bump to 1.59 or higher
+  test-inline-asm:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.59.0 # MSRV
+    steps:
+      - uses: actions/checkout@v3
+      - uses: RustCrypto/actions/cargo-cache@master
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: cargo test --features inline-asm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "asm_block"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "466c0990cf15ef0f331f19fdc16fd60229606ab237476c70a66b747fce2911ab"
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 dependencies = [
@@ -156,6 +162,7 @@ checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 name = "md-5"
 version = "0.10.5"
 dependencies = [
+ "asm_block",
  "digest",
  "hex-literal",
  "md5-asm",

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -19,6 +19,7 @@ digest = "0.10.4"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 md5-asm = { version = "0.5", optional = true }
+asm_block = { version = "0.1.3", optional = true }
 
 [dev-dependencies]
 digest = { version = "0.10.4", features = ["dev"] }
@@ -28,4 +29,5 @@ hex-literal = "0.2.2"
 default = ["std"]
 std = ["digest/std"]
 asm = ["md5-asm"] # WARNING: this feature SHOULD NOT be enabled by library crates
+inline-asm = ["asm_block"] # Enable inline assembly support. WARNING: Bumps MSRV to 1.59
 oid = ["digest/oid"] # Enable OID support. WARNING: Bumps MSRV to 1.57

--- a/md5/README.md
+++ b/md5/README.md
@@ -28,6 +28,8 @@ including HMAC-MD5.
 
 Rust **1.41** or higher.
 
+Enabling feature flag `inline-asm` requires Rust **1.59** or higher.
+
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
 

--- a/md5/src/asm/mod.rs
+++ b/md5/src/asm/mod.rs
@@ -1,0 +1,12 @@
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+mod x86;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub use x86::compress_block;
+
+#[inline]
+pub fn compress(state: &mut [u32; 4], blocks: &[[u8; 64]]) {
+    for block in blocks {
+        compress_block(state, block)
+    }
+}

--- a/md5/src/asm/mod.rs
+++ b/md5/src/asm/mod.rs
@@ -2,11 +2,4 @@
 mod x86;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use x86::compress_block;
-
-#[inline]
-pub fn compress(state: &mut [u32; 4], blocks: &[[u8; 64]]) {
-    for block in blocks {
-        compress_block(state, block)
-    }
-}
+pub use x86::compress;

--- a/md5/src/asm/x86.rs
+++ b/md5/src/asm/x86.rs
@@ -1,0 +1,280 @@
+//! MD5 assembly code for `x86_64` and `x86`. Adapted from Project Nayuki.
+/*
+ * MD5 hash in x86-64 assembly
+ *
+ * Copyright (c) 2016 Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/fast-md5-hash-implementation-in-x86-assembly
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+use core::arch::asm;
+
+use asm_block::asm_block;
+
+/// MD5 operators
+macro_rules! asm_md5_op {
+    (F, $a: tt, $b: tt, $c: tt, $d: tt, $k: tt, $s: literal, $t: literal, $tmp1: tt, $tmp2: tt) => {
+        concat!(
+            asm_block! {
+                mov $tmp1, $c;
+                add $a, $k;
+                xor $tmp1, $d;
+                and $tmp1, $b;
+                xor $tmp1, $d;
+            },
+            asm_md5_op!(END, $a, $b, $s, $t, $tmp1)
+        )
+    };
+    (G, $a: tt, $b: tt, $c: tt, $d: tt, $k: tt, $s: literal, $t: literal, $tmp1: tt, $tmp2: tt) => {
+        concat!(
+            asm_block! {
+                mov $tmp1, $d;
+                mov $tmp2, $d;
+                add $a, $k;
+                not $tmp1;
+                and $tmp2, $b;
+                and $tmp1, $c;
+                or $tmp1, $tmp2;
+            },
+            asm_md5_op!(END, $a, $b, $s, $t, $tmp1)
+        )
+    };
+    (H, $a: tt, $b: tt, $c: tt, $d: tt, $k: tt, $s: literal, $t: literal, $tmp1: tt, $tmp2: tt) => {
+        concat!(
+            asm_block! {
+                mov $tmp1, $c;
+                add $a, $k;
+                xor $tmp1, $d;
+                xor $tmp1, $b;
+            },
+            asm_md5_op!(END, $a, $b, $s, $t, $tmp1)
+        )
+    };
+    (I, $a: tt, $b: tt, $c: tt, $d: tt, $k: tt, $s: literal, $t: literal, $tmp1: tt, $tmp2: tt) => {
+        concat!(
+            asm_block! {
+                mov $tmp1, $d;
+                not $tmp1;
+                add $a, $k;
+                or $tmp1, $b;
+                xor $tmp1, $c;
+            },
+            asm_md5_op!(END, $a, $b, $s, $t, $tmp1)
+        )
+    };
+    (END, $a: tt, $b: tt, $s: literal, $t: literal, $tmp: tt) => {
+        asm_block! {
+            lea $a, [$a + $tmp + $t];
+            rol $a, $s;
+            add $a, $b;
+        }
+    };
+}
+
+/// MD5 rounds, adding back the original value of states is omitted here
+#[rustfmt::skip]
+macro_rules! asm_md5 {
+    (
+        // states
+        $a: tt, $b: tt, $c: tt, $d: tt,
+        // inputs
+        $x0: tt, $x1: tt, $x2: tt, $x3: tt,
+        $x4: tt, $x5: tt, $x6: tt, $x7: tt,
+        $x8: tt, $x9: tt, $xa: tt, $xb: tt,
+        $xc: tt, $xd: tt, $xe: tt, $xf: tt,
+        // clobbers
+        $t1: tt, $t2: tt
+     ) => {
+        concat!(
+            // round 1
+            asm_md5_op!(F, $a, $b, $c, $d, $x0,  7, 0xd76aa478, $t1, $t2),
+            asm_md5_op!(F, $d, $a, $b, $c, $x1, 12, 0xe8c7b756, $t1, $t2),
+            asm_md5_op!(F, $c, $d, $a, $b, $x2, 17, 0x242070db, $t1, $t2),
+            asm_md5_op!(F, $b, $c, $d, $a, $x3, 22, 0xc1bdceee, $t1, $t2),
+   
+            asm_md5_op!(F, $a, $b, $c, $d, $x4,  7, 0xf57c0faf, $t1, $t2),
+            asm_md5_op!(F, $d, $a, $b, $c, $x5, 12, 0x4787c62a, $t1, $t2),
+            asm_md5_op!(F, $c, $d, $a, $b, $x6, 17, 0xa8304613, $t1, $t2),
+            asm_md5_op!(F, $b, $c, $d, $a, $x7, 22, 0xfd469501, $t1, $t2),
+ 
+            asm_md5_op!(F, $a, $b, $c, $d, $x8,  7, 0x698098d8, $t1, $t2),
+            asm_md5_op!(F, $d, $a, $b, $c, $x9, 12, 0x8b44f7af, $t1, $t2),
+            asm_md5_op!(F, $c, $d, $a, $b, $xa, 17, 0xffff5bb1, $t1, $t2),
+            asm_md5_op!(F, $b, $c, $d, $a, $xb, 22, 0x895cd7be, $t1, $t2),
+ 
+            asm_md5_op!(F, $a, $b, $c, $d, $xc,  7, 0x6b901122, $t1, $t2),
+            asm_md5_op!(F, $d, $a, $b, $c, $xd, 12, 0xfd987193, $t1, $t2),
+            asm_md5_op!(F, $c, $d, $a, $b, $xe, 17, 0xa679438e, $t1, $t2),
+            asm_md5_op!(F, $b, $c, $d, $a, $xf, 22, 0x49b40821, $t1, $t2),
+
+            // round 2
+            asm_md5_op!(G, $a, $b, $c, $d, $x1,  5, 0xf61e2562, $t1, $t2),
+            asm_md5_op!(G, $d, $a, $b, $c, $x6,  9, 0xc040b340, $t1, $t2),
+            asm_md5_op!(G, $c, $d, $a, $b, $xb, 14, 0x265e5a51, $t1, $t2),
+            asm_md5_op!(G, $b, $c, $d, $a, $x0, 20, 0xe9b6c7aa, $t1, $t2),
+
+            asm_md5_op!(G, $a, $b, $c, $d, $x5,  5, 0xd62f105d, $t1, $t2),
+            asm_md5_op!(G, $d, $a, $b, $c, $xa,  9, 0x02441453, $t1, $t2),
+            asm_md5_op!(G, $c, $d, $a, $b, $xf, 14, 0xd8a1e681, $t1, $t2),
+            asm_md5_op!(G, $b, $c, $d, $a, $x4, 20, 0xe7d3fbc8, $t1, $t2),
+
+            asm_md5_op!(G, $a, $b, $c, $d, $x9,  5, 0x21e1cde6, $t1, $t2),
+            asm_md5_op!(G, $d, $a, $b, $c, $xe,  9, 0xc33707d6, $t1, $t2),
+            asm_md5_op!(G, $c, $d, $a, $b, $x3, 14, 0xf4d50d87, $t1, $t2),
+            asm_md5_op!(G, $b, $c, $d, $a, $x8, 20, 0x455a14ed, $t1, $t2),
+
+            asm_md5_op!(G, $a, $b, $c, $d, $xd,  5, 0xa9e3e905, $t1, $t2),
+            asm_md5_op!(G, $d, $a, $b, $c, $x2,  9, 0xfcefa3f8, $t1, $t2),
+            asm_md5_op!(G, $c, $d, $a, $b, $x7, 14, 0x676f02d9, $t1, $t2),
+            asm_md5_op!(G, $b, $c, $d, $a, $xc, 20, 0x8d2a4c8a, $t1, $t2),
+
+            // round 3
+            asm_md5_op!(H, $a, $b, $c, $d, $x5,  4, 0xfffa3942, $t1, $t2),
+            asm_md5_op!(H, $d, $a, $b, $c, $x8, 11, 0x8771f681, $t1, $t2),
+            asm_md5_op!(H, $c, $d, $a, $b, $xb, 16, 0x6d9d6122, $t1, $t2),
+            asm_md5_op!(H, $b, $c, $d, $a, $xe, 23, 0xfde5380c, $t1, $t2),
+
+            asm_md5_op!(H, $a, $b, $c, $d, $x1,  4, 0xa4beea44, $t1, $t2),
+            asm_md5_op!(H, $d, $a, $b, $c, $x4, 11, 0x4bdecfa9, $t1, $t2),
+            asm_md5_op!(H, $c, $d, $a, $b, $x7, 16, 0xf6bb4b60, $t1, $t2),
+            asm_md5_op!(H, $b, $c, $d, $a, $xa, 23, 0xbebfbc70, $t1, $t2),
+
+            asm_md5_op!(H, $a, $b, $c, $d, $xd,  4, 0x289b7ec6, $t1, $t2),
+            asm_md5_op!(H, $d, $a, $b, $c, $x0, 11, 0xeaa127fa, $t1, $t2),
+            asm_md5_op!(H, $c, $d, $a, $b, $x3, 16, 0xd4ef3085, $t1, $t2),
+            asm_md5_op!(H, $b, $c, $d, $a, $x6, 23, 0x04881d05, $t1, $t2),
+
+            asm_md5_op!(H, $a, $b, $c, $d, $x9,  4, 0xd9d4d039, $t1, $t2),
+            asm_md5_op!(H, $d, $a, $b, $c, $xc, 11, 0xe6db99e5, $t1, $t2),
+            asm_md5_op!(H, $c, $d, $a, $b, $xf, 16, 0x1fa27cf8, $t1, $t2),
+            asm_md5_op!(H, $b, $c, $d, $a, $x2, 23, 0xc4ac5665, $t1, $t2),
+
+            // round 4
+            asm_md5_op!(I, $a, $b, $c, $d, $x0,  6, 0xf4292244, $t1, $t2),
+            asm_md5_op!(I, $d, $a, $b, $c, $x7, 10, 0x432aff97, $t1, $t2),
+            asm_md5_op!(I, $c, $d, $a, $b, $xe, 15, 0xab9423a7, $t1, $t2),
+            asm_md5_op!(I, $b, $c, $d, $a, $x5, 21, 0xfc93a039, $t1, $t2),
+
+            asm_md5_op!(I, $a, $b, $c, $d, $xc,  6, 0x655b59c3, $t1, $t2),
+            asm_md5_op!(I, $d, $a, $b, $c, $x3, 10, 0x8f0ccc92, $t1, $t2),
+            asm_md5_op!(I, $c, $d, $a, $b, $xa, 15, 0xffeff47d, $t1, $t2),
+            asm_md5_op!(I, $b, $c, $d, $a, $x1, 21, 0x85845dd1, $t1, $t2),
+
+            asm_md5_op!(I, $a, $b, $c, $d, $x8,  6, 0x6fa87e4f, $t1, $t2),
+            asm_md5_op!(I, $d, $a, $b, $c, $xf, 10, 0xfe2ce6e0, $t1, $t2),
+            asm_md5_op!(I, $c, $d, $a, $b, $x6, 15, 0xa3014314, $t1, $t2),
+            asm_md5_op!(I, $b, $c, $d, $a, $xd, 21, 0x4e0811a1, $t1, $t2),
+
+            asm_md5_op!(I, $a, $b, $c, $d, $x4,  6, 0xf7537e82, $t1, $t2),
+            asm_md5_op!(I, $d, $a, $b, $c, $xb, 10, 0xbd3af235, $t1, $t2),
+            asm_md5_op!(I, $c, $d, $a, $b, $x2, 15, 0x2ad7d2bb, $t1, $t2),
+            asm_md5_op!(I, $b, $c, $d, $a, $x9, 21, 0xeb86d391, $t1, $t2),
+        )
+    };
+}
+
+/// MD5 compress function. We don't have enough registers to load the whole block,
+/// so we need to use memory address to refer to the inputs. But there are enough
+/// registers to to house states, block address, and clobbers (7 in total), so we
+/// can use automatical register allocation.
+#[cfg(target_arch = "x86_64")]
+pub fn compress_block(state: &mut [u32; 4], block: &[u8; 64]) {
+    let mut temp_state: [u32; 4] = *state;
+
+    // SAFETY: inline-assembly
+    unsafe {
+        asm!(
+            asm_md5!(
+                // states
+                {a:e}, {b:e}, {c:e}, {d:e},
+                // inputs
+                [{x} +  0], [{x} +  4], [{x} +  8], [{x} + 12],
+                [{x} + 16], [{x} + 20], [{x} + 24], [{x} + 28],
+                [{x} + 32], [{x} + 36], [{x} + 40], [{x} + 44],
+                [{x} + 48], [{x} + 52], [{x} + 56], [{x} + 60],
+                // clobbers
+                {t1:e}, {t2:e}
+            ),
+
+            // states
+            a = inout(reg) temp_state[0],
+            b = inout(reg) temp_state[1],
+            c = inout(reg) temp_state[2],
+            d = inout(reg) temp_state[3],
+            // inputs
+            x = in(reg) block.as_ptr(),
+            // clobbers
+            t1 = out(reg) _,
+            t2 = out(reg) _,
+        );
+    }
+
+    // update states
+    state[0] = state[0].wrapping_add(temp_state[0]);
+    state[1] = state[1].wrapping_add(temp_state[1]);
+    state[2] = state[2].wrapping_add(temp_state[2]);
+    state[3] = state[3].wrapping_add(temp_state[3]);
+}
+
+/// MD5 compress function. We don't have enough registers to load the whole block,
+/// so we need to use memory address to refer to the inputs. Due to possible failure
+/// of register allocation on `x86`, we explicitly specify registers to use.
+#[cfg(target_arch = "x86")]
+pub fn compress_block(state: &mut [u32; 4], block: &[u8; 64]) {
+    let mut temp_state: [u32; 4] = *state;
+
+    // SAFETY: inline-assembly
+    unsafe {
+        asm!(
+            // Save esi and ebp
+            "sub esp, 8",
+            "mov [esp + 0], esi",
+            "mov [esp + 4], ebp",
+
+            asm_md5!(
+                // states
+                eax, ebx, ecx, edx,
+                // inputs
+                [edi +  0], [edi +  4], [edi +  8], [edi + 12],
+                [edi + 16], [edi + 20], [edi + 24], [edi + 28],
+                [edi + 32], [edi + 36], [edi + 40], [edi + 44],
+                [edi + 48], [edi + 52], [edi + 56], [edi + 60],
+                // clobbers
+                esi, ebp
+            ),
+
+            // Restore esi and ebp
+            "mov ebp, [esp + 4]",
+            "mov esi, [esp + 0]",
+            "add esp, 8",
+
+            // states
+            inout("eax") temp_state[0],
+            inout("ebx") temp_state[1],
+            inout("ecx") temp_state[2],
+            inout("edx") temp_state[3],
+            // inputs
+            in("edi") block.as_ptr(),
+        );
+    }
+
+    // update states
+    state[0] = state[0].wrapping_add(temp_state[0]);
+    state[1] = state[1].wrapping_add(temp_state[1]);
+    state[2] = state[2].wrapping_add(temp_state[2]);
+    state[3] = state[3].wrapping_add(temp_state[3]);
+}

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -33,12 +33,31 @@
 #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
 extern crate md5_asm as compress;
 
-#[cfg(not(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"))))]
+#[cfg(all(
+    feature = "inline-asm",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
+mod asm;
+
+#[cfg(not(all(
+    any(feature = "asm", feature = "inline-asm"),
+    any(target_arch = "x86", target_arch = "x86_64")
+)))]
 mod compress;
 
 pub use digest::{self, Digest};
 
+#[cfg(not(all(
+    feature = "inline-asm",
+    any(target_arch = "x86", target_arch = "x86_64")
+)))]
 use compress::compress;
+
+#[cfg(all(
+    feature = "inline-asm",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
+use asm::compress;
 
 use core::{fmt, slice::from_ref};
 #[cfg(feature = "oid")]


### PR DESCRIPTION
This PR implements md5 using inline assembly, which has the benefit of compiling and running on MSVC targets.

This serves as a demo to a path to address #315, https://github.com/RustCrypto/asm-hashes/issues/45, and https://github.com/RustCrypto/asm-hashes/issues/17

## Performance Consideration
In the assembly implementation, a 3-way addition (2 registers + 1 immediate) is implemented as
```asm
lea <dst>, [<dst> + <index> + <displacement>]
```
https://github.com/johnmave126/hashes/blob/40a315dea9d5619e664c3b70749d0af692bca8b8/md5/src/asm/x86.rs#L81

However in Intel processors before Ice Lake, 3-way `LEA` has a latency of 3 cycles and uses only 1 port. (see [here](https://uops.info/html-instr/LEA_B_I_D32_R32.html#CLX)) In contrast, `LEA` has a latency of 1 and can be dispatched in parallel to 2 ports on newer processors.

In older processors, the following is better:
```asm
lea <dst>, [<dst> + <displacement>]
add <dst>, <index>
```

LLVM always emits something similar to the second flavor. Hence inline assembly will perform slower on processors before Ice Lake, but faster afterwards.

On Intel i7-6700K (Skylake), ubuntu-22.04.1:
```sh
> cargo +nightly bench
running 4 tests
test md5_10    ... bench:          15 ns/iter (+/- 2) = 666 MB/s
test md5_100   ... bench:         143 ns/iter (+/- 16) = 699 MB/s
test md5_1000  ... bench:       1,453 ns/iter (+/- 16) = 688 MB/s
test md5_10000 ... bench:      14,162 ns/iter (+/- 27) = 706 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 0.87s
```
```sh
> cargo +nightly bench --features inline-asm
running 4 tests
test md5_10    ... bench:          16 ns/iter (+/- 0) = 625 MB/s
test md5_100   ... bench:         162 ns/iter (+/- 0) = 617 MB/s
test md5_1000  ... bench:       1,661 ns/iter (+/- 2) = 602 MB/s
test md5_10000 ... bench:      16,307 ns/iter (+/- 14) = 613 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 1.16s
```
Using `LEA+ADD` in inline assembly still beats non-asm on older processors, but not by much:
```sh
> cargo +nightly bench --features inline-asm
running 4 tests
test md5_10    ... bench:          14 ns/iter (+/- 0) = 714 MB/s
test md5_100   ... bench:         145 ns/iter (+/- 0) = 689 MB/s
test md5_1000  ... bench:       1,412 ns/iter (+/- 6) = 708 MB/s
test md5_10000 ... bench:      13,787 ns/iter (+/- 16) = 725 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 0.98s
```
---

On AMD Ryzen 9 5900X (Zen 3), Windows 10 22H2:
```sh
> cargo +nightly bench
running 4 tests
test md5_10    ... bench:          13 ns/iter (+/- 0) = 769 MB/s
test md5_100   ... bench:         124 ns/iter (+/- 4) = 806 MB/s
test md5_1000  ... bench:       1,227 ns/iter (+/- 17) = 814 MB/s
test md5_10000 ... bench:      12,255 ns/iter (+/- 136) = 815 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 1.88s
```
```sh
> cargo +nightly bench --features inline-asm
running 4 tests
test md5_10    ... bench:          11 ns/iter (+/- 0) = 909 MB/s
test md5_100   ... bench:         102 ns/iter (+/- 1) = 980 MB/s
test md5_1000  ... bench:       1,023 ns/iter (+/- 10) = 977 MB/s
test md5_10000 ... bench:      10,434 ns/iter (+/- 366) = 958 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out; finished in 6.79s
```

## Dependency
The inline assembly code for md5 comes from a side project by me, which uses a declarative macro crate ([asm_block](https://crates.io/crates/asm_block) also by me) to help defining macros emitting assembly. This introduces an additional dependency. If that's unwanted, we can strip down the `asm_block` macro to minimally viable and embed it directly.

## MSRV
Enabling inline assembly will bump MSRV to **1.59**.

## CI
The PR also includes an additional CI job to test this feature.