### PR TITLE
Add CI `no_std` optional features integration check

### DIFF
--- a/.github/workflows/belt-hash.yml
+++ b/.github/workflows/belt-hash.yml
@@ -59,3 +59,17 @@ jobs:
       - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features
+
+  # Build iterate all no_std feature combos
+  build-nostd-features:
+    name: Build features on no_std target (thumbv7em-none-eabi)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: thumbv7em-none-eabi
+      - uses: taiki-e/install-action@cargo-hack
+      # No default features build
+      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std

--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -96,3 +96,17 @@ jobs:
           package: ${{ github.workflow }}
           target: ${{ matrix.target }}
           features: ${{ matrix.features }}
+
+  # Build iterate all no_std feature combos
+  build-nostd-features:
+    name: Build features on no_std target (thumbv7em-none-eabi)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: thumbv7em-none-eabi
+      - uses: taiki-e/install-action@cargo-hack
+      # No default features build
+      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std

--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -109,4 +109,4 @@ jobs:
           targets: thumbv7em-none-eabi
       - uses: taiki-e/install-action@cargo-hack
       # No default features build
-      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std
+      - run: cargo hack build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std,simd_asm,simd_opt,simd


### PR DESCRIPTION
Tests all `no_std` features with cargo hack in a target that does not have `std` available

Some optional features may break `no_std` integration that may accidentally bring `std`

Mirrors what we are doing for dalek:
- https://github.com/dalek-cryptography/curve25519-dalek/pull/512