### PR TITLE
blake2: Refuse empty keys in keyed hash construction

### DIFF
--- a/blake2/src/macros.rs
+++ b/blake2/src/macros.rs
@@ -276,9 +276,12 @@ macro_rules! blake2_mac_impl {
         {
             /// Create new instance using provided key, salt, and persona.
             ///
-            /// Key length should not be bigger than block size, salt and persona
-            /// length should not be bigger than quarter of block size. If any
-            /// of those conditions is false the method will return an error.
+            /// # Errors
+            ///
+            /// Key length should not be empty or bigger than the block size and
+            /// the salt and persona length should not be bigger than quarter of
+            /// block size. If any of those conditions is false the method will
+            /// return an error.
             #[inline]
             pub fn new_with_salt_and_personal(
                 key: &[u8],
@@ -288,7 +291,7 @@ macro_rules! blake2_mac_impl {
                 let kl = key.len();
                 let bs = <$hash as BlockSizeUser>::BlockSize::USIZE;
                 let qbs = bs / 4;
-                if kl > bs || salt.len() > qbs || persona.len() > qbs {
+                if kl == 0 || kl > bs || salt.len() > qbs || persona.len() > qbs {
                     return Err(InvalidLength);
                 }
                 let mut padded_key = Block::<$hash>::default();

--- a/blake2/tests/mac.rs
+++ b/blake2/tests/mac.rs
@@ -27,3 +27,9 @@ fn blake2b_new_test() {
     run::<blake2::Blake2sMac256>(&[0x42; 32]);
     run::<blake2::Blake2bMac512>(&[0x42; 64]);
 }
+
+#[test]
+fn mac_refuses_empty_keys() {
+    assert!(blake2::Blake2bMac512::new_with_salt_and_personal(&[], b"salt", b"persona").is_err());
+    assert!(blake2::Blake2sMac256::new_with_salt_and_personal(&[], b"salt", b"persona").is_err());
+}


### PR DESCRIPTION
Fixes #509.

Blake2 0.10 splits keyed hashing into `*Mac` struct variants. However, this permits empty keys to be provided to `new_with_salt_and_personal`, while the implementation assumes a non-empty key. This leads to an invalid construction of Blake2, as the `kk` argument of the parameter block will now be `0x00`, but buffer is initialized as if `kk > 0x00`.

This change introduces a guard to the function, failing if the key was empty.