### PR TITLE
Remove dependency on crates from asm-hashes

### DIFF
--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -24,7 +24,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.71.0
+        msrv: 1.72.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -37,6 +37,7 @@ jobs:
         target:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
+          - loongarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
@@ -45,7 +46,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --each-feature --exclude-features default,std,asm
+      - run: cargo hack build --target ${{ matrix.target }} --each-feature --exclude-features default,std
 
   test:
     needs: set-msrv
@@ -63,18 +64,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack test --feature-powerset
-
-  # Build-only test of the LoongArch64 assembly backend
-  loongarch64_asm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.72
-          targets: loongarch64-unknown-linux-gnu
-      - run: cargo build --target loongarch64-unknown-linux-gnu --features loongarch64_asm
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -35,6 +35,7 @@ jobs:
         target:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
+          - loongarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
@@ -43,7 +44,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --each-feature --exclude-features default,std,asm
+      - run: cargo hack build --target ${{ matrix.target }} --each-feature --exclude-features default,std
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
@@ -57,8 +58,6 @@ jobs:
       matrix:
         include:
           # 32-bit Linux/x86
-          # *** NOTE: Currently broken with `asm` feature enabled! See:
-          #     https://github.com/RustCrypto/hashes/issues/251
           #- target: i686-unknown-linux-gnu
           #  rust: ${{needs.set-msrv.outputs.msrv}}
           #  deps: sudo apt update && sudo apt install gcc-multilib
@@ -103,7 +102,6 @@ jobs:
           targets: x86_64-apple-darwin
       - run: cargo test --no-default-features
       - run: cargo test
-      - run: cargo test --features asm
       - run: cargo test --all-features
 
   # Windows tests
@@ -129,36 +127,18 @@ jobs:
       - uses: msys2/setup-msys2@v2
       - run: cargo test --target ${{ matrix.target }}
 
-  # Build-only test of the LoongArch64 assembly backend
-  loongarch64_asm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.72
-          targets: loongarch64-unknown-linux-gnu
-      - run: cargo build --target loongarch64-unknown-linux-gnu --features loongarch64_asm
-
   # Cross-compiled tests
   cross:
     strategy:
       matrix:
         rust:
-          - 1.71.0
+          - 1.72.0
           - stable
         target:
           - aarch64-unknown-linux-gnu
           - powerpc-unknown-linux-gnu
         features:
           - default
-  # **** NOTE: Currently broken with `asm` feature enabled! See:
-  #      https://github.com/RustCrypto/hashes/issues/251
-  #      include:
-  #          - rust: stable
-  #            target: aarch64-unknown-linux-gnu
-  #            features: asm
 
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.71.0
+        msrv: 1.72.0
 
   # Builds for no_std platforms
   build:

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.71.0
+        msrv: 1.72.0
 
   # Builds for no_std platforms
   build:

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -30,11 +30,12 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.71.0
+          - ${{needs.set-msrv.outputs.msrv}}
           - stable
         target:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
+          - loongarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
@@ -43,7 +44,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --each-feature --exclude-features default,std,asm-aarch64,asm
+      - run: cargo hack build --target ${{ matrix.target }} --each-feature --exclude-features default,std
 
   # Linux tests
   linux:
@@ -74,7 +75,7 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: ${{ matrix.deps }}
-      - run: cargo hack test --feature-powerset --exclude-features asm-aarch64
+      - run: cargo hack test --feature-powerset
 
   # macOS tests
   macos:
@@ -95,7 +96,6 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo test --no-default-features
       - run: cargo test
-      - run: cargo test --features asm
       - run: cargo test --all-features
 
   # Windows tests
@@ -119,18 +119,6 @@ jobs:
       - uses: msys2/setup-msys2@v2
       - run: cargo test --target ${{ matrix.target }}
 
-  # Build-only test of the LoongArch64 assembly backend
-  loongarch64_asm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.72
-          targets: loongarch64-unknown-linux-gnu
-      - run: cargo build --target loongarch64-unknown-linux-gnu --features loongarch64_asm
-
   # Cross-compiled tests
   cross:
     needs: set-msrv
@@ -144,10 +132,6 @@ jobs:
           - powerpc-unknown-linux-gnu
         features:
           - default
-        include:
-            - rust: stable
-              target: aarch64-unknown-linux-gnu
-              features: asm
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/whirlpool.yml
+++ b/.github/workflows/whirlpool.yml
@@ -42,7 +42,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack build --target ${{ matrix.target }} --each-feature --exclude-features default,std,asm
+      - run: cargo hack build --target ${{ matrix.target }} --each-feature --exclude-features default,std
 
   test:
     needs: set-msrv
@@ -59,19 +59,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
-      - run: cargo hack test --feature-powerset --exclude-features asm
+      - run: cargo hack test --feature-powerset
 
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  test-asm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable # cc has a relaxed MSRV policy
-      - run: cargo test --features asm

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.71.0
+          toolchain: 1.75.0
           components: clippy
       - run: cargo clippy --all -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,15 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,7 +202,6 @@ dependencies = [
  "cfg-if",
  "digest",
  "hex-literal",
- "md5-asm",
 ]
 
 [[package]]
@@ -228,15 +218,6 @@ version = "0.11.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
-]
-
-[[package]]
-name = "md5-asm"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d33bc4cdfe5c60340e282bbbee0a6e2bc57f0b9279bb3489c5004d12492e5c"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -270,16 +251,6 @@ dependencies = [
  "cpufeatures",
  "digest",
  "hex-literal",
- "sha1-asm",
-]
-
-[[package]]
-name = "sha1-asm"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba6947745e7f86be3b8af00b7355857085dbdf8901393c89514510eb61f4e21"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -290,16 +261,6 @@ dependencies = [
  "cpufeatures",
  "digest",
  "hex-literal",
- "sha2-asm",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27ba7066011e3fb30d808b51affff34f0a66d3a03a58edd787c6e420e40e44e"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -389,16 +350,6 @@ version = "0.11.0-pre"
 dependencies = [
  "digest",
  "hex-literal",
- "whirlpool-asm",
-]
-
-[[package]]
-name = "whirlpool-asm"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fbc33555bb368a2758340583b26fc67822da6b1b829fd9a48cca1bad2e29fe"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Additionally all crates do not require the standard library (i.e. `no_std` capab
 | [KangarooTwelve] | [`k12`] | [![crates.io](https://img.shields.io/crates/v/k12.svg)](https://crates.io/crates/k12) | [![Documentation](https://docs.rs/k12/badge.svg)](https://docs.rs/k12) | ![MSRV 1.71][msrv-1.71] | :green_heart: |
 | [MD2] | [`md2`] | [![crates.io](https://img.shields.io/crates/v/md2.svg)](https://crates.io/crates/md2) | [![Documentation](https://docs.rs/md2/badge.svg)](https://docs.rs/md2) | ![MSRV 1.71][msrv-1.71] | :broken_heart: |
 | [MD4] | [`md4`] | [![crates.io](https://img.shields.io/crates/v/md4.svg)](https://crates.io/crates/md4) | [![Documentation](https://docs.rs/md4/badge.svg)](https://docs.rs/md4) | ![MSRV 1.71][msrv-1.71] | :broken_heart: |
-| [MD5] | [`md5`] [:exclamation:] | [![crates.io](https://img.shields.io/crates/v/md-5.svg)](https://crates.io/crates/md-5) | [![Documentation](https://docs.rs/md-5/badge.svg)](https://docs.rs/md-5) | ![MSRV 1.71][msrv-1.71] | :broken_heart: |
+| [MD5] | [`md5`] [:exclamation:] | [![crates.io](https://img.shields.io/crates/v/md-5.svg)](https://crates.io/crates/md-5) | [![Documentation](https://docs.rs/md-5/badge.svg)](https://docs.rs/md-5) | ![MSRV 1.72][msrv-1.72] | :broken_heart: |
 | [RIPEMD] | [`ripemd`] | [![crates.io](https://img.shields.io/crates/v/ripemd.svg)](https://crates.io/crates/ripemd) | [![Documentation](https://docs.rs/ripemd/badge.svg)](https://docs.rs/ripemd) | ![MSRV 1.71][msrv-1.71] | :green_heart: |
-| [SHA-1] | [`sha1`] | [![crates.io](https://img.shields.io/crates/v/sha1.svg)](https://crates.io/crates/sha1) | [![Documentation](https://docs.rs/sha1/badge.svg)](https://docs.rs/sha1) | ![MSRV 1.71][msrv-1.71] | :broken_heart: |
-| [SHA-2] | [`sha2`] | [![crates.io](https://img.shields.io/crates/v/sha2.svg)](https://crates.io/crates/sha2) | [![Documentation](https://docs.rs/sha2/badge.svg)](https://docs.rs/sha2) | ![MSRV 1.71][msrv-1.71] | :green_heart: |
+| [SHA-1] | [`sha1`] | [![crates.io](https://img.shields.io/crates/v/sha1.svg)](https://crates.io/crates/sha1) | [![Documentation](https://docs.rs/sha1/badge.svg)](https://docs.rs/sha1) | ![MSRV 1.72][msrv-1.72] | :broken_heart: |
+| [SHA-2] | [`sha2`] | [![crates.io](https://img.shields.io/crates/v/sha2.svg)](https://crates.io/crates/sha2) | [![Documentation](https://docs.rs/sha2/badge.svg)](https://docs.rs/sha2) | ![MSRV 1.72][msrv-1.72] | :green_heart: |
 | [SHA-3] (Keccak) | [`sha3`] | [![crates.io](https://img.shields.io/crates/v/sha3.svg)](https://crates.io/crates/sha3) | [![Documentation](https://docs.rs/sha3/badge.svg)](https://docs.rs/sha3) | ![MSRV 1.71][msrv-1.71] | :green_heart: |
 | [SHABAL] | [`shabal`] | [![crates.io](https://img.shields.io/crates/v/shabal.svg)](https://crates.io/crates/shabal) | [![Documentation](https://docs.rs/shabal/badge.svg)](https://docs.rs/shabal) | ![MSRV 1.71][msrv-1.71] | :green_heart: |
 | [Skein] | [`skein`] | [![crates.io](https://img.shields.io/crates/v/skein.svg)](https://crates.io/crates/skein) | [![Documentation](https://docs.rs/skein/badge.svg)](https://docs.rs/skein) | ![MSRV 1.71][msrv-1.71] | :green_heart: |
@@ -234,6 +234,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [deps-image]: https://deps.rs/repo/github/RustCrypto/hashes/status.svg
 [deps-link]: https://deps.rs/repo/github/RustCrypto/hashes
 [msrv-1.71]: https://img.shields.io/badge/rustc-1.71.0+-blue.svg
+[msrv-1.72]: https://img.shields.io/badge/rustc-1.72.0+-blue.svg
 
 [//]: # (crates)
 

--- a/md5/CHANGELOG.md
+++ b/md5/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Removed
+- `asm` and `loongarch64_asm` crate features [#542]
+
+[#542]: https://github.com/RustCrypto/hashes/pull/542
+
 ## 0.10.6 (2023-09-22)
 ### Added
 - `asm!`-based backend for LoongArch64 targets gated behind `loongarch64_asm` feature [#505]

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/md-5"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "md5", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.71"
+rust-version = "1.72"
 
 [lib]
 name = "md5"
@@ -19,9 +19,6 @@ name = "md5"
 digest = "=0.11.0-pre.4"
 cfg-if = "1"
 
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-md5-asm = { version = "0.5", optional = true }
-
 [dev-dependencies]
 digest = { version = "=0.11.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
@@ -29,9 +26,6 @@ hex-literal = "0.4"
 [features]
 default = ["oid", "std"]
 std = ["digest/std"]
-asm = ["md5-asm"] # WARNING: this feature SHOULD NOT be enabled by library crates
-# Use assembly backend for LoongArch64 targets
-# WARNING: Bumps MSRV to 1.72. This feature SHOULD NOT be enabled by library crates
-loongarch64_asm = []
 oid = ["digest/oid"] # Enable OID support.
+loongarch64_asm = [] # Use assembly backend for LoongArch64 targets
 force-soft = [] # Force software implementation

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -26,6 +26,5 @@ hex-literal = "0.4"
 [features]
 default = ["oid", "std"]
 std = ["digest/std"]
-oid = ["digest/oid"] # Enable OID support.
-loongarch64_asm = [] # Use assembly backend for LoongArch64 targets
+oid = ["digest/oid"] # Enable OID support
 force-soft = [] # Force software implementation

--- a/md5/README.md
+++ b/md5/README.md
@@ -39,7 +39,7 @@ Also, see the [examples section] in the RustCrypto/hashes readme.
 
 ## Minimum Supported Rust Version
 
-Rust **1.71** or higher.
+Rust **1.72** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -71,7 +71,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/md-5/badge.svg
 [docs-link]: https://docs.rs/md-5/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260041-hashes
 [build-image]: https://github.com/RustCrypto/hashes/workflows/md5/badge.svg?branch=master

--- a/md5/src/compress.rs
+++ b/md5/src/compress.rs
@@ -2,8 +2,6 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "force-soft")] {
         mod soft;
         pub use soft::compress;
-    } else if #[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))] {
-        pub use md5_asm::compress;
     } else if #[cfg(all(feature = "loongarch64_asm", target_arch = "loongarch64"))] {
         mod loongarch64_asm;
         pub use loongarch64_asm::compress;

--- a/md5/src/compress.rs
+++ b/md5/src/compress.rs
@@ -2,7 +2,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "force-soft")] {
         mod soft;
         pub use soft::compress;
-    } else if #[cfg(all(feature = "loongarch64_asm", target_arch = "loongarch64"))] {
+    } else if #[cfg(target_arch = "loongarch64")] {
         mod loongarch64_asm;
         pub use loongarch64_asm::compress;
     } else {

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Removed
+- `asm`, `loongarch64_asm`, and `compress` crate features [#542]
+
+[#542]: https://github.com/RustCrypto/hashes/pull/542
+
 ## 0.10.6 (2023-09-21)
 ### Added
 - `asm!`-based backend for LoongArch64 targets gated behind `loongarch64_asm` feature [#504]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -26,8 +26,7 @@ hex-literal = "0.4"
 [features]
 default = ["oid", "std"]
 std = ["digest/std"]
-oid = ["digest/oid"] # Enable OID support.
-loongarch64_asm = [] # Use assembly backend for LoongArch64 targets
+oid = ["digest/oid"] # Enable OID support
 force-soft = [] # Force software implementation
 
 [package.metadata.docs.rs]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/sha1"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha1", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 digest = "=0.11.0-pre.4"
@@ -18,7 +18,6 @@ cfg-if = "1.0"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 cpufeatures = "0.2"
-sha1-asm = { version = "0.5", optional = true }
 
 [dev-dependencies]
 digest = { version = "=0.11.0-pre.4", features = ["dev"] }
@@ -28,11 +27,7 @@ hex-literal = "0.4"
 default = ["oid", "std"]
 std = ["digest/std"]
 oid = ["digest/oid"] # Enable OID support.
-asm = ["sha1-asm"] # WARNING: this feature SHOULD NOT be enabled by library crates
-# Use assembly backend for LoongArch64 targets
-# WARNING: Bumps MSRV to 1.72. This feature SHOULD NOT be enabled by library crates
-loongarch64_asm = []
-compress = [] # Expose compress function
+loongarch64_asm = [] # Use assembly backend for LoongArch64 targets
 force-soft = [] # Force software implementation
 
 [package.metadata.docs.rs]

--- a/sha1/README.md
+++ b/sha1/README.md
@@ -46,7 +46,7 @@ Also, see the [examples section] in the RustCrypto/hashes readme.
 
 ## Minimum Supported Rust Version
 
-Rust **1.71** or higher.
+Rust **1.72** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -78,7 +78,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/sha1/badge.svg
 [docs-link]: https://docs.rs/sha1/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260041-hashes
 [build-image]: https://github.com/RustCrypto/hashes/workflows/sha1/badge.svg?branch=master

--- a/sha1/src/compress.rs
+++ b/sha1/src/compress.rs
@@ -8,7 +8,7 @@ cfg_if::cfg_if! {
         mod soft;
         mod aarch64;
         use aarch64::compress as compress_inner;
-    } else if #[cfg(all(feature = "loongarch64_asm", target_arch = "loongarch64"))] {
+    } else if #[cfg(target_arch = "loongarch64")] {
         mod loongarch64_asm;
         use loongarch64_asm::compress as compress_inner;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {

--- a/sha1/src/compress.rs
+++ b/sha1/src/compress.rs
@@ -12,12 +12,7 @@ cfg_if::cfg_if! {
         mod loongarch64_asm;
         use loongarch64_asm::compress as compress_inner;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-        #[cfg(not(feature = "asm"))]
         mod soft;
-        #[cfg(feature = "asm")]
-        mod soft {
-            pub use sha1_asm::compress;
-        }
         mod x86;
         use x86::compress as compress_inner;
     } else {
@@ -27,7 +22,6 @@ cfg_if::cfg_if! {
 }
 
 /// SHA-1 compression function
-#[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
 pub fn compress(state: &mut [u32; 5], blocks: &[[u8; BLOCK_SIZE]]) {
     compress_inner(state, blocks);
 }

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -25,10 +25,7 @@ use digest::{
 
 mod compress;
 
-#[cfg(feature = "compress")]
 pub use compress::compress;
-#[cfg(not(feature = "compress"))]
-use compress::compress;
 
 const STATE_LEN: usize = 5;
 const BLOCK_SIZE: usize = <Sha1Core as BlockSizeUser>::BlockSize::USIZE;

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Removed
+- `asm`, `asm-aarch64`, `loongarch64_asm`, and `compress` crate features [#542]
+
+[#542]: https://github.com/RustCrypto/hashes/pull/542
+
 ## 0.10.8 (2023-09-26)
 ### Added
 - `asm!`-based backend for LoongArch64 targets gated behind `loongarch64_asm` feature [#507]

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -29,8 +29,7 @@ hex-literal = "0.4"
 [features]
 default = ["oid", "std"]
 std = ["digest/std"]
-oid = ["digest/oid"] # Enable OID support.
-loongarch64_asm = [] # WARNING: this feature SHOULD NOT be enabled by library crates
+oid = ["digest/oid"] # Enable OID support
 force-soft = [] # Force software implementation
 
 [package.metadata.docs.rs]

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sha2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.71"
+rust-version = "1.72"
 
 [dependencies]
 digest = "=0.11.0-pre.4"
@@ -21,7 +21,6 @@ cfg-if = "1"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
-sha2-asm = { version = "0.6.1", optional = true }
 
 [dev-dependencies]
 digest = { version = "=0.11.0-pre.4", features = ["dev"] }
@@ -31,11 +30,8 @@ hex-literal = "0.4"
 default = ["oid", "std"]
 std = ["digest/std"]
 oid = ["digest/oid"] # Enable OID support.
-asm = ["sha2-asm"] # WARNING: this feature SHOULD NOT be enabled by library crates
 loongarch64_asm = [] # WARNING: this feature SHOULD NOT be enabled by library crates
-compress = [] # Expose compress functions
 force-soft = [] # Force software implementation
-asm-aarch64 = ["asm"] # DEPRECATED: use `asm` instead
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sha2/README.md
+++ b/sha2/README.md
@@ -56,7 +56,7 @@ Also, see the [examples section] in the RustCrypto/hashes readme.
 
 ## Minimum Supported Rust Version
 
-Rust **1.71** or higher.
+Rust **1.72** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -88,7 +88,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/sha2/badge.svg
 [docs-link]: https://docs.rs/sha2/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.71+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260041-hashes
 [build-image]: https://github.com/RustCrypto/hashes/workflows/sha2/badge.svg?branch=master

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -23,9 +23,7 @@ mod core_api;
 mod sha256;
 mod sha512;
 
-#[cfg(feature = "compress")]
 pub use sha256::compress256;
-#[cfg(feature = "compress")]
 pub use sha512::compress512;
 
 pub use core_api::{Sha256VarCore, Sha512VarCore};

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -3,12 +3,7 @@ cfg_if::cfg_if! {
         mod soft;
         use soft::compress;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-        #[cfg(not(feature = "asm"))]
         mod soft;
-        #[cfg(feature = "asm")]
-        mod soft {
-            pub(crate) use sha2_asm::compress256 as compress;
-        }
         mod x86;
         use x86::compress;
     } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -10,7 +10,7 @@ cfg_if::cfg_if! {
         mod soft;
         mod aarch64;
         use aarch64::compress;
-    } else if #[cfg(all(feature = "loongarch64_asm", target_arch = "loongarch64"))] {
+    } else if #[cfg(target_arch = "loongarch64")] {
         mod loongarch64_asm;
         use loongarch64_asm::compress;
     } else {

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -10,7 +10,7 @@ cfg_if::cfg_if! {
         mod soft;
         mod aarch64;
         use aarch64::compress;
-    } else if #[cfg(all(feature = "loongarch64_asm", target_arch = "loongarch64"))] {
+    } else if #[cfg(target_arch = "loongarch64")] {
         mod loongarch64_asm;
         use loongarch64_asm::compress;
     } else {

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -3,14 +3,7 @@ cfg_if::cfg_if! {
         mod soft;
         use soft::compress;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-        #[cfg(not(feature = "asm"))]
         mod soft;
-        #[cfg(feature = "asm")]
-        mod soft {
-            pub(crate) fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
-                sha2_asm::compress512(state, blocks);
-            }
-        }
         mod x86;
         use x86::compress;
     } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {

--- a/whirlpool/CHANGELOG.md
+++ b/whirlpool/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Removed
+- `asm` crate feature [#542]
+
+[#542]: https://github.com/RustCrypto/hashes/pull/542
+
 ## 0.10.4 (2022-09-02)
 ### Fixed
 - MSRV issue which was not resolved by v0.10.3 ([#401])

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -15,9 +15,6 @@ rust-version = "1.71"
 [dependencies]
 digest = "=0.11.0-pre.4"
 
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-whirlpool-asm = { version = "0.6", optional = true}
-
 [dev-dependencies]
 digest = { version = "=0.11.0-pre.4", features = ["dev"] }
 hex-literal = "0.4"
@@ -25,4 +22,3 @@ hex-literal = "0.4"
 [features]
 default = ["std"]
 std = ["digest/std"]
-asm = ["whirlpool-asm"] # WARNING: this feature SHOULD NOT be enabled by library crates

--- a/whirlpool/src/compress.rs
+++ b/whirlpool/src/compress.rs
@@ -1,6 +1,4 @@
-#[path = "consts.rs"]
-mod consts;
-use consts::*;
+use crate::consts::*;
 
 fn compress_block(state: &mut [u64; 8], b: &[u8; 64]) {
     let mut k = [0u64; 8];

--- a/whirlpool/src/lib.rs
+++ b/whirlpool/src/lib.rs
@@ -9,14 +9,6 @@
 
 pub use digest::{self, Digest};
 
-#[cfg(not(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64"))))]
-mod compress;
-
-#[cfg(all(feature = "asm", any(target_arch = "x86", target_arch = "x86_64")))]
-use whirlpool_asm as compress;
-
-use compress::compress;
-
 use core::fmt;
 use digest::{
     array::ArrayOps,
@@ -28,6 +20,11 @@ use digest::{
     typenum::U64,
     HashMarker, Output,
 };
+
+mod compress;
+mod consts;
+
+use compress::compress;
 
 /// Core Whirlpool hasher state.
 #[derive(Clone)]


### PR DESCRIPTION
The asm-hashes backends can be a bit faster than the software backends, but they are a maintenance headache and have a bunch of issues like reliance on `cc` and limited cross-platforminess. I think we should eventually archive the asm-hashes repository. Users who desire the additional performance of asm-hashes may either help us to port the code on `asm!`, or stay on the v0.10 crate versions.

MSRV for some crates is bumped to 1.72 because of the Loongarch `asm!` backends, which are now enabled by default.