### PR TITLE
blake2 v0.11.0-pre.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-pre"
+version = "0.11.0-pre.3"
 dependencies = [
  "digest",
  "hex-literal",

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.11.0-pre"
+version = "0.11.0-pre.3"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Note that the first release is `pre.3` so as to sync versions with the other crates which have already received prereleases.

cc @baloo 