### PR TITLE
Enable `oid` feature by default

### DIFF
--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -21,6 +21,6 @@ digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
-default = ["std"]
+default = ["oid", "std"]
 std = ["digest/std"]
 oid = ["digest/oid"]

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -20,6 +20,6 @@ digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
-default = ["std"]
+default = ["oid", "std"]
 std = ["digest/std"]
-oid = ["digest/oid"] # Enable OID support. WARNING: Bumps MSRV to 1.57
+oid = ["digest/oid"]

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -20,6 +20,6 @@ digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
-default = ["std"]
+default = ["oid", "std"]
 std = ["digest/std"]
 oid = ["digest/oid"]

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -20,6 +20,6 @@ digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
-default = ["std"]
+default = ["oid", "std"]
 std = ["digest/std"]
-oid = ["digest/oid"] # Enable OID support. WARNING: Bumps MSRV to 1.57
+oid = ["digest/oid"]

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -27,11 +27,11 @@ digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
-default = ["std"]
+default = ["oid", "std"]
 std = ["digest/std"]
 asm = ["md5-asm"] # WARNING: this feature SHOULD NOT be enabled by library crates
 # Use assembly backend for LoongArch64 targets
 # WARNING: Bumps MSRV to 1.72. This feature SHOULD NOT be enabled by library crates
 loongarch64_asm = []
-oid = ["digest/oid"] # Enable OID support. WARNING: Bumps MSRV to 1.57
+oid = ["digest/oid"] # Enable OID support.
 force-soft = [] # Force software implementation

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -20,6 +20,6 @@ digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
-default = ["std"]
+default = ["oid", "std"]
 std = ["digest/std"]
-oid = ["digest/oid"] # Enable OID support. WARNING: Bumps MSRV to 1.57
+oid = ["digest/oid"]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -25,9 +25,9 @@ digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
-default = ["std"]
+default = ["oid", "std"]
 std = ["digest/std"]
-oid = ["digest/oid"] # Enable OID support. WARNING: Bumps MSRV to 1.57
+oid = ["digest/oid"] # Enable OID support.
 asm = ["sha1-asm"] # WARNING: this feature SHOULD NOT be enabled by library crates
 # Use assembly backend for LoongArch64 targets
 # WARNING: Bumps MSRV to 1.72. This feature SHOULD NOT be enabled by library crates

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -28,7 +28,7 @@ digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
-default = ["std"]
+default = ["oid", "std"]
 std = ["digest/std"]
 oid = ["digest/oid"] # Enable OID support.
 asm = ["sha2-asm"] # WARNING: this feature SHOULD NOT be enabled by library crates

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -26,9 +26,9 @@ digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
-default = ["std"]
+default = ["oid", "std"]
 std = ["digest/std"]
 
-asm = ["keccak/asm"] # Enable ASM (currently ARMv8 only). WARNING: Bumps MSRV to 1.59
-oid = ["digest/oid"] # Enable OID support. WARNING: Bumps MSRV to 1.57
+asm = ["keccak/asm"] # Enable ASM (currently ARMv8 only).
+oid = ["digest/oid"] # Enable OID support.
 reset = [] # Enable reset functionality

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -20,6 +20,6 @@ digest = { version = "=0.11.0-pre.3", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]
-default = ["std"]
+default = ["oid", "std"]
 std = ["digest/std"]
-oid = ["digest/oid"] # Enable OID support. WARNING: Bumps MSRV to 1.57
+oid = ["digest/oid"]


### PR DESCRIPTION
Having to enable this feature has been an ongoing source of confusion, especially since the compiler error that results is fairly inscrutible.