### PR TITLE
Empty OID crashes the cargo doumentation generation with oid feature

### DIFF
--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -177,7 +177,6 @@ impl_turbo_shake!(
     TurboShake128Reader,
     U168,
     "TurboSHAKE128",
-    "",
 );
 impl_turbo_shake!(
     TurboShake256Core,
@@ -186,7 +185,6 @@ impl_turbo_shake!(
     TurboShake256Reader,
     U136,
     "TurboSHAKE256",
-    "",
 );
 
 impl_cshake!(

--- a/sm3/src/lib.rs
+++ b/sm3/src/lib.rs
@@ -1,4 +1,4 @@
-//! An implementation of the [SM3] cryptographic hash function defined
+//! An implementation of the SM3 cryptographic hash function defined
 //! in OSCCA GM/T 0004-2012.
 //!
 //! # Usage


### PR DESCRIPTION
👋🏻 

While building a project with the `pgp` lib, I could not build the documentation due to failed evaluation of constant value. Such empty OID generations would make `const-oid` panic due to how `ObjectIdentifier::new_unwrap` is made. I don't think this is removing any feature, since it would panic during runtime.

I took the opportunity to fix a rustdoc lint.