### PR TITLE
Bump `digest` to v0.11.0-pre.3; MSRV 1.71

### DIFF
--- a/.github/workflows/ascon-hash.yml
+++ b/.github/workflows/ascon-hash.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/ascon-hash.yml
+++ b/.github/workflows/ascon-hash.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.56.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv
@@ -42,9 +42,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      # TODO: remove after bump to MSRV 1.60+
-      - run: cargo update
-      - run: cargo update -p zeroize --precise 1.6.0
       - run: cargo hack build --target ${{ matrix.target }} --each-feature --exclude-features default,std
 
   minimal-versions:
@@ -67,7 +64,4 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      # TODO: remove after bump to MSRV 1.60+
-      - run: cargo update
-      - run: cargo update -p zeroize --precise 1.6.0
       - run: cargo hack test --feature-powerset

--- a/.github/workflows/belt-hash.yml
+++ b/.github/workflows/belt-hash.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/belt-hash.yml
+++ b/.github/workflows/belt-hash.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65
+          - 1.71.0
           - stable
         target:
           - aarch64-unknown-linux-gnu

--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -68,17 +68,18 @@ jobs:
         working-directory: ${{ github.workflow }}
         stable-cmd: cargo hack test --release --feature-powerset --exclude-features simd,simd_opt,simd_asm
 
-  simd:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2021-05-01
-      - run: cargo test --features simd
-      - run: cargo test --features simd_opt
-      - run: cargo test --features simd_asm
+# No longer builds on recent nightlies
+#  simd:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: RustCrypto/actions/cargo-cache@master
+#      - uses: dtolnay/rust-toolchain@master
+#        with:
+#          toolchain: nightly-2021-05-01
+#      - run: cargo test --features simd
+#      - run: cargo test --features simd_opt
+#      - run: cargo test --features simd_asm
 
   # Cross-compiled tests
   cross:

--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51 # 1.41-1.50 `--features` can't be used inside virtual manifest
+          - 1.65
           - stable
         target:
           - aarch64-unknown-linux-gnu

--- a/.github/workflows/fsb.yml
+++ b/.github/workflows/fsb.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/fsb.yml
+++ b/.github/workflows/fsb.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/gost94.yml
+++ b/.github/workflows/gost94.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv
@@ -65,19 +65,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: merge with test on MSRV bump to 1.57 or higher
-  test-msrv-41:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.41.0 # MSRV
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo test
-      - run: cargo test --no-default-features

--- a/.github/workflows/gost94.yml
+++ b/.github/workflows/gost94.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/groestl.yml
+++ b/.github/workflows/groestl.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/groestl.yml
+++ b/.github/workflows/groestl.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/jh.yml
+++ b/.github/workflows/jh.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/jh.yml
+++ b/.github/workflows/jh.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/k12.yml
+++ b/.github/workflows/k12.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.56.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/k12.yml
+++ b/.github/workflows/k12.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/md2.yml
+++ b/.github/workflows/md2.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv
@@ -65,19 +65,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: merge with test on MSRV bump to 1.57 or higher
-  test-msrv-41:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.41.0 # MSRV
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/md2.yml
+++ b/.github/workflows/md2.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/md4.yml
+++ b/.github/workflows/md4.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/md4.yml
+++ b/.github/workflows/md4.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv
@@ -65,19 +65,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: merge with test on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.41.0 # MSRV
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -24,7 +24,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv
@@ -80,18 +80,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: merge with test on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.41.0 # MSRV
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo test

--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -24,7 +24,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/ripemd.yml
+++ b/.github/workflows/ripemd.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/ripemd.yml
+++ b/.github/workflows/ripemd.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv
@@ -66,18 +66,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: merge with test on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.41.0 # MSRV
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo test --no-default-features

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -21,9 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        # Crate supports MSRV 1.41 without `oid` feature. We test true MSRV
-        # in the `test-msrv` job.
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   # Builds for no_std platforms
   build:
@@ -115,9 +113,8 @@ jobs:
       matrix:
         include:
           # 64-bit Windows (GNU)
-          # TODO(tarcieri): try re-enabling this when we bump MSRV
-          #- target: x86_64-pc-windows-gnu
-          #  toolchain: ${{needs.set-msrv.outputs.msrv}}
+          - target: x86_64-pc-windows-gnu
+            toolchain: ${{needs.set-msrv.outputs.msrv}}
           - target: x86_64-pc-windows-gnu
             rust: stable
 
@@ -149,7 +146,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # 1.41-1.50 `--features` can't be used inside virtual manifest
+          - 1.65.0
           - stable
         target:
           - aarch64-unknown-linux-gnu
@@ -176,15 +173,3 @@ jobs:
           package: ${{ github.workflow }}
           target: ${{ matrix.target }}
           features: ${{ matrix.features }}
-
-  # TODO: remove on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.41.0
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   # Builds for no_std platforms
   build:
@@ -146,7 +146,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0
+          - 1.71.0
           - stable
         target:
           - aarch64-unknown-linux-gnu

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -116,7 +116,7 @@ jobs:
           - target: x86_64-pc-windows-gnu
             toolchain: ${{needs.set-msrv.outputs.msrv}}
           - target: x86_64-pc-windows-gnu
-            rust: stable
+            toolchain: stable
 
     runs-on: windows-latest
     steps:
@@ -124,7 +124,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ matrix.toolchain }}
           targets: ${{ matrix.target }}
       - uses: msys2/setup-msys2@v2
       - run: cargo test --target ${{ matrix.target }}

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -21,9 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        # Crate supports MSRV 1.41 without `oid` feature. We test true MSRV
-        # in the `test-msrv` job.
-        msrv: 1.59.0
+        msrv: 1.65.0
 
   # Builds for no_std platforms
   build:
@@ -32,7 +30,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.59
+          - 1.65.0
           - stable
         target:
           - thumbv7em-none-eabi
@@ -168,15 +166,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: remove on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.41.0
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   # Builds for no_std platforms
   build:
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0
+          - 1.71.0
           - stable
         target:
           - thumbv7em-none-eabi

--- a/.github/workflows/sha3.yml
+++ b/.github/workflows/sha3.yml
@@ -21,9 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        # Crate supports MSRV 1.41 without `oid` feature. We test true MSRV
-        # in the `test-msrv` job.
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv
@@ -95,15 +93,3 @@ jobs:
           package: ${{ github.workflow }}
           target: ${{ matrix.target }}
           features: ${{ matrix.features }}
-
-  # TODO: remove on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.41.0
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/sha3.yml
+++ b/.github/workflows/sha3.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/shabal.yml
+++ b/.github/workflows/shabal.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/shabal.yml
+++ b/.github/workflows/shabal.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/skein.yml
+++ b/.github/workflows/skein.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/skein.yml
+++ b/.github/workflows/skein.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/sm3.yml
+++ b/.github/workflows/sm3.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/sm3.yml
+++ b/.github/workflows/sm3.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/streebog.yml
+++ b/.github/workflows/streebog.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.57.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv
@@ -65,17 +65,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # `oid` feature bumps MSRV to 1.57, so we temporarily split this job.
-  test-msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          profile: minimal
-          toolchain: 1.41.0
-          override: true
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/streebog.yml
+++ b/.github/workflows/streebog.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/tiger.yml
+++ b/.github/workflows/tiger.yml
@@ -24,7 +24,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/tiger.yml
+++ b/.github/workflows/tiger.yml
@@ -24,7 +24,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.56.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/whirlpool.yml
+++ b/.github/workflows/whirlpool.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.65.0
+        msrv: 1.71.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/whirlpool.yml
+++ b/.github/workflows/whirlpool.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.65.0
 
   build:
     needs: set-msrv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.10.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
 
 [[package]]
 name = "cpufeatures"
@@ -102,8 +102,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#e36243ee7624243a668ec7f233adccb216afcc41"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3be3c52e023de5662dc05a32f747d09a1d6024fdd1f64b0850e373269efb43"
 dependencies = [
  "blobby",
  "block-buffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-pre.2"
+version = "0.11.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a601d94c4c47c51a046b82b883fe236e5750c0da327dd1427c8b4416296418a"
+checksum = "72bc448e41b30773616b4f51a23f1a51634d41ce0d06a9bf6c3065ee85e227a1"
 dependencies = [
  "crypto-common",
 ]
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-pre.2"
+version = "0.2.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102f7900795d54e3b8566857762a2977c267ab5952e4117283017ee1d5c9ae88"
+checksum = "cc17eb697364b18256ec92675ebe6b7b153d2f1041e568d74533c5d0fc1ca162"
 dependencies = [
  "getrandom",
  "hybrid-array",
@@ -103,7 +103,7 @@ dependencies = [
 [[package]]
 name = "digest"
 version = "0.11.0-pre"
-source = "git+https://github.com/RustCrypto/traits.git#6810dc1dcfe9949f2f2e8e6f3e077737b97c06f1"
+source = "git+https://github.com/RustCrypto/traits.git#e36243ee7624243a668ec7f233adccb216afcc41"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -162,8 +162,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-pre.7"
-source = "git+https://github.com/RustCrypto/utils.git#55a93f1163153b494b7c78d3a2fe2a8da5c48121"
+version = "0.2.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fbaf242418fe980caf09ed348d5a6aeabe71fc1bd8bebad641f4591ae0a46d"
 dependencies = [
  "typenum",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,42 @@
 version = 3
 
 [[package]]
+name = "ascon"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e716048a18530cce4684daf98a7563a499d710e1ed8ef35567fcb43a7c5f1"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "ascon-hash"
+version = "0.3.0-pre"
+dependencies = [
+ "ascon",
+ "digest",
+ "hex",
+ "spectral",
+]
+
+[[package]]
+name = "belt-block"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
+
+[[package]]
+name = "belt-hash"
+version = "0.2.0-pre"
+dependencies = [
+ "belt-block",
+ "digest",
+ "hex-literal",
+]
+
+[[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
@@ -18,11 +52,11 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.11.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "0a601d94c4c47c51a046b82b883fe236e5750c0da327dd1427c8b4416296418a"
 dependencies = [
- "generic-array",
+ "crypto-common",
 ]
 
 [[package]]
@@ -57,19 +91,19 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "102f7900795d54e3b8566857762a2977c267ab5952e4117283017ee1d5c9ae88"
 dependencies = [
- "generic-array",
- "typenum",
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+version = "0.11.0-pre"
+source = "git+https://github.com/RustCrypto/traits.git#6810dc1dcfe9949f2f2e8e6f3e077737b97c06f1"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -80,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "fsb"
-version = "0.1.3"
+version = "0.2.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
@@ -88,18 +122,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "getrandom"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
- "typenum",
- "version_check",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
 name = "gost94"
-version = "0.10.4"
+version = "0.11.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
@@ -107,29 +142,48 @@ dependencies = [
 
 [[package]]
 name = "groestl"
-version = "0.10.1"
+version = "0.11.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
 ]
 
 [[package]]
-name = "hex-literal"
-version = "0.2.2"
+name = "hex"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70693199b3cf4552f3fa720b54163927a3ebed2aef240efaf556033ab336a11"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-pre.7"
+source = "git+https://github.com/RustCrypto/utils.git#55a93f1163153b494b7c78d3a2fe2a8da5c48121"
 dependencies = [
- "hex-literal-impl",
- "proc-macro-hack",
+ "typenum",
 ]
 
 [[package]]
-name = "hex-literal-impl"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59448fc2f82a5fb6907f78c3d69d843e82ff5b051923313cc4438cb0c7b745a8"
+name = "jh"
+version = "0.2.0-pre"
 dependencies = [
- "proc-macro-hack",
+ "digest",
+ "hex-literal",
+ "ppv-lite86",
+]
+
+[[package]]
+name = "k12"
+version = "0.4.0-pre"
+dependencies = [
+ "digest",
+ "hex-literal",
+ "sha3",
 ]
 
 [[package]]
@@ -149,7 +203,7 @@ checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0-pre"
 dependencies = [
  "cfg-if",
  "digest",
@@ -159,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "md2"
-version = "0.10.2"
+version = "0.11.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
@@ -167,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "md4"
-version = "0.10.2"
+version = "0.11.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
@@ -183,14 +237,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
+name = "ppv-lite86"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "ripemd"
-version = "0.1.3"
+version = "0.2.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
@@ -198,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0-pre"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -218,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0-pre"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -238,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.11.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
@@ -248,23 +311,38 @@ dependencies = [
 
 [[package]]
 name = "shabal"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
+]
+
+[[package]]
+name = "skein"
+version = "0.2.0-pre"
+dependencies = [
+ "digest",
+ "hex-literal",
+ "threefish",
 ]
 
 [[package]]
 name = "sm3"
-version = "0.4.2"
+version = "0.5.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
 ]
 
 [[package]]
+name = "spectral"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
+
+[[package]]
 name = "streebog"
-version = "0.10.2"
+version = "0.11.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
@@ -277,8 +355,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
+name = "threefish"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a693d0c8cf16973fac5a93fbe47b8c6452e7097d4fcac49f3d7a18e39c76e62e"
+
+[[package]]
 name = "tiger"
-version = "0.2.1"
+version = "0.3.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
@@ -291,14 +375,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whirlpool"
-version = "0.10.4"
+version = "0.11.0-pre"
 dependencies = [
  "digest",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ opt-level = 2
 
 [patch.crates-io]
 digest = { git = "https://github.com/RustCrypto/traits.git" }
-hybrid-array = { git = "https://github.com/RustCrypto/utils.git" }
+#hybrid-array = { path = "../utils/hybrid-array" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [workspace]
-# This causes issues like https://github.com/RustCrypto/hashes/issues/396
-# Do not uncomment it until MSRV is bumped to 1.51 or higher.
-# resolver = "2"
+resolver = "2"
 members = [
+    "ascon-hash",
+    "belt-hash",
     "blake2",
     "fsb",
     "gost94",
     "groestl",
+    "jh",
+    "k12",
     "md2",
     "md4",
     "md5",
@@ -15,18 +17,16 @@ members = [
     "sha2",
     "sha3",
     "shabal",
+    "skein",
     "sm3",
     "streebog",
     "tiger",
     "whirlpool",
 ]
-exclude = [
-    "ascon-hash",
-    "belt-hash",
-    "jh",
-    "k12",
-    "skein",
-]
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+digest = { git = "https://github.com/RustCrypto/traits.git" }
+hybrid-array = { git = "https://github.com/RustCrypto/utils.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-digest = { git = "https://github.com/RustCrypto/traits.git" }
-#hybrid-array = { path = "../utils/hybrid-array" }

--- a/README.md
+++ b/README.md
@@ -13,27 +13,27 @@ Additionally all crates do not require the standard library (i.e. `no_std` capab
 
 | Algorithm | Crate | Crates.io | Documentation | MSRV | [Security] |
 |-----------|-------|:---------:|:-------------:|:----:|:----------:|
-| [Ascon] hash | [`ascon‑hash`] | [![crates.io](https://img.shields.io/crates/v/ascon-hash.svg)](https://crates.io/crates/ascon-hash) | [![Documentation](https://docs.rs/ascon-hash/badge.svg)](https://docs.rs/ascon-hash) | ![MSRV 1.56][msrv-1.56] | :green_heart: |
-| [BelT] hash | [`belt‑hash`] | [![crates.io](https://img.shields.io/crates/v/belt-hash.svg)](https://crates.io/crates/belt-hash) | [![Documentation](https://docs.rs/belt-hash/badge.svg)](https://docs.rs/belt-hash) | ![MSRV 1.57][msrv-1.57] | :green_heart: |
-| [BLAKE2] | [`blake2`] | [![crates.io](https://img.shields.io/crates/v/blake2.svg)](https://crates.io/crates/blake2) | [![Documentation](https://docs.rs/blake2/badge.svg)](https://docs.rs/blake2) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
-| [FSB] | [`fsb`] | [![crates.io](https://img.shields.io/crates/v/fsb.svg)](https://crates.io/crates/fsb) | [![Documentation](https://docs.rs/fsb/badge.svg)](https://docs.rs/fsb) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
-| [GOST R 34.11-94][GOST94] | [`gost94`] | [![crates.io](https://img.shields.io/crates/v/gost94.svg)](https://crates.io/crates/gost94) | [![Documentation](https://docs.rs/gost94/badge.svg)](https://docs.rs/gost94) | ![MSRV 1.41][msrv-1.41] | :yellow_heart: |
-| [Grøstl] (Groestl) | [`groestl`] | [![crates.io](https://img.shields.io/crates/v/groestl.svg)](https://crates.io/crates/groestl) | [![Documentation](https://docs.rs/groestl/badge.svg)](https://docs.rs/groestl) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
-| [JH] | [`jh`] | [![crates.io](https://img.shields.io/crates/v/jh.svg)](https://crates.io/crates/jh) | [![Documentation](https://docs.rs/jh/badge.svg)](https://docs.rs/jh) | ![MSRV 1.57][msrv-1.57] | :green_heart: |
-| [KangarooTwelve] | [`k12`] | [![crates.io](https://img.shields.io/crates/v/k12.svg)](https://crates.io/crates/k12) | [![Documentation](https://docs.rs/k12/badge.svg)](https://docs.rs/k12) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
-| [MD2] | [`md2`] | [![crates.io](https://img.shields.io/crates/v/md2.svg)](https://crates.io/crates/md2) | [![Documentation](https://docs.rs/md2/badge.svg)](https://docs.rs/md2) | ![MSRV 1.41][msrv-1.41] | :broken_heart: |
-| [MD4] | [`md4`] | [![crates.io](https://img.shields.io/crates/v/md4.svg)](https://crates.io/crates/md4) | [![Documentation](https://docs.rs/md4/badge.svg)](https://docs.rs/md4) | ![MSRV 1.41][msrv-1.41] | :broken_heart: |
-| [MD5] | [`md5`] [:exclamation:] | [![crates.io](https://img.shields.io/crates/v/md-5.svg)](https://crates.io/crates/md-5) | [![Documentation](https://docs.rs/md-5/badge.svg)](https://docs.rs/md-5) | ![MSRV 1.41][msrv-1.41] | :broken_heart: |
-| [RIPEMD] | [`ripemd`] | [![crates.io](https://img.shields.io/crates/v/ripemd.svg)](https://crates.io/crates/ripemd) | [![Documentation](https://docs.rs/ripemd/badge.svg)](https://docs.rs/ripemd) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
-| [SHA-1] | [`sha1`] | [![crates.io](https://img.shields.io/crates/v/sha1.svg)](https://crates.io/crates/sha1) | [![Documentation](https://docs.rs/sha1/badge.svg)](https://docs.rs/sha1) | ![MSRV 1.41][msrv-1.41] | :broken_heart: |
-| [SHA-2] | [`sha2`] | [![crates.io](https://img.shields.io/crates/v/sha2.svg)](https://crates.io/crates/sha2) | [![Documentation](https://docs.rs/sha2/badge.svg)](https://docs.rs/sha2) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
-| [SHA-3] (Keccak) | [`sha3`] | [![crates.io](https://img.shields.io/crates/v/sha3.svg)](https://crates.io/crates/sha3) | [![Documentation](https://docs.rs/sha3/badge.svg)](https://docs.rs/sha3) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
-| [SHABAL] | [`shabal`] | [![crates.io](https://img.shields.io/crates/v/shabal.svg)](https://crates.io/crates/shabal) | [![Documentation](https://docs.rs/shabal/badge.svg)](https://docs.rs/shabal) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
-| [Skein] | [`skein`] | [![crates.io](https://img.shields.io/crates/v/skein.svg)](https://crates.io/crates/skein) | [![Documentation](https://docs.rs/skein/badge.svg)](https://docs.rs/skein) | ![MSRV 1.57][msrv-1.57] | :green_heart: |
-| [SM3] (OSCCA GM/T 0004-2012) | [`sm3`] | [![crates.io](https://img.shields.io/crates/v/sm3.svg)](https://crates.io/crates/sm3) | [![Documentation](https://docs.rs/sm3/badge.svg)](https://docs.rs/sm3) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
-| [Streebog] (GOST R 34.11-2012) | [`streebog`] | [![crates.io](https://img.shields.io/crates/v/streebog.svg)](https://crates.io/crates/streebog) | [![Documentation](https://docs.rs/streebog/badge.svg)](https://docs.rs/streebog) | ![MSRV 1.41][msrv-1.41] | :yellow_heart: |
-| [Tiger] | [`tiger`] | [![crates.io](https://img.shields.io/crates/v/tiger.svg)](https://crates.io/crates/tiger) | [![Documentation](https://docs.rs/tiger/badge.svg)](https://docs.rs/tiger) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
-| [Whirlpool] | [`whirlpool`] | [![crates.io](https://img.shields.io/crates/v/whirlpool.svg)](https://crates.io/crates/whirlpool) | [![Documentation](https://docs.rs/whirlpool/badge.svg)](https://docs.rs/whirlpool) | ![MSRV 1.41][msrv-1.41] | :green_heart: |
+| [Ascon] hash | [`ascon‑hash`] | [![crates.io](https://img.shields.io/crates/v/ascon-hash.svg)](https://crates.io/crates/ascon-hash) | [![Documentation](https://docs.rs/ascon-hash/badge.svg)](https://docs.rs/ascon-hash) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [BelT] hash | [`belt‑hash`] | [![crates.io](https://img.shields.io/crates/v/belt-hash.svg)](https://crates.io/crates/belt-hash) | [![Documentation](https://docs.rs/belt-hash/badge.svg)](https://docs.rs/belt-hash) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [BLAKE2] | [`blake2`] | [![crates.io](https://img.shields.io/crates/v/blake2.svg)](https://crates.io/crates/blake2) | [![Documentation](https://docs.rs/blake2/badge.svg)](https://docs.rs/blake2) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [FSB] | [`fsb`] | [![crates.io](https://img.shields.io/crates/v/fsb.svg)](https://crates.io/crates/fsb) | [![Documentation](https://docs.rs/fsb/badge.svg)](https://docs.rs/fsb) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [GOST R 34.11-94][GOST94] | [`gost94`] | [![crates.io](https://img.shields.io/crates/v/gost94.svg)](https://crates.io/crates/gost94) | [![Documentation](https://docs.rs/gost94/badge.svg)](https://docs.rs/gost94) | ![MSRV 1.65][msrv-1.65] | :yellow_heart: |
+| [Grøstl] (Groestl) | [`groestl`] | [![crates.io](https://img.shields.io/crates/v/groestl.svg)](https://crates.io/crates/groestl) | [![Documentation](https://docs.rs/groestl/badge.svg)](https://docs.rs/groestl) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [JH] | [`jh`] | [![crates.io](https://img.shields.io/crates/v/jh.svg)](https://crates.io/crates/jh) | [![Documentation](https://docs.rs/jh/badge.svg)](https://docs.rs/jh) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [KangarooTwelve] | [`k12`] | [![crates.io](https://img.shields.io/crates/v/k12.svg)](https://crates.io/crates/k12) | [![Documentation](https://docs.rs/k12/badge.svg)](https://docs.rs/k12) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [MD2] | [`md2`] | [![crates.io](https://img.shields.io/crates/v/md2.svg)](https://crates.io/crates/md2) | [![Documentation](https://docs.rs/md2/badge.svg)](https://docs.rs/md2) | ![MSRV 1.65][msrv-1.65] | :broken_heart: |
+| [MD4] | [`md4`] | [![crates.io](https://img.shields.io/crates/v/md4.svg)](https://crates.io/crates/md4) | [![Documentation](https://docs.rs/md4/badge.svg)](https://docs.rs/md4) | ![MSRV 1.65][msrv-1.65] | :broken_heart: |
+| [MD5] | [`md5`] [:exclamation:] | [![crates.io](https://img.shields.io/crates/v/md-5.svg)](https://crates.io/crates/md-5) | [![Documentation](https://docs.rs/md-5/badge.svg)](https://docs.rs/md-5) | ![MSRV 1.65][msrv-1.65] | :broken_heart: |
+| [RIPEMD] | [`ripemd`] | [![crates.io](https://img.shields.io/crates/v/ripemd.svg)](https://crates.io/crates/ripemd) | [![Documentation](https://docs.rs/ripemd/badge.svg)](https://docs.rs/ripemd) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [SHA-1] | [`sha1`] | [![crates.io](https://img.shields.io/crates/v/sha1.svg)](https://crates.io/crates/sha1) | [![Documentation](https://docs.rs/sha1/badge.svg)](https://docs.rs/sha1) | ![MSRV 1.65][msrv-1.65] | :broken_heart: |
+| [SHA-2] | [`sha2`] | [![crates.io](https://img.shields.io/crates/v/sha2.svg)](https://crates.io/crates/sha2) | [![Documentation](https://docs.rs/sha2/badge.svg)](https://docs.rs/sha2) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [SHA-3] (Keccak) | [`sha3`] | [![crates.io](https://img.shields.io/crates/v/sha3.svg)](https://crates.io/crates/sha3) | [![Documentation](https://docs.rs/sha3/badge.svg)](https://docs.rs/sha3) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [SHABAL] | [`shabal`] | [![crates.io](https://img.shields.io/crates/v/shabal.svg)](https://crates.io/crates/shabal) | [![Documentation](https://docs.rs/shabal/badge.svg)](https://docs.rs/shabal) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [Skein] | [`skein`] | [![crates.io](https://img.shields.io/crates/v/skein.svg)](https://crates.io/crates/skein) | [![Documentation](https://docs.rs/skein/badge.svg)](https://docs.rs/skein) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [SM3] (OSCCA GM/T 0004-2012) | [`sm3`] | [![crates.io](https://img.shields.io/crates/v/sm3.svg)](https://crates.io/crates/sm3) | [![Documentation](https://docs.rs/sm3/badge.svg)](https://docs.rs/sm3) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [Streebog] (GOST R 34.11-2012) | [`streebog`] | [![crates.io](https://img.shields.io/crates/v/streebog.svg)](https://crates.io/crates/streebog) | [![Documentation](https://docs.rs/streebog/badge.svg)](https://docs.rs/streebog) | ![MSRV 1.65][msrv-1.65] | :yellow_heart: |
+| [Tiger] | [`tiger`] | [![crates.io](https://img.shields.io/crates/v/tiger.svg)](https://crates.io/crates/tiger) | [![Documentation](https://docs.rs/tiger/badge.svg)](https://docs.rs/tiger) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
+| [Whirlpool] | [`whirlpool`] | [![crates.io](https://img.shields.io/crates/v/whirlpool.svg)](https://crates.io/crates/whirlpool) | [![Documentation](https://docs.rs/whirlpool/badge.svg)](https://docs.rs/whirlpool) | ![MSRV 1.65][msrv-1.65] | :green_heart: |
 
 NOTE: the [`blake3`] crate implements the `digest` traits used by the rest of the hashes in this repository, but is maintained by the BLAKE3 team.
 
@@ -233,9 +233,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [deps-image]: https://deps.rs/repo/github/RustCrypto/hashes/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/hashes
-[msrv-1.41]: https://img.shields.io/badge/rustc-1.41.0+-blue.svg
-[msrv-1.56]: https://img.shields.io/badge/rustc-1.56.0+-blue.svg
-[msrv-1.57]: https://img.shields.io/badge/rustc-1.57.0+-blue.svg
+[msrv-1.65]: https://img.shields.io/badge/rustc-1.65.0+-blue.svg
 
 [//]: # (crates)
 

--- a/ascon-hash/Cargo.toml
+++ b/ascon-hash/Cargo.toml
@@ -13,10 +13,10 @@ documentation = "https://docs.rs/ascon-hash"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "hash", "ascon"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = { version = "=0.11.0-pre", default-features = false, features = ["core-api"] }
+digest = { version = "=0.11.0-pre.3", default-features = false, features = ["core-api"] }
 ascon = { version = "0.4", default-features = false }
 
 [dev-dependencies]

--- a/ascon-hash/Cargo.toml
+++ b/ascon-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon-hash"
-version = "0.2.0"
+version = "0.3.0-pre"
 description = "Implementation of the Ascon and AsconA hashes and XOFs"
 authors = [
     "Sebastian Ramacher <sebastian.ramacher@ait.ac.at>",
@@ -13,12 +13,10 @@ documentation = "https://docs.rs/ascon-hash"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "hash", "ascon"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.56"
-
-[workspace]
+rust-version = "1.65"
 
 [dependencies]
-digest = { version = "0.10", default-features = false, features = ["core-api"] }
+digest = { version = "=0.11.0-pre", default-features = false, features = ["core-api"] }
 ascon = { version = "0.4", default-features = false }
 
 [dev-dependencies]

--- a/ascon-hash/README.md
+++ b/ascon-hash/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Pure Rust implementation of the lightweight cryptographic hash functions
 [AsconHash and AsconAHash][1] and the extendable output functions (XOF) AsconXOF
@@ -21,7 +21,7 @@ USE AT YOUR OWN RISK!
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -48,7 +48,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/ascon-hash/badge.svg
 [docs-link]: https://docs.rs/ascon-hash/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260041-hashes
 [build-image]: https://github.com/RustCrypto/hashes/workflows/ascon-hash/badge.svg?branch=master

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -6,18 +6,18 @@ authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 documentation = "https://docs.rs/belt-hash"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "belt", "stb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 belt-block = { version = "0.1.1", default-features = false }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,30 +1,26 @@
 [package]
 name = "belt-hash"
-version = "0.1.1"
+version = "0.2.0-pre"
 description = "BelT hash function (STB 34.101.31-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.65"
 documentation = "https://docs.rs/belt-hash"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "belt", "stb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.10.4"
+digest = "=0.11.0-pre"
 belt-block = { version = "0.1.1", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.10.4", features = ["dev"] }
-hex-literal = "0.3.3"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]
 std = ["digest/std"]
 oid = ["digest/oid"]
-
-# TODO: remove when crate will be part of the root workspace
-[profile.dev]
-opt-level = 2

--- a/belt-hash/README.md
+++ b/belt-hash/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Pure Rust implementation of the [BelT] hash function specified in [STB 34.101.31-2020].
 
@@ -13,7 +13,7 @@ Pure Rust implementation of the [BelT] hash function specified in [STB 34.101.31
 
 ## Minimum Supported Rust Version
 
-Rust **1.57** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -45,7 +45,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/belt-hash/badge.svg
 [docs-link]: https://docs.rs/belt-hash
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260041-hashes
 [build-image]: https://github.com/RustCrypto/hashes/workflows/belt-hash/badge.svg?branch=master

--- a/belt-hash/src/lib.rs
+++ b/belt-hash/src/lib.rs
@@ -13,7 +13,7 @@
 //! // process input message
 //! hasher.update(b"hello world");
 //!
-//! // acquire hash digest in the form of GenericArray,
+//! // acquire hash digest in the form of Array,
 //! // which in this case is equivalent to [u8; 32]
 //! let result = hasher.finalize();
 //! let expected = hex!(
@@ -111,7 +111,7 @@ impl FixedOutputCore for BeltHashCore {
         let pos = buffer.get_pos();
         if pos != 0 {
             let block = buffer.pad_with_zeros();
-            self.compress_block(block);
+            self.compress_block(&block);
         }
         let bs = Self::BlockSize::USIZE as u128;
         let r = encode_r(8 * ((bs * self.r) + pos as u128));

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Criterion benchmarks of the hash crates"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.65"
 publish = false
 
 [workspace]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Criterion benchmarks of the hash crates"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 publish = false
 
 [workspace]

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0-pre"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/blake2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "blake2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = { version = "0.10.7", features = ["mac"] }
+digest = { version = "=0.11.0-pre", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -10,13 +10,13 @@ documentation = "https://docs.rs/blake2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "blake2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = { version = "=0.11.0-pre", features = ["mac"] }
+digest = { version = "=0.11.0-pre.3", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/blake2/README.md
+++ b/blake2/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Pure Rust implementation of the [BLAKE2 hash function][1] family.
 
@@ -13,7 +13,7 @@ Pure Rust implementation of the [BLAKE2 hash function][1] family.
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -47,7 +47,7 @@ dual licensed as above, without any additional terms or conditions.
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260041-hashes
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [build-image]: https://github.com/RustCrypto/hashes/workflows/blake2/badge.svg?branch=master
 [build-link]: https://github.com/RustCrypto/hashes/actions?query=workflow%3Ablake2
 

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -92,7 +92,7 @@ use digest::{
         VariableOutputCore,
     },
     crypto_common::{InvalidLength, Key, KeyInit, KeySizeUser},
-    generic_array::{ArrayLength, GenericArray},
+    array::{ArraySize, Array},
     typenum::{IsLessOrEqual, LeEq, NonZero, Unsigned},
     FixedOutput, HashMarker, InvalidOutputSize, MacMarker, Output, Update,
 };

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -84,6 +84,7 @@ pub use digest::{self, Digest};
 
 use core::{convert::TryInto, fmt, marker::PhantomData, ops::Div};
 use digest::{
+    array::{Array, ArraySize},
     block_buffer::{Lazy, LazyBuffer},
     consts::{U128, U32, U4, U64},
     core_api::{
@@ -92,7 +93,6 @@ use digest::{
         VariableOutputCore,
     },
     crypto_common::{InvalidLength, Key, KeyInit, KeySizeUser},
-    array::{ArraySize, Array},
     typenum::{IsLessOrEqual, LeEq, NonZero, Unsigned},
     FixedOutput, HashMarker, InvalidOutputSize, MacMarker, Output, Update,
 };

--- a/blake2/src/macros.rs
+++ b/blake2/src/macros.rs
@@ -44,8 +44,7 @@ macro_rules! blake2_impl {
 
                 // salt is two words long
                 if salt.len() < length {
-                    let mut padded_salt =
-                        GenericArray::<u8, <$bytes as Div<U4>>::Output>::default();
+                    let mut padded_salt = Array::<u8, <$bytes as Div<U4>>::Output>::default();
                     for i in 0..salt.len() {
                         padded_salt[i] = salt[i];
                     }
@@ -63,8 +62,7 @@ macro_rules! blake2_impl {
 
                 // persona is also two words long
                 if persona.len() < length {
-                    let mut padded_persona =
-                        GenericArray::<u8, <$bytes as Div<U4>>::Output>::default();
+                    let mut padded_persona = Array::<u8, <$bytes as Div<U4>>::Output>::default();
                     for i in 0..persona.len() {
                         padded_persona[i] = persona[i];
                     }
@@ -95,7 +93,7 @@ macro_rules! blake2_impl {
 
             fn finalize_with_flag(
                 &mut self,
-                final_block: &GenericArray<u8, $block_size>,
+                final_block: &Array<u8, $block_size>,
                 flag: $word,
                 out: &mut Output<Self>,
             ) {
@@ -224,7 +222,7 @@ macro_rules! blake2_impl {
             ) {
                 self.t += buffer.get_pos() as u64;
                 let block = buffer.pad_with_zeros();
-                self.finalize_with_flag(block, 0, out);
+                self.finalize_with_flag(&block, 0, out);
             }
         }
 
@@ -259,7 +257,7 @@ macro_rules! blake2_mac_impl {
         #[doc=$doc]
         pub struct $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size>,
+            OutSize: ArraySize + IsLessOrEqual<$max_size>,
             LeEq<OutSize, $max_size>: NonZero,
         {
             core: $hash,
@@ -271,7 +269,7 @@ macro_rules! blake2_mac_impl {
 
         impl<OutSize> $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size>,
+            OutSize: ArraySize + IsLessOrEqual<$max_size>,
             LeEq<OutSize, $max_size>: NonZero,
         {
             /// Create new instance using provided key, salt, and persona.
@@ -309,7 +307,7 @@ macro_rules! blake2_mac_impl {
 
         impl<OutSize> KeySizeUser for $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size>,
+            OutSize: ArraySize + IsLessOrEqual<$max_size>,
             LeEq<OutSize, $max_size>: NonZero,
         {
             type KeySize = $max_size;
@@ -317,7 +315,7 @@ macro_rules! blake2_mac_impl {
 
         impl<OutSize> KeyInit for $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size>,
+            OutSize: ArraySize + IsLessOrEqual<$max_size>,
             LeEq<OutSize, $max_size>: NonZero,
         {
             #[inline]
@@ -349,7 +347,7 @@ macro_rules! blake2_mac_impl {
 
         impl<OutSize> Update for $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size>,
+            OutSize: ArraySize + IsLessOrEqual<$max_size>,
             LeEq<OutSize, $max_size>: NonZero,
         {
             #[inline]
@@ -361,7 +359,7 @@ macro_rules! blake2_mac_impl {
 
         impl<OutSize> OutputSizeUser for $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size> + 'static,
+            OutSize: ArraySize + IsLessOrEqual<$max_size> + 'static,
             LeEq<OutSize, $max_size>: NonZero,
         {
             type OutputSize = OutSize;
@@ -369,7 +367,7 @@ macro_rules! blake2_mac_impl {
 
         impl<OutSize> FixedOutput for $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size> + 'static,
+            OutSize: ArraySize + IsLessOrEqual<$max_size> + 'static,
             LeEq<OutSize, $max_size>: NonZero,
         {
             #[inline]
@@ -384,7 +382,7 @@ macro_rules! blake2_mac_impl {
         #[cfg(feature = "reset")]
         impl<OutSize> Reset for $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size>,
+            OutSize: ArraySize + IsLessOrEqual<$max_size>,
             LeEq<OutSize, $max_size>: NonZero,
         {
             fn reset(&mut self) {
@@ -399,7 +397,7 @@ macro_rules! blake2_mac_impl {
         #[cfg(feature = "reset")]
         impl<OutSize> FixedOutputReset for $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size>,
+            OutSize: ArraySize + IsLessOrEqual<$max_size>,
             LeEq<OutSize, $max_size>: NonZero,
         {
             #[inline]
@@ -414,14 +412,14 @@ macro_rules! blake2_mac_impl {
 
         impl<OutSize> MacMarker for $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size>,
+            OutSize: ArraySize + IsLessOrEqual<$max_size>,
             LeEq<OutSize, $max_size>: NonZero,
         {
         }
 
         impl<OutSize> fmt::Debug for $name<OutSize>
         where
-            OutSize: ArrayLength<u8> + IsLessOrEqual<$max_size>,
+            OutSize: ArraySize + IsLessOrEqual<$max_size>,
             LeEq<OutSize, $max_size>: NonZero,
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/blake2/tests/mac.rs
+++ b/blake2/tests/mac.rs
@@ -8,15 +8,15 @@ new_test!(blake2s_mac, "blake2s/mac", blake2::Blake2sMac256);
 
 #[test]
 fn blake2b_new_test() {
-    use blake2::digest::{generic_array::GenericArray, KeyInit, Mac};
+    use blake2::digest::{array::Array, KeyInit, Mac};
 
     fn run<T: Mac + KeyInit>(key: &[u8]) {
         const DATA: &[u8] = &[42; 300];
-        let res1 = <T as Mac>::new(GenericArray::from_slice(key))
+        let res1 = T::new(Array::ref_from_slice(key))
             .chain_update(DATA)
             .finalize()
             .into_bytes();
-        let res2 = <T as Mac>::new_from_slice(key)
+        let res2 = T::new_from_slice(key)
             .unwrap()
             .chain_update(DATA)
             .finalize()

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -1,23 +1,24 @@
 [package]
 name = "fsb"
-version = "0.1.3"
+version = "0.2.0-pre"
 description = "FSB hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/fsb"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "fsb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
-whirlpool = { version = "0.10.1", path = "../whirlpool", default-features = false }
+digest = "=0.11.0-pre"
+whirlpool = { version = "=0.11.0-pre", path = "../whirlpool", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -10,14 +10,14 @@ documentation = "https://docs.rs/fsb"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "fsb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 whirlpool = { version = "=0.11.0-pre", path = "../whirlpool", default-features = false }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/fsb/README.md
+++ b/fsb/README.md
@@ -13,7 +13,7 @@ Pure Rust implementation of the [FSB hash function][1] family.
 
 ## Minimum Supported Rust Version
 
-Rust **1.41** or higher.
+Rust **1.65** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -47,7 +47,7 @@ dual licensed as above, without any additional terms or conditions.
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260041-hashes
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [build-image]: https://github.com/RustCrypto/hashes/workflows/fsb/badge.svg?branch=master
 [build-link]: https://github.com/RustCrypto/hashes/actions?query=workflow%3Afsb
 

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -10,13 +10,13 @@ documentation = "https://docs.rs/gost94"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "gost94", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "gost94"
-version = "0.10.4"
+version = "0.11.0-pre"
 description = "GOST R 34.11-94 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/gost94"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "gost94", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/gost94/src/lib.rs
+++ b/gost94/src/lib.rs
@@ -11,7 +11,7 @@
 //! // process input message
 //! hasher.update("The quick brown fox jumps over the lazy dog");
 //!
-//! // acquire hash digest in the form of GenericArray,
+//! // acquire hash digest in the form of Array,
 //! // which in this case is equivalent to [u8; 32]
 //! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -10,13 +10,13 @@ documentation = "https://docs.rs/groestl"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "groestl", "grostl", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "groestl"
-version = "0.10.1"
+version = "0.11.0-pre"
 description = "Grøstl hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/groestl"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "groestl", "grostl", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/groestl/src/lib.rs
+++ b/groestl/src/lib.rs
@@ -12,7 +12,7 @@
 //! // process input message
 //! hasher.update(b"my message");
 //!
-//! // acquire hash digest in the form of GenericArray,
+//! // acquire hash digest in the form of Array,
 //! // which in this case is equivalent to [u8; 32]
 //! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jh"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = "Pure Rust implementation of the JH cryptographic hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,9 +13,9 @@ keywords = ["crypto", "jh", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.10"
+digest = "=0.11.0-pre"
 hex-literal = "0.4"
 simd = { package = "ppv-lite86", version = "0.2.6" }
 
 [dev-dependencies]
-digest = { version = "0.10", features = ["dev"] }
+digest = { version = "=0.11.0-pre", features = ["dev"] }

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -5,7 +5,7 @@ description = "Pure Rust implementation of the JH cryptographic hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.71"
 readme = "README.md"
 documentation = "https://docs.rs/jh"
 repository = "https://github.com/RustCrypto/hashes"
@@ -13,9 +13,9 @@ keywords = ["crypto", "jh", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 hex-literal = "0.4"
 simd = { package = "ppv-lite86", version = "0.2.6" }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }

--- a/jh/src/compressor.rs
+++ b/jh/src/compressor.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals)]
 
 use core::ptr;
-use digest::generic_array::{typenum::U64, GenericArray};
+use digest::array::{typenum::U64, Array};
 use simd::{dispatch, vec128_storage, AndNot, Machine, Swap64, VZip, Vec2};
 
 #[rustfmt::skip]
@@ -167,7 +167,7 @@ impl Compressor {
     }
 
     #[inline]
-    pub(crate) fn update(&mut self, data: &GenericArray<u8, U64>) {
+    pub(crate) fn update(&mut self, data: &Array<u8, U64>) {
         f8(unsafe { &mut self.cv }, data.as_ptr());
     }
 

--- a/jh/src/lib.rs
+++ b/jh/src/lib.rs
@@ -55,7 +55,7 @@ use digest::{
         TruncSide, UpdateCore, VariableOutputCore,
     },
     crypto_common::{BlockSizeUser, OutputSizeUser},
-    generic_array::typenum::{Unsigned, U28, U32, U48, U64},
+    array::typenum::{Unsigned, U28, U32, U48, U64},
     HashMarker, InvalidOutputSize, Output,
 };
 

--- a/jh/src/lib.rs
+++ b/jh/src/lib.rs
@@ -49,13 +49,13 @@ pub use digest::{self, Digest};
 use crate::compressor::Compressor;
 use core::fmt;
 use digest::{
+    array::typenum::{Unsigned, U28, U32, U48, U64},
     block_buffer::Eager,
     core_api::{
         AlgorithmName, Block, Buffer, BufferKindUser, CoreWrapper, CtVariableCoreWrapper,
         TruncSide, UpdateCore, VariableOutputCore,
     },
     crypto_common::{BlockSizeUser, OutputSizeUser},
-    array::typenum::{Unsigned, U28, U32, U48, U64},
     HashMarker, InvalidOutputSize, Output,
 };
 

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k12"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = "Pure Rust implementation of the KangarooTwelve hash function"
 authors = ["RustCrypto Developers", "Diggory Hardy <github1@dhardy.name>"]
 license = "Apache-2.0 OR MIT"
@@ -10,20 +10,16 @@ documentation = "https://docs.rs/k12"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.56"
+rust-version = "1.65"
 
 [dependencies]
-digest = { version = "0.10.7", default-features = false, features = ["core-api"] }
-sha3 = { version = "0.10.8", default-features = false }
+digest = { version = "=0.11.0-pre", default-features = false, features = ["core-api"] }
+sha3 = { version = "=0.11.0-pre", default-features = false, path = "../sha3" }
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["alloc", "dev"] }
-hex-literal = "0.3"
+digest = { version = "=0.11.0-pre", features = ["alloc", "dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]
 std = ["digest/std"]
-
-# TODO: remove when crate will be part of the root workspace
-[profile.dev]
-opt-level = 2

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -10,14 +10,14 @@ documentation = "https://docs.rs/k12"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = { version = "=0.11.0-pre", default-features = false, features = ["core-api"] }
+digest = { version = "=0.11.0-pre.3", default-features = false, features = ["core-api"] }
 sha3 = { version = "=0.11.0-pre", default-features = false, path = "../sha3" }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["alloc", "dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["alloc", "dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -10,13 +10,13 @@ documentation = "https://docs.rs/md2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "md2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "md2"
-version = "0.10.2"
+version = "0.11.0-pre"
 license = "MIT OR Apache-2.0"
 authors = ["RustCrypto Developers"]
 description = "MD2 hash function"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/md2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "md2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/md2/src/lib.rs
+++ b/md2/src/lib.rs
@@ -12,7 +12,7 @@
 //! // process input message
 //! hasher.update(b"hello world");
 //!
-//! // acquire hash digest in the form of GenericArray,
+//! // acquire hash digest in the form of Array,
 //! // which in this case is equivalent to [u8; 16]
 //! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("d9cce882ee690a5c1ce70beff3a78c77"));
@@ -109,10 +109,10 @@ impl FixedOutputCore for Md2Core {
     fn finalize_fixed_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
         let pos = buffer.get_pos();
         let rem = buffer.remaining() as u8;
-        let block = buffer.pad_with_zeros();
+        let mut block = buffer.pad_with_zeros();
         block[pos..].iter_mut().for_each(|b| *b = rem);
 
-        self.compress(block);
+        self.compress(&block);
         let checksum = self.checksum;
         self.compress(&checksum);
         out.copy_from_slice(&self.x[0..16]);

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "md4"
-version = "0.10.2"
+version = "0.11.0-pre"
 description = "MD4 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/md4"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "md4", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -10,13 +10,13 @@ documentation = "https://docs.rs/md4"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "md4", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/md4/src/lib.rs
+++ b/md4/src/lib.rs
@@ -12,7 +12,7 @@
 //! // process input message
 //! hasher.update(b"hello world");
 //!
-//! // acquire hash digest in the form of GenericArray,
+//! // acquire hash digest in the form of Array,
 //! // which in this case is equivalent to [u8; 16]
 //! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("aa010fbc1d14c795d86ef98c95479d17"));

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -10,20 +10,20 @@ documentation = "https://docs.rs/md-5"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "md5", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [lib]
 name = "md5"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 cfg-if = "1"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 md5-asm = { version = "0.5", optional = true }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,29 +1,30 @@
 [package]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0-pre"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/md-5"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "md5", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [lib]
 name = "md5"
 
 [dependencies]
-digest = "0.10.7"
-cfg-if = "1.0"
+digest = "=0.11.0-pre"
+cfg-if = "1"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 md5-asm = { version = "0.5", optional = true }
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -12,7 +12,7 @@
 //! // process input message
 //! hasher.update(b"hello world");
 //!
-//! // acquire hash digest in the form of GenericArray,
+//! // acquire hash digest in the form of Array,
 //! // which in this case is equivalent to [u8; 16]
 //! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("5eb63bbbe01eeed093cb22bb8f5acdc3"));
@@ -137,7 +137,7 @@ const BLOCK_SIZE: usize = <Md5Core as BlockSizeUser>::BlockSize::USIZE;
 
 #[inline(always)]
 fn convert(blocks: &[Block<Md5Core>]) -> &[[u8; BLOCK_SIZE]] {
-    // SAFETY: GenericArray<u8, U64> and [u8; 64] have
+    // SAFETY: Array<u8, U64> and [u8; 64] have
     // exactly the same memory layout
     let p = blocks.as_ptr() as *const [u8; BLOCK_SIZE];
     unsafe { core::slice::from_raw_parts(p, blocks.len()) }

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -10,13 +10,13 @@ documentation = "https://docs.rs/ripemd"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "ripemd", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "ripemd"
-version = "0.1.3"
+version = "0.2.0-pre"
 description = "Pure Rust implementation of the RIPEMD hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/ripemd"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "ripemd", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/ripemd/src/lib.rs
+++ b/ripemd/src/lib.rs
@@ -18,7 +18,7 @@
 //! // process input message
 //! hasher.update(b"Hello world!");
 //!
-//! // acquire hash digest in the form of GenericArray,
+//! // acquire hash digest in the form of Array,
 //! // which in this case is equivalent to [u8; 20]
 //! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("7f772647d88750add82d8e1a7a3e5c0902a346a3"));

--- a/ripemd/tests/mod.rs
+++ b/ripemd/tests/mod.rs
@@ -18,10 +18,7 @@ fn ripemd128_1mil_a() {
     for _ in 0..1000 {
         h.update(&buf[..]);
     }
-    assert_eq!(
-        h.finalize(),
-        hex!("4a7f5723f954eba1216c9d8f6320431f").into()
-    );
+    assert_eq!(h.finalize(), hex!("4a7f5723f954eba1216c9d8f6320431f"));
 }
 
 #[test]
@@ -43,7 +40,7 @@ fn ripemd160_1mil_a() {
     }
     assert_eq!(
         h.finalize(),
-        hex!("52783243c1697bdbe16d37f97f68f08325dc1528").into()
+        hex!("52783243c1697bdbe16d37f97f68f08325dc1528")
     );
 }
 
@@ -66,7 +63,7 @@ fn ripemd256_1mil_a() {
     }
     assert_eq!(
         h.finalize(),
-        hex!("ac953744e10e31514c150d4d8d7b677342e33399788296e43ae4850ce4f97978").into()
+        hex!("ac953744e10e31514c150d4d8d7b677342e33399788296e43ae4850ce4f97978")
     );
 }
 
@@ -93,7 +90,7 @@ fn ripemd320_1mil_a() {
         hex!("
             bdee37f4371e20646b8b0d862dda16292ae36f40
             965e8c8509e63d1dbddecc503e2b63eb9245bb66
-        ").into()
+        ")
     );
 }
 

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0-pre"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/sha1"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha1", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 cfg-if = "1.0"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))'.dependencies]
@@ -20,8 +21,8 @@ cpufeatures = "0.2"
 sha1-asm = { version = "0.5", optional = true }
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -10,10 +10,10 @@ documentation = "https://docs.rs/sha1"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha1", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 cfg-if = "1.0"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))'.dependencies]
@@ -21,7 +21,7 @@ cpufeatures = "0.2"
 sha1-asm = { version = "0.5", optional = true }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/sha1/src/compress.rs
+++ b/sha1/src/compress.rs
@@ -32,7 +32,7 @@ const BLOCK_SIZE: usize = <Sha1Core as BlockSizeUser>::BlockSize::USIZE;
 /// SHA-1 compression function
 #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
 pub fn compress(state: &mut [u32; 5], blocks: &[Block<Sha1Core>]) {
-    // SAFETY: GenericArray<u8, U64> and [u8; 64] have
+    // SAFETY: Array<u8, U64> and [u8; 64] have
     // exactly the same memory layout
     let blocks: &[[u8; BLOCK_SIZE]] =
         unsafe { &*(blocks as *const _ as *const [[u8; BLOCK_SIZE]]) };

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -33,7 +33,7 @@
 //! // process input message
 //! hasher.update(b"hello world");
 //!
-//! // acquire hash digest in the form of GenericArray,
+//! // acquire hash digest in the form of Array,
 //! // which in this case is equivalent to [u8; 20]
 //! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"));

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -13,10 +13,10 @@ documentation = "https://docs.rs/sha2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 cfg-if = "1"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
@@ -24,17 +24,15 @@ cpufeatures = "0.2"
 sha2-asm = { version = "0.6.1", optional = true }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
 default = ["std"]
 std = ["digest/std"]
-oid = ["digest/oid"] # Enable OID support. WARNING: Bumps MSRV to 1.57
+oid = ["digest/oid"] # Enable OID support.
 asm = ["sha2-asm"] # WARNING: this feature SHOULD NOT be enabled by library crates
-# Use assembly backend for LoongArch64 targets
-# WARNING: Bumps MSRV to 1.72. This feature SHOULD NOT be enabled by library crates
-loongarch64_asm = []
+loongarch64_asm = [] # WARNING: this feature SHOULD NOT be enabled by library crates
 compress = [] # Expose compress functions
 force-soft = [] # Force software implementation
 asm-aarch64 = ["asm"] # DEPRECATED: use `asm` instead

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0-pre"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.
@@ -8,23 +8,24 @@ including SHA-224, SHA-256, SHA-384, and SHA-512.
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/sha2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
-cfg-if = "1.0"
+digest = "=0.11.0-pre"
+cfg-if = "1"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
 sha2-asm = { version = "0.6.1", optional = true }
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -1,4 +1,4 @@
-use digest::{generic_array::GenericArray, typenum::U64};
+use digest::{array::Array, typenum::U64};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "force-soft")] {
@@ -31,8 +31,8 @@ cfg_if::cfg_if! {
 /// This is a low-level "hazmat" API which provides direct access to the core
 /// functionality of SHA-256.
 #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
-pub fn compress256(state: &mut [u32; 8], blocks: &[GenericArray<u8, U64>]) {
-    // SAFETY: GenericArray<u8, U64> and [u8; 64] have
+pub fn compress256(state: &mut [u32; 8], blocks: &[Array<u8, U64>]) {
+    // SAFETY: Array<u8, U64> and [u8; 64] have
     // exactly the same memory layout
     let p = blocks.as_ptr() as *const [u8; 64];
     let blocks = unsafe { core::slice::from_raw_parts(p, blocks.len()) };

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -1,4 +1,4 @@
-use digest::{generic_array::GenericArray, typenum::U128};
+use digest::{array::Array, typenum::U128};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "force-soft")] {
@@ -33,8 +33,8 @@ cfg_if::cfg_if! {
 /// This is a low-level "hazmat" API which provides direct access to the core
 /// functionality of SHA-512.
 #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
-pub fn compress512(state: &mut [u64; 8], blocks: &[GenericArray<u8, U128>]) {
-    // SAFETY: GenericArray<u8, U64> and [u8; 64] have
+pub fn compress512(state: &mut [u64; 8], blocks: &[Array<u8, U128>]) {
+    // SAFETY: Array<u8, U64> and [u8; 64] have
     // exactly the same memory layout
     let p = blocks.as_ptr() as *const [u8; 128];
     let blocks = unsafe { core::slice::from_raw_parts(p, blocks.len()) };

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -14,15 +14,15 @@ documentation = "https://docs.rs/sha3"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha3", "keccak", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 keccak = "0.1.4"
 zeroize = { version = "1.6.0", default-features = false, optional=true } # WARNING: Bumps MSRV to 1.56
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.10.8"
+version = "0.11.0-pre"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as
@@ -9,20 +9,21 @@ the accelerated variant TurboSHAKE
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/sha3"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha3", "keccak", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 keccak = "0.1.4"
 zeroize = { version = "1.6.0", default-features = false, optional=true } # WARNING: Bumps MSRV to 1.56
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -72,6 +72,7 @@ use core::fmt;
 #[cfg(feature = "oid")]
 use digest::const_oid::{AssociatedOid, ObjectIdentifier};
 use digest::{
+    array::typenum::Unsigned,
     block_buffer::Eager,
     consts::{U104, U136, U144, U168, U200, U28, U32, U48, U64, U72},
     core_api::{
@@ -79,7 +80,6 @@ use digest::{
         ExtendableOutputCore, FixedOutputCore, OutputSizeUser, Reset, UpdateCore, XofReaderCore,
         XofReaderCoreWrapper,
     },
-    array::typenum::Unsigned,
     HashMarker, Output,
 };
 

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -79,7 +79,7 @@ use digest::{
         ExtendableOutputCore, FixedOutputCore, OutputSizeUser, Reset, UpdateCore, XofReaderCore,
         XofReaderCoreWrapper,
     },
-    generic_array::typenum::Unsigned,
+    array::typenum::Unsigned,
     HashMarker, Output,
 };
 

--- a/sha3/src/macros.rs
+++ b/sha3/src/macros.rs
@@ -39,12 +39,12 @@ macro_rules! impl_sha3 {
             #[inline]
             fn finalize_fixed_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
                 let pos = buffer.get_pos();
-                let block = buffer.pad_with_zeros();
+                let mut block = buffer.pad_with_zeros();
                 block[pos] = $pad;
                 let n = block.len();
                 block[n - 1] |= 0x80;
 
-                self.state.absorb_block(block);
+                self.state.absorb_block(&block);
 
                 self.state.as_bytes(out);
             }
@@ -135,12 +135,12 @@ macro_rules! impl_shake {
             #[inline]
             fn finalize_xof_core(&mut self, buffer: &mut Buffer<Self>) -> Self::ReaderCore {
                 let pos = buffer.get_pos();
-                let block = buffer.pad_with_zeros();
+                let mut block = buffer.pad_with_zeros();
                 block[pos] = $pad;
                 let n = block.len();
                 block[n - 1] |= 0x80;
 
-                self.state.absorb_block(block);
+                self.state.absorb_block(&block);
                 $reader {
                     state: self.state.clone(),
                 }
@@ -281,12 +281,12 @@ macro_rules! impl_turbo_shake {
             #[inline]
             fn finalize_xof_core(&mut self, buffer: &mut Buffer<Self>) -> Self::ReaderCore {
                 let pos = buffer.get_pos();
-                let block = buffer.pad_with_zeros();
+                let mut block = buffer.pad_with_zeros();
                 block[pos] = self.domain_separation;
                 let n = block.len();
                 block[n - 1] |= 0x80;
 
-                self.state.absorb_block(block);
+                self.state.absorb_block(&block);
                 $reader {
                     state: self.state.clone(),
                 }
@@ -424,10 +424,10 @@ macro_rules! impl_cshake {
                 );
                 buffer.digest_blocks(customization, |blocks| {
                     for block in blocks {
-                        state.absorb_block(block);
+                        state.absorb_block(&block);
                     }
                 });
-                state.absorb_block(buffer.pad_with_zeros());
+                state.absorb_block(&buffer.pad_with_zeros());
 
                 Self {
                     padding: $cshake_pad,
@@ -463,12 +463,12 @@ macro_rules! impl_cshake {
             #[inline]
             fn finalize_xof_core(&mut self, buffer: &mut Buffer<Self>) -> Self::ReaderCore {
                 let pos = buffer.get_pos();
-                let block = buffer.pad_with_zeros();
+                let mut block = buffer.pad_with_zeros();
                 block[pos] = self.padding;
                 let n = block.len();
                 block[n - 1] |= 0x80;
 
-                self.state.absorb_block(block);
+                self.state.absorb_block(&block);
                 $reader {
                     state: self.state.clone(),
                 }

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "shabal"
-version = "0.4.1"
+version = "0.5.0-pre"
 description = "Shabal hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/shabal"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "shabal", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -10,13 +10,13 @@ documentation = "https://docs.rs/shabal"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "shabal", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/shabal/src/core_api.rs
+++ b/shabal/src/core_api.rs
@@ -1,18 +1,18 @@
 use crate::consts;
 use core::{convert::TryInto, fmt, mem, num::Wrapping};
 use digest::{
+    array::Array,
     block_buffer::Eager,
     consts::U64,
     core_api::{
         AlgorithmName, BlockSizeUser, Buffer, BufferKindUser, OutputSizeUser, TruncSide,
         UpdateCore, VariableOutputCore,
     },
-    generic_array::GenericArray,
     HashMarker, InvalidOutputSize, Output,
 };
 
 type BlockSize = U64;
-type Block = GenericArray<u8, BlockSize>;
+type Block = Array<u8, BlockSize>;
 type M = [Wrapping<u32>; 16];
 
 /// Inner state of Shabal hash functions.
@@ -216,10 +216,10 @@ impl VariableOutputCore for ShabalVarCore {
     #[inline]
     fn finalize_variable_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
         let pos = buffer.get_pos();
-        let block = buffer.pad_with_zeros();
+        let mut block = buffer.pad_with_zeros();
         block[pos] = 0x80;
 
-        let m = read_m(block);
+        let m = read_m(&block);
         self.add_m(&m);
         self.xor_w();
         self.perm(&m);

--- a/shabal/src/lib.rs
+++ b/shabal/src/lib.rs
@@ -23,7 +23,7 @@
 //! // process input message
 //! hasher.update(b"helloworld");
 //!
-//! // acquire hash digest in the form of GenericArray,
+//! // acquire hash digest in the form of Array,
 //! // which in this case is equivalent to [u8; 32]
 //! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -5,7 +5,7 @@ description = "Skein hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.71"
 readme = "README.md"
 documentation = "https://docs.rs/skein"
 repository = "https://github.com/RustCrypto/hashes"
@@ -13,9 +13,9 @@ keywords = ["crypto", "skein", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 threefish = { version = "0.5.2", default-features = false }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "skein"
-version = "0.1.0"
+version = "0.2.0-pre"
 description = "Skein hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.65"
 readme = "README.md"
 documentation = "https://docs.rs/skein"
 repository = "https://github.com/RustCrypto/hashes"
@@ -13,9 +13,9 @@ keywords = ["crypto", "skein", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.10"
+digest = "=0.11.0-pre"
 threefish = { version = "0.5.2", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.10", features = ["dev"] }
+digest = { version = "=0.11.0-pre", features = ["dev"] }
 hex-literal = "0.4"

--- a/skein/benches/skein1024.rs
+++ b/skein/benches/skein1024.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 extern crate test;
 
-use digest::{bench_update, array::typenum::U128};
+use digest::{array::typenum::U128, bench_update};
 use skein::Skein1024;
 use test::Bencher;
 

--- a/skein/benches/skein1024.rs
+++ b/skein/benches/skein1024.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 extern crate test;
 
-use digest::{bench_update, generic_array::typenum::U128};
+use digest::{bench_update, array::typenum::U128};
 use skein::Skein1024;
 use test::Bencher;
 

--- a/skein/benches/skein256.rs
+++ b/skein/benches/skein256.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 extern crate test;
 
-use digest::{bench_update, array::typenum::U32};
+use digest::{array::typenum::U32, bench_update};
 use skein::Skein256;
 use test::Bencher;
 

--- a/skein/benches/skein256.rs
+++ b/skein/benches/skein256.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 extern crate test;
 
-use digest::{bench_update, generic_array::typenum::U32};
+use digest::{bench_update, array::typenum::U32};
 use skein::Skein256;
 use test::Bencher;
 

--- a/skein/benches/skein512.rs
+++ b/skein/benches/skein512.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 extern crate test;
 
-use digest::{bench_update, array::typenum::U64};
+use digest::{array::typenum::U64, bench_update};
 use skein::Skein512;
 use test::Bencher;
 

--- a/skein/benches/skein512.rs
+++ b/skein/benches/skein512.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 extern crate test;
 
-use digest::{bench_update, generic_array::typenum::U64};
+use digest::{bench_update, array::typenum::U64};
 use skein::Skein512;
 use test::Bencher;
 

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -10,13 +10,13 @@ documentation = "https://docs.rs/sm3"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sm3", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "sm3"
-version = "0.4.2"
+version = "0.5.0-pre"
 description = "SM3 (OSCCA GM/T 0004-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/sm3"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sm3", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -10,13 +10,13 @@ documentation = "https://docs.rs/streebog"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "streebog", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "streebog"
-version = "0.10.2"
+version = "0.11.0-pre"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/streebog"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "streebog", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/streebog/src/core_api.rs
+++ b/streebog/src/core_api.rs
@@ -140,7 +140,7 @@ impl VariableOutputCore for StreebogVarCore {
     #[inline]
     fn finalize_variable_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
         let pos = buffer.get_pos();
-        let block = buffer.pad_with_zeros();
+        let mut block = buffer.pad_with_zeros();
         block[pos] = 1;
         self.compress(block.as_ref(), pos as u64);
         self.g(&[0u8; 64], &to_bytes(&self.n));

--- a/tiger/Cargo.toml
+++ b/tiger/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "tiger"
-version = "0.2.1"
+version = "0.3.0-pre"
 description = "Tiger hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/tiger"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "hash", "tiger", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/tiger/Cargo.toml
+++ b/tiger/Cargo.toml
@@ -10,13 +10,13 @@ documentation = "https://docs.rs/tiger"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "hash", "tiger", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/tiger/src/lib.rs
+++ b/tiger/src/lib.rs
@@ -14,7 +14,7 @@
 //! // process input message
 //! hasher.update(b"hello world");
 //!
-//! // acquire hash digest in the form of GenericArray,
+//! // acquire hash digest in the form of Array,
 //! // which in this case is equivalent to [u8; 24]
 //! let result = hasher.finalize();
 //! assert_eq!(result[..], hex!("4c8fbddae0b6f25832af45e7c62811bb64ec3e43691e9cc3"));

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -10,16 +10,16 @@ documentation = "https://docs.rs/whirlpool"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "whirlpool", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.65"
+rust-version = "1.71"
 
 [dependencies]
-digest = "=0.11.0-pre"
+digest = "=0.11.0-pre.3"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 whirlpool-asm = { version = "0.6", optional = true}
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre", features = ["dev"] }
+digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,25 +1,26 @@
 [package]
 name = "whirlpool"
-version = "0.10.4"
+version = "0.11.0-pre"
 description = "Whirlpool hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/whirlpool"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "whirlpool", "hash", "digest"]
 categories = ["cryptography", "no-std"]
+rust-version = "1.65"
 
 [dependencies]
-digest = "0.10.7"
+digest = "=0.11.0-pre"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 whirlpool-asm = { version = "0.6", optional = true}
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
-hex-literal = "0.2.2"
+digest = { version = "=0.11.0-pre", features = ["dev"] }
+hex-literal = "0.4"
 
 [features]
 default = ["std"]

--- a/whirlpool/src/lib.rs
+++ b/whirlpool/src/lib.rs
@@ -170,7 +170,7 @@ const BLOCK_SIZE: usize = <WhirlpoolCore as BlockSizeUser>::BlockSize::USIZE;
 
 #[inline(always)]
 fn convert(blocks: &[Block<WhirlpoolCore>]) -> &[[u8; BLOCK_SIZE]] {
-    // SAFETY: GenericArray<u8, U64> and [u8; 64] have
+    // SAFETY: Array<u8, U64> and [u8; 64] have
     // exactly the same memory layout
     let p = blocks.as_ptr() as *const [u8; BLOCK_SIZE];
     unsafe { core::slice::from_raw_parts(p, blocks.len()) }


### PR DESCRIPTION
Also bumps crate editions to 2021 where appropriate