### PR TITLE
Expose belt_compress to public

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "md-5"
@@ -316,6 +316,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/belt-hash/CHANGELOG.md
+++ b/belt-hash/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2022-11-22)
+### Added
+- `belt_compress` function ([#520])
+
+[#520]: https://github.com/RustCrypto/hashes/pull/520
+
 ## 0.1.0 (2022-09-23)
 - Initial release ([#416])
 

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-hash"
-version = "0.1.0"
+version = "0.1.1"
 description = "BelT hash function (STB 34.101.31-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/belt-hash/src/lib.rs
+++ b/belt-hash/src/lib.rs
@@ -167,7 +167,7 @@ pub type BeltHash = CoreWrapper<BeltHashCore>;
 
 /// Compression function described in the section 6.3.2
 #[inline(always)]
-fn belt_compress(x1: [u32; 4], x2: [u32; 4], x34: [u32; 8]) -> ([u32; 4], [u32; 8]) {
+pub fn belt_compress(x1: [u32; 4], x2: [u32; 4], x34: [u32; 8]) -> ([u32; 4], [u32; 8]) {
     let x3 = [x34[0], x34[1], x34[2], x34[3]];
     let x4 = [x34[4], x34[5], x34[6], x34[7]];
 


### PR DESCRIPTION
Because bake-kdf algorithm uses belt-hash and compression in internal algorithm belt-keyrep, expose it to public.