### PR TITLE
CI: replace MIPS cross tests with PPC32

### DIFF
--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -88,7 +88,7 @@ jobs:
           - stable
         target:
           - aarch64-unknown-linux-gnu
-          - mips-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
         features:
           - default
 

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -141,7 +141,7 @@ jobs:
           - stable
         target:
           - aarch64-unknown-linux-gnu
-          - mips-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
         features:
           - default
   # **** NOTE: Currently broken with `asm` feature enabled! See:

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -131,7 +131,7 @@ jobs:
           - stable
         target:
           - aarch64-unknown-linux-gnu
-          - mips-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
         features:
           - default
         include:

--- a/.github/workflows/sha3.yml
+++ b/.github/workflows/sha3.yml
@@ -78,7 +78,7 @@ jobs:
           - stable
         target:
           - aarch64-unknown-linux-gnu
-          - mips-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
         features:
           - default
 


### PR DESCRIPTION
`mips-unknown-linux-gnu` is now a Tier 3 target: rust-lang/rust#115218.

This means we can't use it for cross tests anymore since `std` is no longer built for it.

This commit replaces it with `powerpc-unknown-linux-gnu`, a big endian Tier 2 target.