### PR TITLE
sha3 v0.10.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "digest",
  "hex-literal",

--- a/sha3/CHANGELOG.md
+++ b/sha3/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.7 (2023-04-11)
+### Added
+- `asm` feature ([#437])
+- TurboSHAKE ([#458])
+
+[#437]: https://github.com/RustCrypto/hashes/pull/437
+[#458]: https://github.com/RustCrypto/hashes/pull/458
+
 ## 0.10.6 (2022-10-19)
 ### Fixed
 - XOF reader type aliases ([#427])

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "sha3"
-version = "0.10.6"
-description = "SHA-3 (Keccak) hash function"
+version = "0.10.7"
+description = """
+Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
+including the SHAKE family of eXtendable-Output Functions (XOFs), as well as
+the accelerated variant TurboSHAKE
+"""
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/sha3/LICENSE-MIT
+++ b/sha3/LICENSE-MIT
@@ -1,7 +1,7 @@
 Copyright (c) 2006-2009 Graydon Hoare
 Copyright (c) 2009-2013 Mozilla Foundation
 Copyright (c) 2014 Sébastien Martini
-Copyright (c) 2016-2017 Artyom Pavlov, Marek Kotewicz
+Copyright (c) 2016-2023 Artyom Pavlov, Marek Kotewicz
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -11,6 +11,8 @@
 //! * `Keccak224`, `Keccak256`, `Keccak384`, `Keccak512` (NIST submission
 //!    without padding changes)
 //!
+//! Additionally supports `TurboSHAKE`.
+//!
 //! # Examples
 //!
 //! Output size of SHA3-256 is fixed, so its functionality is usually


### PR DESCRIPTION
### Added
- `asm` feature ([#437])
- TurboSHAKE ([#458])

[#437]: https://github.com/RustCrypto/hashes/pull/437
[#458]: https://github.com/RustCrypto/hashes/pull/458