### PR TITLE
sha3 v0.10.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "digest",
  "hex-literal",

--- a/sha3/CHANGELOG.md
+++ b/sha3/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.8 (2023-04-08)
+### Fixed
+- Performance regression: now uses `p1600` fn ([#472])
+
+[#472]: https://github.com/RustCrypto/hashes/pull/472
+
 ## 0.10.7 (2023-04-11)
 ### Added
 - `asm` feature ([#437])

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as


### PR DESCRIPTION
### Fixed
- Performance regression: now uses `p1600` fn ([#472])

[#472]: https://github.com/RustCrypto/hashes/pull/472