### PR TITLE
sha2: Add aarch64 backends for SHA2.

### DIFF
--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -23,7 +23,7 @@ jobs:
     with:
         # Crate supports MSRV 1.41 without `oid` feature. We test true MSRV
         # in the `test-msrv` job.
-        msrv: 1.57.0
+        msrv: 1.59.0
 
   # Builds for no_std platforms
   build:
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.57
+          - 1.59
           - stable
         target:
           - thumbv7em-none-eabi

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -13,7 +13,7 @@ cfg_if::cfg_if! {
         }
         mod x86;
         use x86::compress;
-    } else if #[cfg(target_arch = "aarch64")] {
+    } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
         mod soft;
         mod aarch64;
         use aarch64::compress;

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -13,7 +13,7 @@ cfg_if::cfg_if! {
         }
         mod x86;
         use x86::compress;
-    } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
+    } else if #[cfg(target_arch = "aarch64")] {
         mod soft;
         mod aarch64;
         use aarch64::compress;

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -112,7 +112,11 @@ unsafe fn vsha256hq_u32(
     hash_abcd: uint32x4_t,
     wk: uint32x4_t,
 ) -> uint32x4_t {
-    asm!("SHA256H {:q}, {:q}, {:v}.4S", inout(vreg) hash_efgh, in(vreg) hash_abcd, in(vreg) wk);
+    asm!(
+        "SHA256H {:q}, {:q}, {:v}.4S",
+        inout(vreg) hash_efgh, in(vreg) hash_abcd, in(vreg) wk,
+        options(pure, nomem, nostack, preserves_flags)
+    );
     hash_efgh
 }
 
@@ -122,13 +126,21 @@ unsafe fn vsha256h2q_u32(
     hash_abcd: uint32x4_t,
     wk: uint32x4_t,
 ) -> uint32x4_t {
-    asm!("SHA256H2 {:q}, {:q}, {:v}.4S", inout(vreg) hash_efgh, in(vreg) hash_abcd, in(vreg) wk);
+    asm!(
+        "SHA256H2 {:q}, {:q}, {:v}.4S",
+        inout(vreg) hash_efgh, in(vreg) hash_abcd, in(vreg) wk,
+        options(pure, nomem, nostack, preserves_flags)
+    );
     hash_efgh
 }
 
 #[inline(always)]
 unsafe fn vsha256su0q_u32(mut w0_3: uint32x4_t, w4_7: uint32x4_t) -> uint32x4_t {
-    asm!("SHA256SU0 {:v}.4S, {:v}.4S", inout(vreg) w0_3, in(vreg) w4_7);
+    asm!(
+        "SHA256SU0 {:v}.4S, {:v}.4S",
+        inout(vreg) w0_3, in(vreg) w4_7,
+        options(pure, nomem, nostack, preserves_flags)
+    );
     w0_3
 }
 
@@ -138,6 +150,10 @@ unsafe fn vsha256su1q_u32(
     w8_11: uint32x4_t,
     w12_15: uint32x4_t,
 ) -> uint32x4_t {
-    asm!("SHA256SU1 {:v}.4S, {:v}.4S, {:v}.4S", inout(vreg) tw0_3, in(vreg) w8_11, in(vreg) w12_15);
+    asm!(
+        "SHA256SU1 {:v}.4S, {:v}.4S, {:v}.4S",
+        inout(vreg) tw0_3, in(vreg) w8_11, in(vreg) w12_15,
+        options(pure, nomem, nostack, preserves_flags)
+    );
     tw0_3
 }

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -1,6 +1,13 @@
 //! SHA-256 `aarch64` backend.
 
+// Implementation adapted from mbedtls.
+
 // TODO: stdarch intrinsics: RustCrypto/hashes#257
+
+use core::arch::aarch64::*;
+use core::arch::asm;
+
+use crate::consts::K32;
 
 cpufeatures::new!(sha2_hwcap, "sha2");
 
@@ -8,8 +15,120 @@ pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if sha2_hwcap::get() {
-        sha2_asm::compress256(state, blocks);
+        for block in blocks {
+            unsafe { sha256_compress(state, block) }
+        }
     } else {
         super::soft::compress(state, blocks);
     }
+}
+
+macro_rules! vsha256hq_u32 {
+    ($hash_efgh:expr, $hash_abcd:expr, $wk:expr) => {{
+        let mut out = $hash_efgh;
+        asm!("SHA256H {:q}, {:q}, {:v}.4S", inout(vreg) out, in(vreg) $hash_abcd, in(vreg) $wk);
+        out
+    }};
+}
+
+macro_rules! vsha256h2q_u32 {
+    ($hash_efgh:expr, $hash_abcd:expr, $wk:expr) => {{
+        let mut out = $hash_efgh;
+        asm!("SHA256H2 {:q}, {:q}, {:v}.4S", inout(vreg) out, in(vreg) $hash_abcd, in(vreg) $wk);
+        out
+    }};
+}
+
+macro_rules! vsha256su0q_u32 {
+    ($w0_3:expr, $w4_7:expr) => {{
+        let mut out = $w0_3;
+        asm!("SHA256SU0 {:v}.4S, {:v}.4S", inout(vreg) out, in(vreg) $w4_7);
+        out
+    }};
+}
+
+macro_rules! vsha256su1q_u32 {
+    ($tw0_3:expr, $w8_11:expr, $w12_15:expr) => {{
+        let mut out = $tw0_3;
+        asm!("SHA256SU1 {:v}.4S, {:v}.4S, {:v}.4S", inout(vreg) out, in(vreg) $w8_11, in(vreg) $w12_15);
+        out
+    }};
+}
+
+unsafe fn sha256_compress(state: &mut [u32; 8], block: &[u8; 64]) {
+    // Load state into vectors.
+    let mut abcd = vld1q_u32(state[0..4].as_ptr());
+    let mut efgh = vld1q_u32(state[4..8].as_ptr());
+
+    // Keep original state values.
+    let abcd_orig = abcd;
+    let efgh_orig = efgh;
+
+    // Load the message block into vectors, assuming little endianness.
+    let mut s0 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[0..16].as_ptr())));
+    let mut s1 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[16..32].as_ptr())));
+    let mut s2 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[32..48].as_ptr())));
+    let mut s3 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[48..64].as_ptr())));
+
+    // Rounds 0 to 3
+    let mut tmp = vaddq_u32(s0, vld1q_u32(&K32[0]));
+    let mut abcd_prev = abcd;
+    abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+    efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+
+    // Rounds 4 to 7
+    tmp = vaddq_u32(s1, vld1q_u32(&K32[4]));
+    abcd_prev = abcd;
+    abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+    efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+
+    // Rounds 8 to 11
+    tmp = vaddq_u32(s2, vld1q_u32(&K32[8]));
+    abcd_prev = abcd;
+    abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+    efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+
+    // Rounds 12 to 15
+    tmp = vaddq_u32(s3, vld1q_u32(&K32[12]));
+    abcd_prev = abcd;
+    abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+    efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+
+    for t in (16..64).step_by(16) {
+        // Rounds t to t + 3
+        s0 = vsha256su1q_u32!(vsha256su0q_u32!(s0, s1), s2, s3);
+        tmp = vaddq_u32(s0, vld1q_u32(&K32[t]));
+        abcd_prev = abcd;
+        abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+        efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+
+        // Rounds t + 4 to t + 7
+        s1 = vsha256su1q_u32!(vsha256su0q_u32!(s1, s2), s3, s0);
+        tmp = vaddq_u32(s1, vld1q_u32(&K32[t + 4]));
+        abcd_prev = abcd;
+        abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+        efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+
+        // Rounds t + 8 to t + 11
+        s2 = vsha256su1q_u32!(vsha256su0q_u32!(s2, s3), s0, s1);
+        tmp = vaddq_u32(s2, vld1q_u32(&K32[t + 8]));
+        abcd_prev = abcd;
+        abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+        efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+
+        // Rounds t + 12 to t + 15
+        s3 = vsha256su1q_u32!(vsha256su0q_u32!(s3, s0), s1, s2);
+        tmp = vaddq_u32(s3, vld1q_u32(&K32[t + 12]));
+        abcd_prev = abcd;
+        abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+        efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+    }
+
+    // Add the block-specific state to the original state.
+    abcd = vaddq_u32(abcd, abcd_orig);
+    efgh = vaddq_u32(efgh, efgh_orig);
+
+    // Store vectors into state.
+    vst1q_u32(state[0..4].as_mut_ptr(), abcd);
+    vst1q_u32(state[4..8].as_mut_ptr(), efgh);
 }

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -53,7 +53,10 @@ macro_rules! vsha256su1q_u32 {
     }};
 }
 
+#[target_feature(enable = "sha2")]
 unsafe fn sha256_compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+    // SAFETY: Requires the sha2 feature.
+
     // Load state into vectors.
     let mut abcd = vld1q_u32(state[0..4].as_ptr());
     let mut efgh = vld1q_u32(state[4..8].as_ptr());

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -15,9 +15,7 @@ pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if sha2_hwcap::get() {
-        for block in blocks {
-            unsafe { sha256_compress(state, block) }
-        }
+        unsafe { sha256_compress(state, blocks) }
     } else {
         super::soft::compress(state, blocks);
     }
@@ -55,78 +53,81 @@ macro_rules! vsha256su1q_u32 {
     }};
 }
 
-unsafe fn sha256_compress(state: &mut [u32; 8], block: &[u8; 64]) {
+unsafe fn sha256_compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     // Load state into vectors.
     let mut abcd = vld1q_u32(state[0..4].as_ptr());
     let mut efgh = vld1q_u32(state[4..8].as_ptr());
 
-    // Keep original state values.
-    let abcd_orig = abcd;
-    let efgh_orig = efgh;
+    // Iterate through the message blocks.
+    for block in blocks {
+        // Keep original state values.
+        let abcd_orig = abcd;
+        let efgh_orig = efgh;
 
-    // Load the message block into vectors, assuming little endianness.
-    let mut s0 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[0..16].as_ptr())));
-    let mut s1 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[16..32].as_ptr())));
-    let mut s2 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[32..48].as_ptr())));
-    let mut s3 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[48..64].as_ptr())));
+        // Load the message block into vectors, assuming little endianness.
+        let mut s0 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[0..16].as_ptr())));
+        let mut s1 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[16..32].as_ptr())));
+        let mut s2 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[32..48].as_ptr())));
+        let mut s3 = vreinterpretq_u32_u8(vrev32q_u8(vld1q_u8(block[48..64].as_ptr())));
 
-    // Rounds 0 to 3
-    let mut tmp = vaddq_u32(s0, vld1q_u32(&K32[0]));
-    let mut abcd_prev = abcd;
-    abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-    efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+        // Rounds 0 to 3
+        let mut tmp = vaddq_u32(s0, vld1q_u32(&K32[0]));
+        let mut abcd_prev = abcd;
+        abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+        efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
 
-    // Rounds 4 to 7
-    tmp = vaddq_u32(s1, vld1q_u32(&K32[4]));
-    abcd_prev = abcd;
-    abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-    efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
-
-    // Rounds 8 to 11
-    tmp = vaddq_u32(s2, vld1q_u32(&K32[8]));
-    abcd_prev = abcd;
-    abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-    efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
-
-    // Rounds 12 to 15
-    tmp = vaddq_u32(s3, vld1q_u32(&K32[12]));
-    abcd_prev = abcd;
-    abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-    efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
-
-    for t in (16..64).step_by(16) {
-        // Rounds t to t + 3
-        s0 = vsha256su1q_u32!(vsha256su0q_u32!(s0, s1), s2, s3);
-        tmp = vaddq_u32(s0, vld1q_u32(&K32[t]));
+        // Rounds 4 to 7
+        tmp = vaddq_u32(s1, vld1q_u32(&K32[4]));
         abcd_prev = abcd;
         abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
         efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
 
-        // Rounds t + 4 to t + 7
-        s1 = vsha256su1q_u32!(vsha256su0q_u32!(s1, s2), s3, s0);
-        tmp = vaddq_u32(s1, vld1q_u32(&K32[t + 4]));
+        // Rounds 8 to 11
+        tmp = vaddq_u32(s2, vld1q_u32(&K32[8]));
         abcd_prev = abcd;
         abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
         efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
 
-        // Rounds t + 8 to t + 11
-        s2 = vsha256su1q_u32!(vsha256su0q_u32!(s2, s3), s0, s1);
-        tmp = vaddq_u32(s2, vld1q_u32(&K32[t + 8]));
+        // Rounds 12 to 15
+        tmp = vaddq_u32(s3, vld1q_u32(&K32[12]));
         abcd_prev = abcd;
         abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
         efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
 
-        // Rounds t + 12 to t + 15
-        s3 = vsha256su1q_u32!(vsha256su0q_u32!(s3, s0), s1, s2);
-        tmp = vaddq_u32(s3, vld1q_u32(&K32[t + 12]));
-        abcd_prev = abcd;
-        abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-        efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+        for t in (16..64).step_by(16) {
+            // Rounds t to t + 3
+            s0 = vsha256su1q_u32!(vsha256su0q_u32!(s0, s1), s2, s3);
+            tmp = vaddq_u32(s0, vld1q_u32(&K32[t]));
+            abcd_prev = abcd;
+            abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+            efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+
+            // Rounds t + 4 to t + 7
+            s1 = vsha256su1q_u32!(vsha256su0q_u32!(s1, s2), s3, s0);
+            tmp = vaddq_u32(s1, vld1q_u32(&K32[t + 4]));
+            abcd_prev = abcd;
+            abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+            efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+
+            // Rounds t + 8 to t + 11
+            s2 = vsha256su1q_u32!(vsha256su0q_u32!(s2, s3), s0, s1);
+            tmp = vaddq_u32(s2, vld1q_u32(&K32[t + 8]));
+            abcd_prev = abcd;
+            abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+            efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+
+            // Rounds t + 12 to t + 15
+            s3 = vsha256su1q_u32!(vsha256su0q_u32!(s3, s0), s1, s2);
+            tmp = vaddq_u32(s3, vld1q_u32(&K32[t + 12]));
+            abcd_prev = abcd;
+            abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
+            efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+        }
+
+        // Add the block-specific state to the original state.
+        abcd = vaddq_u32(abcd, abcd_orig);
+        efgh = vaddq_u32(efgh, efgh_orig);
     }
-
-    // Add the block-specific state to the original state.
-    abcd = vaddq_u32(abcd, abcd_orig);
-    efgh = vaddq_u32(efgh, efgh_orig);
 
     // Store vectors into state.
     vst1q_u32(state[0..4].as_mut_ptr(), abcd);

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -21,38 +21,6 @@ pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     }
 }
 
-macro_rules! vsha256hq_u32 {
-    ($hash_efgh:expr, $hash_abcd:expr, $wk:expr) => {{
-        let mut out = $hash_efgh;
-        asm!("SHA256H {:q}, {:q}, {:v}.4S", inout(vreg) out, in(vreg) $hash_abcd, in(vreg) $wk);
-        out
-    }};
-}
-
-macro_rules! vsha256h2q_u32 {
-    ($hash_efgh:expr, $hash_abcd:expr, $wk:expr) => {{
-        let mut out = $hash_efgh;
-        asm!("SHA256H2 {:q}, {:q}, {:v}.4S", inout(vreg) out, in(vreg) $hash_abcd, in(vreg) $wk);
-        out
-    }};
-}
-
-macro_rules! vsha256su0q_u32 {
-    ($w0_3:expr, $w4_7:expr) => {{
-        let mut out = $w0_3;
-        asm!("SHA256SU0 {:v}.4S, {:v}.4S", inout(vreg) out, in(vreg) $w4_7);
-        out
-    }};
-}
-
-macro_rules! vsha256su1q_u32 {
-    ($tw0_3:expr, $w8_11:expr, $w12_15:expr) => {{
-        let mut out = $tw0_3;
-        asm!("SHA256SU1 {:v}.4S, {:v}.4S, {:v}.4S", inout(vreg) out, in(vreg) $w8_11, in(vreg) $w12_15);
-        out
-    }};
-}
-
 #[target_feature(enable = "sha2")]
 unsafe fn sha256_compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     // SAFETY: Requires the sha2 feature.
@@ -76,55 +44,55 @@ unsafe fn sha256_compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
         // Rounds 0 to 3
         let mut tmp = vaddq_u32(s0, vld1q_u32(&K32[0]));
         let mut abcd_prev = abcd;
-        abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-        efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+        abcd = vsha256hq_u32(abcd_prev, efgh, tmp);
+        efgh = vsha256h2q_u32(efgh, abcd_prev, tmp);
 
         // Rounds 4 to 7
         tmp = vaddq_u32(s1, vld1q_u32(&K32[4]));
         abcd_prev = abcd;
-        abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-        efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+        abcd = vsha256hq_u32(abcd_prev, efgh, tmp);
+        efgh = vsha256h2q_u32(efgh, abcd_prev, tmp);
 
         // Rounds 8 to 11
         tmp = vaddq_u32(s2, vld1q_u32(&K32[8]));
         abcd_prev = abcd;
-        abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-        efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+        abcd = vsha256hq_u32(abcd_prev, efgh, tmp);
+        efgh = vsha256h2q_u32(efgh, abcd_prev, tmp);
 
         // Rounds 12 to 15
         tmp = vaddq_u32(s3, vld1q_u32(&K32[12]));
         abcd_prev = abcd;
-        abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-        efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+        abcd = vsha256hq_u32(abcd_prev, efgh, tmp);
+        efgh = vsha256h2q_u32(efgh, abcd_prev, tmp);
 
         for t in (16..64).step_by(16) {
             // Rounds t to t + 3
-            s0 = vsha256su1q_u32!(vsha256su0q_u32!(s0, s1), s2, s3);
+            s0 = vsha256su1q_u32(vsha256su0q_u32(s0, s1), s2, s3);
             tmp = vaddq_u32(s0, vld1q_u32(&K32[t]));
             abcd_prev = abcd;
-            abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-            efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+            abcd = vsha256hq_u32(abcd_prev, efgh, tmp);
+            efgh = vsha256h2q_u32(efgh, abcd_prev, tmp);
 
             // Rounds t + 4 to t + 7
-            s1 = vsha256su1q_u32!(vsha256su0q_u32!(s1, s2), s3, s0);
+            s1 = vsha256su1q_u32(vsha256su0q_u32(s1, s2), s3, s0);
             tmp = vaddq_u32(s1, vld1q_u32(&K32[t + 4]));
             abcd_prev = abcd;
-            abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-            efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+            abcd = vsha256hq_u32(abcd_prev, efgh, tmp);
+            efgh = vsha256h2q_u32(efgh, abcd_prev, tmp);
 
             // Rounds t + 8 to t + 11
-            s2 = vsha256su1q_u32!(vsha256su0q_u32!(s2, s3), s0, s1);
+            s2 = vsha256su1q_u32(vsha256su0q_u32(s2, s3), s0, s1);
             tmp = vaddq_u32(s2, vld1q_u32(&K32[t + 8]));
             abcd_prev = abcd;
-            abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-            efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+            abcd = vsha256hq_u32(abcd_prev, efgh, tmp);
+            efgh = vsha256h2q_u32(efgh, abcd_prev, tmp);
 
             // Rounds t + 12 to t + 15
-            s3 = vsha256su1q_u32!(vsha256su0q_u32!(s3, s0), s1, s2);
+            s3 = vsha256su1q_u32(vsha256su0q_u32(s3, s0), s1, s2);
             tmp = vaddq_u32(s3, vld1q_u32(&K32[t + 12]));
             abcd_prev = abcd;
-            abcd = vsha256hq_u32!(abcd_prev, efgh, tmp);
-            efgh = vsha256h2q_u32!(efgh, abcd_prev, tmp);
+            abcd = vsha256hq_u32(abcd_prev, efgh, tmp);
+            efgh = vsha256h2q_u32(efgh, abcd_prev, tmp);
         }
 
         // Add the block-specific state to the original state.
@@ -135,4 +103,42 @@ unsafe fn sha256_compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     // Store vectors into state.
     vst1q_u32(state[0..4].as_mut_ptr(), abcd);
     vst1q_u32(state[4..8].as_mut_ptr(), efgh);
+}
+
+// TODO remove these polyfills once SHA2 intrinsics land
+
+#[inline(always)]
+unsafe fn vsha256hq_u32(
+    mut hash_efgh: uint32x4_t,
+    hash_abcd: uint32x4_t,
+    wk: uint32x4_t,
+) -> uint32x4_t {
+    asm!("SHA256H {:q}, {:q}, {:v}.4S", inout(vreg) hash_efgh, in(vreg) hash_abcd, in(vreg) wk);
+    hash_efgh
+}
+
+#[inline(always)]
+unsafe fn vsha256h2q_u32(
+    mut hash_efgh: uint32x4_t,
+    hash_abcd: uint32x4_t,
+    wk: uint32x4_t,
+) -> uint32x4_t {
+    asm!("SHA256H2 {:q}, {:q}, {:v}.4S", inout(vreg) hash_efgh, in(vreg) hash_abcd, in(vreg) wk);
+    hash_efgh
+}
+
+#[inline(always)]
+unsafe fn vsha256su0q_u32(mut w0_3: uint32x4_t, w4_7: uint32x4_t) -> uint32x4_t {
+    asm!("SHA256SU0 {:v}.4S, {:v}.4S", inout(vreg) w0_3, in(vreg) w4_7);
+    w0_3
+}
+
+#[inline(always)]
+unsafe fn vsha256su1q_u32(
+    mut tw0_3: uint32x4_t,
+    w8_11: uint32x4_t,
+    w12_15: uint32x4_t,
+) -> uint32x4_t {
+    asm!("SHA256SU1 {:v}.4S, {:v}.4S, {:v}.4S", inout(vreg) tw0_3, in(vreg) w8_11, in(vreg) w12_15);
+    tw0_3
 }

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -4,8 +4,7 @@
 
 // TODO: stdarch intrinsics: RustCrypto/hashes#257
 
-use core::arch::aarch64::*;
-use core::arch::asm;
+use core::arch::{aarch64::*, asm};
 
 use crate::consts::K32;
 

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -15,7 +15,7 @@ cfg_if::cfg_if! {
         }
         mod x86;
         use x86::compress;
-    } else if #[cfg(target_arch = "aarch64")] {
+    } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
         mod soft;
         mod aarch64;
         use aarch64::compress;

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -15,6 +15,10 @@ cfg_if::cfg_if! {
         }
         mod x86;
         use x86::compress;
+    } else if #[cfg(target_arch = "aarch64")] {
+        mod soft;
+        mod aarch64;
+        use aarch64::compress;
     } else {
         mod soft;
         use soft::compress;

--- a/sha2/src/sha512/aarch64.rs
+++ b/sha2/src/sha512/aarch64.rs
@@ -1,7 +1,6 @@
 // Implementation adapted from mbedtls.
 
-use core::arch::aarch64::*;
-use core::arch::asm;
+use core::arch::{aarch64::*, asm};
 
 use crate::consts::K64;
 

--- a/sha2/src/sha512/aarch64.rs
+++ b/sha2/src/sha512/aarch64.rs
@@ -1,0 +1,210 @@
+// Implementation adapted from mbedtls.
+
+use core::arch::aarch64::*;
+use core::arch::asm;
+
+use crate::consts::K64;
+
+cpufeatures::new!(sha2_hwcap, "sha2");
+
+pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+    // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
+    // after stabilization
+    if sha2_hwcap::get() {
+        for block in blocks {
+            unsafe { sha512_compress(state, block) }
+        }
+    } else {
+        super::soft::compress(state, blocks);
+    }
+}
+
+macro_rules! vsha512hq_u64 {
+    ($hash_ed:expr, $hash_gf:expr, $kwh_kwh2:expr) => {{
+        let mut out = $hash_ed;
+        asm!("SHA512H {:q}, {:q}, {:v}.2D", inout(vreg) out, in(vreg) $hash_gf, in(vreg) $kwh_kwh2);
+        out
+    }};
+}
+
+macro_rules! vsha512h2q_u64 {
+    ($sum_ab:expr, $hash_c_:expr, $hash_ab:expr) => {{
+        let mut out = $sum_ab;
+        asm!("SHA512H2 {:q}, {:q}, {:v}.2D", inout(vreg) out, in(vreg) $hash_c_, in(vreg) $hash_ab);
+        out
+    }};
+}
+
+macro_rules! vsha512su0q_u64 {
+    ($w0_1:expr, $w2_:expr) => {{
+        let mut out = $w0_1;
+        asm!("SHA512SU0 {:v}.2D, {:v}.2D", inout(vreg) out, in(vreg) $w2_);
+        out
+    }};
+}
+
+macro_rules! vsha512su1q_u64 {
+    ($s01_s02:expr, $w14_15:expr, $w9_10:expr) => {{
+        let mut out = $s01_s02;
+        asm!("SHA512SU1 {:v}.2D, {:v}.2D, {:v}.2D", inout(vreg) out, in(vreg) $w14_15, in(vreg) $w9_10);
+        out
+    }};
+}
+
+unsafe fn sha512_compress(state: &mut [u64; 8], block: &[u8; 128]) {
+    // Load state into vectors.
+    let mut ab = vld1q_u64(state[0..2].as_ptr());
+    let mut cd = vld1q_u64(state[2..4].as_ptr());
+    let mut ef = vld1q_u64(state[4..6].as_ptr());
+    let mut gh = vld1q_u64(state[6..8].as_ptr());
+
+    // Keep original state values.
+    let ab_orig = ab;
+    let cd_orig = cd;
+    let ef_orig = ef;
+    let gh_orig = gh;
+
+    // Load the message block into vectors, assuming little endianness.
+    let mut s0 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[0..16].as_ptr())));
+    let mut s1 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[16..32].as_ptr())));
+    let mut s2 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[32..48].as_ptr())));
+    let mut s3 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[48..64].as_ptr())));
+    let mut s4 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[64..80].as_ptr())));
+    let mut s5 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[80..96].as_ptr())));
+    let mut s6 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[96..112].as_ptr())));
+    let mut s7 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[112..128].as_ptr())));
+
+    // Rounds 0 and 1
+    let mut initial_sum = vaddq_u64(s0, vld1q_u64(&K64[0]));
+    let mut sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
+    let mut intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+    gh = vsha512h2q_u64!(intermed, cd, ab);
+    cd = vaddq_u64(cd, intermed);
+
+    // Rounds 2 and 3
+    initial_sum = vaddq_u64(s1, vld1q_u64(&K64[2]));
+    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
+    intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
+    ef = vsha512h2q_u64!(intermed, ab, gh);
+    ab = vaddq_u64(ab, intermed);
+
+    // Rounds 4 and 5
+    initial_sum = vaddq_u64(s2, vld1q_u64(&K64[4]));
+    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
+    intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
+    cd = vsha512h2q_u64!(intermed, gh, ef);
+    gh = vaddq_u64(gh, intermed);
+
+    // Rounds 6 and 7
+    initial_sum = vaddq_u64(s3, vld1q_u64(&K64[6]));
+    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
+    intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
+    ab = vsha512h2q_u64!(intermed, ef, cd);
+    ef = vaddq_u64(ef, intermed);
+
+    // Rounds 8 and 9
+    initial_sum = vaddq_u64(s4, vld1q_u64(&K64[8]));
+    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
+    intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+    gh = vsha512h2q_u64!(intermed, cd, ab);
+    cd = vaddq_u64(cd, intermed);
+
+    // Rounds 10 and 11
+    initial_sum = vaddq_u64(s5, vld1q_u64(&K64[10]));
+    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
+    intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
+    ef = vsha512h2q_u64!(intermed, ab, gh);
+    ab = vaddq_u64(ab, intermed);
+
+    // Rounds 12 and 13
+    initial_sum = vaddq_u64(s6, vld1q_u64(&K64[12]));
+    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
+    intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
+    cd = vsha512h2q_u64!(intermed, gh, ef);
+    gh = vaddq_u64(gh, intermed);
+
+    // Rounds 14 and 15
+    initial_sum = vaddq_u64(s7, vld1q_u64(&K64[14]));
+    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
+    intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
+    ab = vsha512h2q_u64!(intermed, ef, cd);
+    ef = vaddq_u64(ef, intermed);
+
+    for t in (16..80).step_by(16) {
+        // Rounds t and t + 1
+        s0 = vsha512su1q_u64!(vsha512su0q_u64!(s0, s1), s7, vextq_u64(s4, s5, 1));
+        initial_sum = vaddq_u64(s0, vld1q_u64(&K64[t]));
+        sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
+        intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+        gh = vsha512h2q_u64!(intermed, cd, ab);
+        cd = vaddq_u64(cd, intermed);
+
+        // Rounds t + 2 and t + 3
+        s1 = vsha512su1q_u64!(vsha512su0q_u64!(s1, s2), s0, vextq_u64(s5, s6, 1));
+        initial_sum = vaddq_u64(s1, vld1q_u64(&K64[t + 2]));
+        sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
+        intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
+        ef = vsha512h2q_u64!(intermed, ab, gh);
+        ab = vaddq_u64(ab, intermed);
+
+        // Rounds t + 4 and t + 5
+        s2 = vsha512su1q_u64!(vsha512su0q_u64!(s2, s3), s1, vextq_u64(s6, s7, 1));
+        initial_sum = vaddq_u64(s2, vld1q_u64(&K64[t + 4]));
+        sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
+        intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
+        cd = vsha512h2q_u64!(intermed, gh, ef);
+        gh = vaddq_u64(gh, intermed);
+
+        // Rounds t + 6 and t + 7
+        s3 = vsha512su1q_u64!(vsha512su0q_u64!(s3, s4), s2, vextq_u64(s7, s0, 1));
+        initial_sum = vaddq_u64(s3, vld1q_u64(&K64[t + 6]));
+        sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
+        intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
+        ab = vsha512h2q_u64!(intermed, ef, cd);
+        ef = vaddq_u64(ef, intermed);
+
+        // Rounds t + 8 and t + 9
+        s4 = vsha512su1q_u64!(vsha512su0q_u64!(s4, s5), s3, vextq_u64(s0, s1, 1));
+        initial_sum = vaddq_u64(s4, vld1q_u64(&K64[t + 8]));
+        sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
+        intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+        gh = vsha512h2q_u64!(intermed, cd, ab);
+        cd = vaddq_u64(cd, intermed);
+
+        // Rounds t + 10 and t + 11
+        s5 = vsha512su1q_u64!(vsha512su0q_u64!(s5, s6), s4, vextq_u64(s1, s2, 1));
+        initial_sum = vaddq_u64(s5, vld1q_u64(&K64[t + 10]));
+        sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
+        intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
+        ef = vsha512h2q_u64!(intermed, ab, gh);
+        ab = vaddq_u64(ab, intermed);
+
+        // Rounds t + 12 and t + 13
+        s6 = vsha512su1q_u64!(vsha512su0q_u64!(s6, s7), s5, vextq_u64(s2, s3, 1));
+        initial_sum = vaddq_u64(s6, vld1q_u64(&K64[t + 12]));
+        sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
+        intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
+        cd = vsha512h2q_u64!(intermed, gh, ef);
+        gh = vaddq_u64(gh, intermed);
+
+        // Rounds t + 14 and t + 15
+        s7 = vsha512su1q_u64!(vsha512su0q_u64!(s7, s0), s6, vextq_u64(s3, s4, 1));
+        initial_sum = vaddq_u64(s7, vld1q_u64(&K64[t + 14]));
+        sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
+        intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
+        ab = vsha512h2q_u64!(intermed, ef, cd);
+        ef = vaddq_u64(ef, intermed);
+    }
+
+    // Add the block-specific state to the original state.
+    ab = vaddq_u64(ab, ab_orig);
+    cd = vaddq_u64(cd, cd_orig);
+    ef = vaddq_u64(ef, ef_orig);
+    gh = vaddq_u64(gh, gh_orig);
+
+    // Store vectors into state.
+    vst1q_u64(state[0..2].as_mut_ptr(), ab);
+    vst1q_u64(state[2..4].as_mut_ptr(), cd);
+    vst1q_u64(state[4..6].as_mut_ptr(), ef);
+    vst1q_u64(state[6..8].as_mut_ptr(), gh);
+}

--- a/sha2/src/sha512/aarch64.rs
+++ b/sha2/src/sha512/aarch64.rs
@@ -17,38 +17,6 @@ pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
     }
 }
 
-macro_rules! vsha512hq_u64 {
-    ($hash_ed:expr, $hash_gf:expr, $kwh_kwh2:expr) => {{
-        let mut out = $hash_ed;
-        asm!("SHA512H {:q}, {:q}, {:v}.2D", inout(vreg) out, in(vreg) $hash_gf, in(vreg) $kwh_kwh2);
-        out
-    }};
-}
-
-macro_rules! vsha512h2q_u64 {
-    ($sum_ab:expr, $hash_c_:expr, $hash_ab:expr) => {{
-        let mut out = $sum_ab;
-        asm!("SHA512H2 {:q}, {:q}, {:v}.2D", inout(vreg) out, in(vreg) $hash_c_, in(vreg) $hash_ab);
-        out
-    }};
-}
-
-macro_rules! vsha512su0q_u64 {
-    ($w0_1:expr, $w2_:expr) => {{
-        let mut out = $w0_1;
-        asm!("SHA512SU0 {:v}.2D, {:v}.2D", inout(vreg) out, in(vreg) $w2_);
-        out
-    }};
-}
-
-macro_rules! vsha512su1q_u64 {
-    ($s01_s02:expr, $w14_15:expr, $w9_10:expr) => {{
-        let mut out = $s01_s02;
-        asm!("SHA512SU1 {:v}.2D, {:v}.2D, {:v}.2D", inout(vreg) out, in(vreg) $w14_15, in(vreg) $w9_10);
-        out
-    }};
-}
-
 #[target_feature(enable = "sha3")]
 unsafe fn sha512_compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
     // SAFETY: Requires the sha3 feature.
@@ -80,122 +48,122 @@ unsafe fn sha512_compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
         // Rounds 0 and 1
         let mut initial_sum = vaddq_u64(s0, vld1q_u64(&K64[0]));
         let mut sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
-        let mut intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
-        gh = vsha512h2q_u64!(intermed, cd, ab);
+        let mut intermed = vsha512hq_u64(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+        gh = vsha512h2q_u64(intermed, cd, ab);
         cd = vaddq_u64(cd, intermed);
 
         // Rounds 2 and 3
         initial_sum = vaddq_u64(s1, vld1q_u64(&K64[2]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
-        intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
-        ef = vsha512h2q_u64!(intermed, ab, gh);
+        intermed = vsha512hq_u64(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
+        ef = vsha512h2q_u64(intermed, ab, gh);
         ab = vaddq_u64(ab, intermed);
 
         // Rounds 4 and 5
         initial_sum = vaddq_u64(s2, vld1q_u64(&K64[4]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
-        intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
-        cd = vsha512h2q_u64!(intermed, gh, ef);
+        intermed = vsha512hq_u64(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
+        cd = vsha512h2q_u64(intermed, gh, ef);
         gh = vaddq_u64(gh, intermed);
 
         // Rounds 6 and 7
         initial_sum = vaddq_u64(s3, vld1q_u64(&K64[6]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
-        intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
-        ab = vsha512h2q_u64!(intermed, ef, cd);
+        intermed = vsha512hq_u64(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
+        ab = vsha512h2q_u64(intermed, ef, cd);
         ef = vaddq_u64(ef, intermed);
 
         // Rounds 8 and 9
         initial_sum = vaddq_u64(s4, vld1q_u64(&K64[8]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
-        intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
-        gh = vsha512h2q_u64!(intermed, cd, ab);
+        intermed = vsha512hq_u64(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+        gh = vsha512h2q_u64(intermed, cd, ab);
         cd = vaddq_u64(cd, intermed);
 
         // Rounds 10 and 11
         initial_sum = vaddq_u64(s5, vld1q_u64(&K64[10]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
-        intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
-        ef = vsha512h2q_u64!(intermed, ab, gh);
+        intermed = vsha512hq_u64(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
+        ef = vsha512h2q_u64(intermed, ab, gh);
         ab = vaddq_u64(ab, intermed);
 
         // Rounds 12 and 13
         initial_sum = vaddq_u64(s6, vld1q_u64(&K64[12]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
-        intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
-        cd = vsha512h2q_u64!(intermed, gh, ef);
+        intermed = vsha512hq_u64(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
+        cd = vsha512h2q_u64(intermed, gh, ef);
         gh = vaddq_u64(gh, intermed);
 
         // Rounds 14 and 15
         initial_sum = vaddq_u64(s7, vld1q_u64(&K64[14]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
-        intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
-        ab = vsha512h2q_u64!(intermed, ef, cd);
+        intermed = vsha512hq_u64(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
+        ab = vsha512h2q_u64(intermed, ef, cd);
         ef = vaddq_u64(ef, intermed);
 
         for t in (16..80).step_by(16) {
             // Rounds t and t + 1
-            s0 = vsha512su1q_u64!(vsha512su0q_u64!(s0, s1), s7, vextq_u64(s4, s5, 1));
+            s0 = vsha512su1q_u64(vsha512su0q_u64(s0, s1), s7, vextq_u64(s4, s5, 1));
             initial_sum = vaddq_u64(s0, vld1q_u64(&K64[t]));
             sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
-            intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
-            gh = vsha512h2q_u64!(intermed, cd, ab);
+            intermed = vsha512hq_u64(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+            gh = vsha512h2q_u64(intermed, cd, ab);
             cd = vaddq_u64(cd, intermed);
 
             // Rounds t + 2 and t + 3
-            s1 = vsha512su1q_u64!(vsha512su0q_u64!(s1, s2), s0, vextq_u64(s5, s6, 1));
+            s1 = vsha512su1q_u64(vsha512su0q_u64(s1, s2), s0, vextq_u64(s5, s6, 1));
             initial_sum = vaddq_u64(s1, vld1q_u64(&K64[t + 2]));
             sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
-            intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
-            ef = vsha512h2q_u64!(intermed, ab, gh);
+            intermed = vsha512hq_u64(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
+            ef = vsha512h2q_u64(intermed, ab, gh);
             ab = vaddq_u64(ab, intermed);
 
             // Rounds t + 4 and t + 5
-            s2 = vsha512su1q_u64!(vsha512su0q_u64!(s2, s3), s1, vextq_u64(s6, s7, 1));
+            s2 = vsha512su1q_u64(vsha512su0q_u64(s2, s3), s1, vextq_u64(s6, s7, 1));
             initial_sum = vaddq_u64(s2, vld1q_u64(&K64[t + 4]));
             sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
-            intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
-            cd = vsha512h2q_u64!(intermed, gh, ef);
+            intermed = vsha512hq_u64(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
+            cd = vsha512h2q_u64(intermed, gh, ef);
             gh = vaddq_u64(gh, intermed);
 
             // Rounds t + 6 and t + 7
-            s3 = vsha512su1q_u64!(vsha512su0q_u64!(s3, s4), s2, vextq_u64(s7, s0, 1));
+            s3 = vsha512su1q_u64(vsha512su0q_u64(s3, s4), s2, vextq_u64(s7, s0, 1));
             initial_sum = vaddq_u64(s3, vld1q_u64(&K64[t + 6]));
             sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
-            intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
-            ab = vsha512h2q_u64!(intermed, ef, cd);
+            intermed = vsha512hq_u64(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
+            ab = vsha512h2q_u64(intermed, ef, cd);
             ef = vaddq_u64(ef, intermed);
 
             // Rounds t + 8 and t + 9
-            s4 = vsha512su1q_u64!(vsha512su0q_u64!(s4, s5), s3, vextq_u64(s0, s1, 1));
+            s4 = vsha512su1q_u64(vsha512su0q_u64(s4, s5), s3, vextq_u64(s0, s1, 1));
             initial_sum = vaddq_u64(s4, vld1q_u64(&K64[t + 8]));
             sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
-            intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
-            gh = vsha512h2q_u64!(intermed, cd, ab);
+            intermed = vsha512hq_u64(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+            gh = vsha512h2q_u64(intermed, cd, ab);
             cd = vaddq_u64(cd, intermed);
 
             // Rounds t + 10 and t + 11
-            s5 = vsha512su1q_u64!(vsha512su0q_u64!(s5, s6), s4, vextq_u64(s1, s2, 1));
+            s5 = vsha512su1q_u64(vsha512su0q_u64(s5, s6), s4, vextq_u64(s1, s2, 1));
             initial_sum = vaddq_u64(s5, vld1q_u64(&K64[t + 10]));
             sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
-            intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
-            ef = vsha512h2q_u64!(intermed, ab, gh);
+            intermed = vsha512hq_u64(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
+            ef = vsha512h2q_u64(intermed, ab, gh);
             ab = vaddq_u64(ab, intermed);
 
             // Rounds t + 12 and t + 13
-            s6 = vsha512su1q_u64!(vsha512su0q_u64!(s6, s7), s5, vextq_u64(s2, s3, 1));
+            s6 = vsha512su1q_u64(vsha512su0q_u64(s6, s7), s5, vextq_u64(s2, s3, 1));
             initial_sum = vaddq_u64(s6, vld1q_u64(&K64[t + 12]));
             sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
-            intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
-            cd = vsha512h2q_u64!(intermed, gh, ef);
+            intermed = vsha512hq_u64(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
+            cd = vsha512h2q_u64(intermed, gh, ef);
             gh = vaddq_u64(gh, intermed);
 
             // Rounds t + 14 and t + 15
-            s7 = vsha512su1q_u64!(vsha512su0q_u64!(s7, s0), s6, vextq_u64(s3, s4, 1));
+            s7 = vsha512su1q_u64(vsha512su0q_u64(s7, s0), s6, vextq_u64(s3, s4, 1));
             initial_sum = vaddq_u64(s7, vld1q_u64(&K64[t + 14]));
             sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
-            intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
-            ab = vsha512h2q_u64!(intermed, ef, cd);
+            intermed = vsha512hq_u64(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
+            ab = vsha512h2q_u64(intermed, ef, cd);
             ef = vaddq_u64(ef, intermed);
         }
 
@@ -211,4 +179,42 @@ unsafe fn sha512_compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
     vst1q_u64(state[2..4].as_mut_ptr(), cd);
     vst1q_u64(state[4..6].as_mut_ptr(), ef);
     vst1q_u64(state[6..8].as_mut_ptr(), gh);
+}
+
+// TODO remove these polyfills once SHA3 intrinsics land
+
+#[inline(always)]
+unsafe fn vsha512hq_u64(
+    mut hash_ed: uint64x2_t,
+    hash_gf: uint64x2_t,
+    kwh_kwh2: uint64x2_t,
+) -> uint64x2_t {
+    asm!("SHA512H {:q}, {:q}, {:v}.2D", inout(vreg) hash_ed, in(vreg) hash_gf, in(vreg) kwh_kwh2);
+    hash_ed
+}
+
+#[inline(always)]
+unsafe fn vsha512h2q_u64(
+    mut sum_ab: uint64x2_t,
+    hash_c_: uint64x2_t,
+    hash_ab: uint64x2_t,
+) -> uint64x2_t {
+    asm!("SHA512H2 {:q}, {:q}, {:v}.2D", inout(vreg) sum_ab, in(vreg) hash_c_, in(vreg) hash_ab);
+    sum_ab
+}
+
+#[inline(always)]
+unsafe fn vsha512su0q_u64(mut w0_1: uint64x2_t, w2_: uint64x2_t) -> uint64x2_t {
+    asm!("SHA512SU0 {:v}.2D, {:v}.2D", inout(vreg) w0_1, in(vreg) w2_);
+    w0_1
+}
+
+#[inline(always)]
+unsafe fn vsha512su1q_u64(
+    mut s01_s02: uint64x2_t,
+    w14_15: uint64x2_t,
+    w9_10: uint64x2_t,
+) -> uint64x2_t {
+    asm!("SHA512SU1 {:v}.2D, {:v}.2D, {:v}.2D", inout(vreg) s01_s02, in(vreg) w14_15, in(vreg) w9_10);
+    s01_s02
 }

--- a/sha2/src/sha512/aarch64.rs
+++ b/sha2/src/sha512/aarch64.rs
@@ -5,12 +5,12 @@ use core::arch::asm;
 
 use crate::consts::K64;
 
-cpufeatures::new!(sha2_hwcap, "sha2");
+cpufeatures::new!(sha3_hwcap, "sha3");
 
 pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
-    if sha2_hwcap::get() {
+    if sha3_hwcap::get() {
         unsafe { sha512_compress(state, blocks) }
     } else {
         super::soft::compress(state, blocks);
@@ -49,7 +49,10 @@ macro_rules! vsha512su1q_u64 {
     }};
 }
 
+#[target_feature(enable = "sha3")]
 unsafe fn sha512_compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+    // SAFETY: Requires the sha3 feature.
+
     // Load state into vectors.
     let mut ab = vld1q_u64(state[0..2].as_ptr());
     let mut cd = vld1q_u64(state[2..4].as_ptr());

--- a/sha2/src/sha512/aarch64.rs
+++ b/sha2/src/sha512/aarch64.rs
@@ -11,9 +11,7 @@ pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if sha2_hwcap::get() {
-        for block in blocks {
-            unsafe { sha512_compress(state, block) }
-        }
+        unsafe { sha512_compress(state, blocks) }
     } else {
         super::soft::compress(state, blocks);
     }
@@ -51,156 +49,159 @@ macro_rules! vsha512su1q_u64 {
     }};
 }
 
-unsafe fn sha512_compress(state: &mut [u64; 8], block: &[u8; 128]) {
+unsafe fn sha512_compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
     // Load state into vectors.
     let mut ab = vld1q_u64(state[0..2].as_ptr());
     let mut cd = vld1q_u64(state[2..4].as_ptr());
     let mut ef = vld1q_u64(state[4..6].as_ptr());
     let mut gh = vld1q_u64(state[6..8].as_ptr());
 
-    // Keep original state values.
-    let ab_orig = ab;
-    let cd_orig = cd;
-    let ef_orig = ef;
-    let gh_orig = gh;
+    // Iterate through the message blocks.
+    for block in blocks {
+        // Keep original state values.
+        let ab_orig = ab;
+        let cd_orig = cd;
+        let ef_orig = ef;
+        let gh_orig = gh;
 
-    // Load the message block into vectors, assuming little endianness.
-    let mut s0 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[0..16].as_ptr())));
-    let mut s1 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[16..32].as_ptr())));
-    let mut s2 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[32..48].as_ptr())));
-    let mut s3 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[48..64].as_ptr())));
-    let mut s4 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[64..80].as_ptr())));
-    let mut s5 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[80..96].as_ptr())));
-    let mut s6 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[96..112].as_ptr())));
-    let mut s7 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[112..128].as_ptr())));
+        // Load the message block into vectors, assuming little endianness.
+        let mut s0 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[0..16].as_ptr())));
+        let mut s1 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[16..32].as_ptr())));
+        let mut s2 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[32..48].as_ptr())));
+        let mut s3 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[48..64].as_ptr())));
+        let mut s4 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[64..80].as_ptr())));
+        let mut s5 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[80..96].as_ptr())));
+        let mut s6 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[96..112].as_ptr())));
+        let mut s7 = vreinterpretq_u64_u8(vrev64q_u8(vld1q_u8(block[112..128].as_ptr())));
 
-    // Rounds 0 and 1
-    let mut initial_sum = vaddq_u64(s0, vld1q_u64(&K64[0]));
-    let mut sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
-    let mut intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
-    gh = vsha512h2q_u64!(intermed, cd, ab);
-    cd = vaddq_u64(cd, intermed);
-
-    // Rounds 2 and 3
-    initial_sum = vaddq_u64(s1, vld1q_u64(&K64[2]));
-    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
-    intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
-    ef = vsha512h2q_u64!(intermed, ab, gh);
-    ab = vaddq_u64(ab, intermed);
-
-    // Rounds 4 and 5
-    initial_sum = vaddq_u64(s2, vld1q_u64(&K64[4]));
-    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
-    intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
-    cd = vsha512h2q_u64!(intermed, gh, ef);
-    gh = vaddq_u64(gh, intermed);
-
-    // Rounds 6 and 7
-    initial_sum = vaddq_u64(s3, vld1q_u64(&K64[6]));
-    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
-    intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
-    ab = vsha512h2q_u64!(intermed, ef, cd);
-    ef = vaddq_u64(ef, intermed);
-
-    // Rounds 8 and 9
-    initial_sum = vaddq_u64(s4, vld1q_u64(&K64[8]));
-    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
-    intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
-    gh = vsha512h2q_u64!(intermed, cd, ab);
-    cd = vaddq_u64(cd, intermed);
-
-    // Rounds 10 and 11
-    initial_sum = vaddq_u64(s5, vld1q_u64(&K64[10]));
-    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
-    intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
-    ef = vsha512h2q_u64!(intermed, ab, gh);
-    ab = vaddq_u64(ab, intermed);
-
-    // Rounds 12 and 13
-    initial_sum = vaddq_u64(s6, vld1q_u64(&K64[12]));
-    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
-    intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
-    cd = vsha512h2q_u64!(intermed, gh, ef);
-    gh = vaddq_u64(gh, intermed);
-
-    // Rounds 14 and 15
-    initial_sum = vaddq_u64(s7, vld1q_u64(&K64[14]));
-    sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
-    intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
-    ab = vsha512h2q_u64!(intermed, ef, cd);
-    ef = vaddq_u64(ef, intermed);
-
-    for t in (16..80).step_by(16) {
-        // Rounds t and t + 1
-        s0 = vsha512su1q_u64!(vsha512su0q_u64!(s0, s1), s7, vextq_u64(s4, s5, 1));
-        initial_sum = vaddq_u64(s0, vld1q_u64(&K64[t]));
-        sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
-        intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+        // Rounds 0 and 1
+        let mut initial_sum = vaddq_u64(s0, vld1q_u64(&K64[0]));
+        let mut sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
+        let mut intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
         gh = vsha512h2q_u64!(intermed, cd, ab);
         cd = vaddq_u64(cd, intermed);
 
-        // Rounds t + 2 and t + 3
-        s1 = vsha512su1q_u64!(vsha512su0q_u64!(s1, s2), s0, vextq_u64(s5, s6, 1));
-        initial_sum = vaddq_u64(s1, vld1q_u64(&K64[t + 2]));
+        // Rounds 2 and 3
+        initial_sum = vaddq_u64(s1, vld1q_u64(&K64[2]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
         intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
         ef = vsha512h2q_u64!(intermed, ab, gh);
         ab = vaddq_u64(ab, intermed);
 
-        // Rounds t + 4 and t + 5
-        s2 = vsha512su1q_u64!(vsha512su0q_u64!(s2, s3), s1, vextq_u64(s6, s7, 1));
-        initial_sum = vaddq_u64(s2, vld1q_u64(&K64[t + 4]));
+        // Rounds 4 and 5
+        initial_sum = vaddq_u64(s2, vld1q_u64(&K64[4]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
         intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
         cd = vsha512h2q_u64!(intermed, gh, ef);
         gh = vaddq_u64(gh, intermed);
 
-        // Rounds t + 6 and t + 7
-        s3 = vsha512su1q_u64!(vsha512su0q_u64!(s3, s4), s2, vextq_u64(s7, s0, 1));
-        initial_sum = vaddq_u64(s3, vld1q_u64(&K64[t + 6]));
+        // Rounds 6 and 7
+        initial_sum = vaddq_u64(s3, vld1q_u64(&K64[6]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
         intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
         ab = vsha512h2q_u64!(intermed, ef, cd);
         ef = vaddq_u64(ef, intermed);
 
-        // Rounds t + 8 and t + 9
-        s4 = vsha512su1q_u64!(vsha512su0q_u64!(s4, s5), s3, vextq_u64(s0, s1, 1));
-        initial_sum = vaddq_u64(s4, vld1q_u64(&K64[t + 8]));
+        // Rounds 8 and 9
+        initial_sum = vaddq_u64(s4, vld1q_u64(&K64[8]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
         intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
         gh = vsha512h2q_u64!(intermed, cd, ab);
         cd = vaddq_u64(cd, intermed);
 
-        // Rounds t + 10 and t + 11
-        s5 = vsha512su1q_u64!(vsha512su0q_u64!(s5, s6), s4, vextq_u64(s1, s2, 1));
-        initial_sum = vaddq_u64(s5, vld1q_u64(&K64[t + 10]));
+        // Rounds 10 and 11
+        initial_sum = vaddq_u64(s5, vld1q_u64(&K64[10]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
         intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
         ef = vsha512h2q_u64!(intermed, ab, gh);
         ab = vaddq_u64(ab, intermed);
 
-        // Rounds t + 12 and t + 13
-        s6 = vsha512su1q_u64!(vsha512su0q_u64!(s6, s7), s5, vextq_u64(s2, s3, 1));
-        initial_sum = vaddq_u64(s6, vld1q_u64(&K64[t + 12]));
+        // Rounds 12 and 13
+        initial_sum = vaddq_u64(s6, vld1q_u64(&K64[12]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
         intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
         cd = vsha512h2q_u64!(intermed, gh, ef);
         gh = vaddq_u64(gh, intermed);
 
-        // Rounds t + 14 and t + 15
-        s7 = vsha512su1q_u64!(vsha512su0q_u64!(s7, s0), s6, vextq_u64(s3, s4, 1));
-        initial_sum = vaddq_u64(s7, vld1q_u64(&K64[t + 14]));
+        // Rounds 14 and 15
+        initial_sum = vaddq_u64(s7, vld1q_u64(&K64[14]));
         sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
         intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
         ab = vsha512h2q_u64!(intermed, ef, cd);
         ef = vaddq_u64(ef, intermed);
+
+        for t in (16..80).step_by(16) {
+            // Rounds t and t + 1
+            s0 = vsha512su1q_u64!(vsha512su0q_u64!(s0, s1), s7, vextq_u64(s4, s5, 1));
+            initial_sum = vaddq_u64(s0, vld1q_u64(&K64[t]));
+            sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
+            intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+            gh = vsha512h2q_u64!(intermed, cd, ab);
+            cd = vaddq_u64(cd, intermed);
+
+            // Rounds t + 2 and t + 3
+            s1 = vsha512su1q_u64!(vsha512su0q_u64!(s1, s2), s0, vextq_u64(s5, s6, 1));
+            initial_sum = vaddq_u64(s1, vld1q_u64(&K64[t + 2]));
+            sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
+            intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
+            ef = vsha512h2q_u64!(intermed, ab, gh);
+            ab = vaddq_u64(ab, intermed);
+
+            // Rounds t + 4 and t + 5
+            s2 = vsha512su1q_u64!(vsha512su0q_u64!(s2, s3), s1, vextq_u64(s6, s7, 1));
+            initial_sum = vaddq_u64(s2, vld1q_u64(&K64[t + 4]));
+            sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
+            intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
+            cd = vsha512h2q_u64!(intermed, gh, ef);
+            gh = vaddq_u64(gh, intermed);
+
+            // Rounds t + 6 and t + 7
+            s3 = vsha512su1q_u64!(vsha512su0q_u64!(s3, s4), s2, vextq_u64(s7, s0, 1));
+            initial_sum = vaddq_u64(s3, vld1q_u64(&K64[t + 6]));
+            sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
+            intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
+            ab = vsha512h2q_u64!(intermed, ef, cd);
+            ef = vaddq_u64(ef, intermed);
+
+            // Rounds t + 8 and t + 9
+            s4 = vsha512su1q_u64!(vsha512su0q_u64!(s4, s5), s3, vextq_u64(s0, s1, 1));
+            initial_sum = vaddq_u64(s4, vld1q_u64(&K64[t + 8]));
+            sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), gh);
+            intermed = vsha512hq_u64!(sum, vextq_u64(ef, gh, 1), vextq_u64(cd, ef, 1));
+            gh = vsha512h2q_u64!(intermed, cd, ab);
+            cd = vaddq_u64(cd, intermed);
+
+            // Rounds t + 10 and t + 11
+            s5 = vsha512su1q_u64!(vsha512su0q_u64!(s5, s6), s4, vextq_u64(s1, s2, 1));
+            initial_sum = vaddq_u64(s5, vld1q_u64(&K64[t + 10]));
+            sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ef);
+            intermed = vsha512hq_u64!(sum, vextq_u64(cd, ef, 1), vextq_u64(ab, cd, 1));
+            ef = vsha512h2q_u64!(intermed, ab, gh);
+            ab = vaddq_u64(ab, intermed);
+
+            // Rounds t + 12 and t + 13
+            s6 = vsha512su1q_u64!(vsha512su0q_u64!(s6, s7), s5, vextq_u64(s2, s3, 1));
+            initial_sum = vaddq_u64(s6, vld1q_u64(&K64[t + 12]));
+            sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), cd);
+            intermed = vsha512hq_u64!(sum, vextq_u64(ab, cd, 1), vextq_u64(gh, ab, 1));
+            cd = vsha512h2q_u64!(intermed, gh, ef);
+            gh = vaddq_u64(gh, intermed);
+
+            // Rounds t + 14 and t + 15
+            s7 = vsha512su1q_u64!(vsha512su0q_u64!(s7, s0), s6, vextq_u64(s3, s4, 1));
+            initial_sum = vaddq_u64(s7, vld1q_u64(&K64[t + 14]));
+            sum = vaddq_u64(vextq_u64(initial_sum, initial_sum, 1), ab);
+            intermed = vsha512hq_u64!(sum, vextq_u64(gh, ab, 1), vextq_u64(ef, gh, 1));
+            ab = vsha512h2q_u64!(intermed, ef, cd);
+            ef = vaddq_u64(ef, intermed);
+        }
+
+        // Add the block-specific state to the original state.
+        ab = vaddq_u64(ab, ab_orig);
+        cd = vaddq_u64(cd, cd_orig);
+        ef = vaddq_u64(ef, ef_orig);
+        gh = vaddq_u64(gh, gh_orig);
     }
-
-    // Add the block-specific state to the original state.
-    ab = vaddq_u64(ab, ab_orig);
-    cd = vaddq_u64(cd, cd_orig);
-    ef = vaddq_u64(ef, ef_orig);
-    gh = vaddq_u64(gh, gh_orig);
 
     // Store vectors into state.
     vst1q_u64(state[0..2].as_mut_ptr(), ab);

--- a/sha2/src/sha512/aarch64.rs
+++ b/sha2/src/sha512/aarch64.rs
@@ -188,7 +188,11 @@ unsafe fn vsha512hq_u64(
     hash_gf: uint64x2_t,
     kwh_kwh2: uint64x2_t,
 ) -> uint64x2_t {
-    asm!("SHA512H {:q}, {:q}, {:v}.2D", inout(vreg) hash_ed, in(vreg) hash_gf, in(vreg) kwh_kwh2);
+    asm!(
+        "SHA512H {:q}, {:q}, {:v}.2D",
+        inout(vreg) hash_ed, in(vreg) hash_gf, in(vreg) kwh_kwh2,
+        options(pure, nomem, nostack, preserves_flags)
+    );
     hash_ed
 }
 
@@ -198,13 +202,21 @@ unsafe fn vsha512h2q_u64(
     hash_c_: uint64x2_t,
     hash_ab: uint64x2_t,
 ) -> uint64x2_t {
-    asm!("SHA512H2 {:q}, {:q}, {:v}.2D", inout(vreg) sum_ab, in(vreg) hash_c_, in(vreg) hash_ab);
+    asm!(
+        "SHA512H2 {:q}, {:q}, {:v}.2D",
+        inout(vreg) sum_ab, in(vreg) hash_c_, in(vreg) hash_ab,
+        options(pure, nomem, nostack, preserves_flags)
+    );
     sum_ab
 }
 
 #[inline(always)]
 unsafe fn vsha512su0q_u64(mut w0_1: uint64x2_t, w2_: uint64x2_t) -> uint64x2_t {
-    asm!("SHA512SU0 {:v}.2D, {:v}.2D", inout(vreg) w0_1, in(vreg) w2_);
+    asm!(
+        "SHA512SU0 {:v}.2D, {:v}.2D",
+        inout(vreg) w0_1, in(vreg) w2_,
+        options(pure, nomem, nostack, preserves_flags)
+    );
     w0_1
 }
 
@@ -214,6 +226,10 @@ unsafe fn vsha512su1q_u64(
     w14_15: uint64x2_t,
     w9_10: uint64x2_t,
 ) -> uint64x2_t {
-    asm!("SHA512SU1 {:v}.2D, {:v}.2D, {:v}.2D", inout(vreg) s01_s02, in(vreg) w14_15, in(vreg) w9_10);
+    asm!(
+        "SHA512SU1 {:v}.2D, {:v}.2D, {:v}.2D",
+        inout(vreg) s01_s02, in(vreg) w14_15, in(vreg) w9_10,
+        options(pure, nomem, nostack, preserves_flags)
+    );
     s01_s02
 }


### PR DESCRIPTION
Adds NEON-enabled backends for SHA2 on `aarch64`.

Eliminates the need for the `asm` feature on `aarch64` for SHA-{224, 256} performance and provides a big performance boost for SHA-512, which didn’t benefit from the `asm` feature.

Before:

```
test sha256_10    ... bench:          27 ns/iter (+/- 0) = 370 MB/s
test sha256_100   ... bench:         278 ns/iter (+/- 3) = 359 MB/s
test sha256_1000  ... bench:       2,747 ns/iter (+/- 24) = 364 MB/s
test sha256_10000 ... bench:      27,392 ns/iter (+/- 293) = 365 MB/s
test sha512_10    ... bench:          17 ns/iter (+/- 0) = 588 MB/s
test sha512_100   ... bench:         164 ns/iter (+/- 7) = 609 MB/s
test sha512_1000  ... bench:       1,650 ns/iter (+/- 28) = 606 MB/s
test sha512_10000 ... bench:      16,533 ns/iter (+/- 1,540) = 604 MB/s
```

After:

```
test sha256_10    ... bench:           4 ns/iter (+/- 0) = 2500 MB/s
test sha256_100   ... bench:          46 ns/iter (+/- 0) = 2173 MB/s
test sha256_1000  ... bench:         424 ns/iter (+/- 6) = 2358 MB/s
test sha256_10000 ... bench:       4,190 ns/iter (+/- 31) = 2386 MB/s
test sha512_10    ... bench:           6 ns/iter (+/- 0) = 1666 MB/s
test sha512_100   ... bench:          65 ns/iter (+/- 0) = 1538 MB/s
test sha512_1000  ... bench:         636 ns/iter (+/- 5) = 1572 MB/s
test sha512_10000 ... bench:       6,311 ns/iter (+/- 68) = 1584 MB/s
```

(Benchmarks run on my M2 Air laptop, unplugged, on my kitchen table.)