### PR TITLE
Cut pre.1 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-pre.0"
+version = "0.2.0-pre.1"
 dependencies = [
  "belt-block",
  "digest",
@@ -206,7 +206,7 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 dependencies = [
  "cfg-if",
  "digest",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 dependencies = [
  "digest",
  "hex-literal",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-pre.0"
+version = "0.5.0-pre.1"
 dependencies = [
  "digest",
  "hex-literal",
@@ -345,7 +345,7 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 
 [[package]]
 name = "streebog"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 dependencies = [
  "digest",
  "hex-literal",

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-hash"
-version = "0.2.0-pre.0"
+version = "0.2.0-pre.1"
 description = "BelT hash function (STB 34.101.31-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.71"
 
 [dependencies]
 digest = { version = "=0.11.0-pre.4", default-features = false, features = ["core-api"] }
-sha3 = { version = "=0.11.0-pre.0", default-features = false, path = "../sha3" }
+sha3 = { version = "=0.11.0-pre.1", default-features = false, path = "../sha3" }
 
 [dev-dependencies]
 digest = { version = "=0.11.0-pre.4", features = ["alloc", "dev"] }

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm3"
-version = "0.5.0-pre.0"
+version = "0.5.0-pre.1"
 description = "SM3 (OSCCA GM/T 0004-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.11.0-pre.0"
+version = "0.11.0-pre.1"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts a new release of every crate which previously received a pre.0 prerelease, i.e. is used as a (dev-)dependency in downstream projects that need to be upgraded.

This includes the following:

- `belt-hash` v0.2.0-pre.1
- `md-5` v0.11.0-pre.1
- `sha1` v0.11.0-pre.1
- `sha2` v0.11.0-pre.1
- `sha3` v0.11.0-pre.1
- `sm3` v0.5.0-pre.1
- `streebog` v0.11.0-pre.1