### PR TITLE
sha3: Add derive Zeroize for Sha3State

### DIFF
--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -18,6 +18,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 digest = "0.10.4"
 keccak = "0.1.4"
+zeroize = { version = "1.6.0", default-features = false, optional=true } # WARNING: Bumps MSRV to 1.56
 
 [dev-dependencies]
 digest = { version = "0.10.4", features = ["dev"] }

--- a/sha3/src/state.rs
+++ b/sha3/src/state.rs
@@ -1,4 +1,6 @@
 use core::convert::TryInto;
+#[cfg(feature = "zeroize")]
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const PLEN: usize = 25;
 const DEFAULT_ROUND_COUNT: usize = 24;
@@ -17,6 +19,16 @@ impl Default for Sha3State {
         }
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl Drop for Sha3State {
+    fn drop(&mut self) {
+        self.state.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl ZeroizeOnDrop for Sha3State {}
 
 impl Sha3State {
     pub(crate) fn new(round_count: usize) -> Self {


### PR DESCRIPTION
Not zeroizing the Sha3State allows to recover any squeezed output. This is because the `keccak` permutations can be inversed. Hence, access to the complete state allows to perform this operation.

While this is security-relevant, including it would significantly increase the MSRV. Therefore, it is gated behind the `zeroize` feature.

@tarcieri what do you think about gating the zeroizing behind a feature?

The `ascon` implementation would "require" zeroizing as well. As the implementations differ, zeroizing has to be done in the `sponges` crate. Therefore, I would prepare a similar PR for the `sponges` repository targeting `ascon`.