### PR TITLE
sm3: Improve fn gg2 performance

### DIFF
--- a/sm3/src/compress.rs
+++ b/sm3/src/compress.rs
@@ -19,7 +19,8 @@ fn gg1(x: u32, y: u32, z: u32) -> u32 {
 
 #[inline(always)]
 fn gg2(x: u32, y: u32, z: u32) -> u32 {
-    (x & y) | (!x & z)
+    // (x & y) | (!x & z)
+    (y ^ z) & x ^ z
 }
 
 #[inline(always)]

--- a/sm3/src/compress.rs
+++ b/sm3/src/compress.rs
@@ -19,7 +19,7 @@ fn gg1(x: u32, y: u32, z: u32) -> u32 {
 
 #[inline(always)]
 fn gg2(x: u32, y: u32, z: u32) -> u32 {
-    // (x & y) | (!x & z)
+    // This line is equivalent to `(x & y) | (!x & z)`, but executes faster
     (y ^ z) & x ^ z
 }
 


### PR DESCRIPTION
Before:

```
test sm3_10    ... bench:          26 ns/iter (+/- 0) = 384 MB/s
test sm3_100   ... bench:         254 ns/iter (+/- 7) = 393 MB/s
test sm3_1000  ... bench:       2,471 ns/iter (+/- 41) = 404 MB/s
test sm3_10000 ... bench:      24,372 ns/iter (+/- 589) = 410 MB/s
```

After:

```
test sm3_10    ... bench:          25 ns/iter (+/- 0) = 400 MB/s
test sm3_100   ... bench:         246 ns/iter (+/- 8) = 406 MB/s
test sm3_1000  ... bench:       2,404 ns/iter (+/- 97) = 415 MB/s
test sm3_10000 ... bench:      23,811 ns/iter (+/- 424) = 419 MB/s
```
