### PR TITLE
Fix an off-by-one error in the docs for sha2

### DIFF
--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -6,7 +6,8 @@
 //! Algorithmically, there are only 2 core algorithms: SHA-256 and SHA-512.
 //! All other algorithms are just applications of these with different initial
 //! hash values, and truncated to different digest bit lengths. The first two
-//! algorithms in the list are based on SHA-256, while the last three on SHA-512.
+//! algorithms in the list are based on SHA-256, while the last four are based
+//! on SHA-512.
 //!
 //! # Usage
 //!


### PR DESCRIPTION
👋🏻 Just a little drive-by docs fix!

There are six total, and the docs mentioned "first two" and "last three" = 5.

This appears to have been introduced in 75298d3, and based on the text in this spot that was removed in that commit, this should read "last four" instead.