### PR TITLE
chore: fix link to `ascon-hash` crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 [//]: # (crates)
 
+[`ascon-hash`]: ./ascon-hash
 [`belt-hash`]: ./belt-hash
 [`blake2`]: ./blake2
 [`fsb`]: ./fsb


### PR DESCRIPTION
The link to the `ascon-hash` crate was broken due to missing a reference. I've added this reference.