### PR TITLE
Updates to remove `hybrid_array::ArrayOps`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662b1e7b4a15dc889bf687cdd5dc4291b278ad0cf546424a87721dcb54ff1d82"
+checksum = "d8856b3db5eb76328f03589feb25c7a3166bfa0ae3b38b1408d546b097fa7947"
 dependencies = [
  "typenum",
 ]

--- a/md5/src/lib.rs
+++ b/md5/src/lib.rs
@@ -14,7 +14,7 @@ pub(crate) mod consts;
 
 use core::{fmt, slice::from_ref};
 use digest::{
-    array::ArrayOps,
+    array::Array,
     block_buffer::Eager,
     core_api::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, CoreWrapper, FixedOutputCore,
@@ -57,7 +57,7 @@ impl UpdateCore for Md5Core {
     #[inline]
     fn update_blocks(&mut self, blocks: &[Block<Self>]) {
         self.block_len = self.block_len.wrapping_add(blocks.len() as u64);
-        let blocks = ArrayOps::cast_slice_to_core(blocks);
+        let blocks = Array::cast_slice_to_core(blocks);
         compress::compress(&mut self.state, blocks)
     }
 }

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -11,7 +11,7 @@ pub use digest::{self, Digest};
 
 use core::{fmt, slice::from_ref};
 use digest::{
-    array::ArrayOps,
+    array::Array,
     block_buffer::Eager,
     core_api::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, CoreWrapper, FixedOutputCore,
@@ -61,7 +61,7 @@ impl UpdateCore for Sha1Core {
     #[inline]
     fn update_blocks(&mut self, blocks: &[Block<Self>]) {
         self.block_len += blocks.len() as u64;
-        let blocks = ArrayOps::cast_slice_to_core(blocks);
+        let blocks = Array::cast_slice_to_core(blocks);
         compress(&mut self.h, blocks);
     }
 }

--- a/sha2/src/core_api.rs
+++ b/sha2/src/core_api.rs
@@ -1,7 +1,7 @@
 use crate::{consts, sha256::compress256, sha512::compress512};
 use core::{fmt, slice::from_ref};
 use digest::{
-    array::ArrayOps,
+    array::Array,
     block_buffer::Eager,
     core_api::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, OutputSizeUser, TruncSide,
@@ -38,7 +38,7 @@ impl UpdateCore for Sha256VarCore {
     #[inline]
     fn update_blocks(&mut self, blocks: &[Block<Self>]) {
         self.block_len += blocks.len() as u64;
-        let blocks = ArrayOps::cast_slice_to_core(blocks);
+        let blocks = Array::cast_slice_to_core(blocks);
         compress256(&mut self.state, blocks);
     }
 }
@@ -124,7 +124,7 @@ impl UpdateCore for Sha512VarCore {
     #[inline]
     fn update_blocks(&mut self, blocks: &[Block<Self>]) {
         self.block_len += blocks.len() as u128;
-        let blocks = ArrayOps::cast_slice_to_core(blocks);
+        let blocks = Array::cast_slice_to_core(blocks);
         compress512(&mut self.state, blocks);
     }
 }

--- a/whirlpool/src/lib.rs
+++ b/whirlpool/src/lib.rs
@@ -12,7 +12,7 @@ pub use digest::{self, Digest};
 
 use core::fmt;
 use digest::{
-    array::ArrayOps,
+    array::Array,
     block_buffer::Eager,
     core_api::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, CoreWrapper, FixedOutputCore,
@@ -59,7 +59,7 @@ impl UpdateCore for WhirlpoolCore {
     fn update_blocks(&mut self, blocks: &[Block<Self>]) {
         let block_bits = 8 * Self::block_size() as u64;
         self.update_len(block_bits * (blocks.len() as u64));
-        let blocks = ArrayOps::cast_slice_to_core(blocks);
+        let blocks = Array::cast_slice_to_core(blocks);
         compress(&mut self.state, blocks);
     }
 }


### PR DESCRIPTION
This was a breaking change: RustCrypto/hybrid-array#30

This PR includes the necessary updates to remain compatible.