### PR TITLE
Support `no_unroll` for Ascon

### DIFF
--- a/ascon-hash/Cargo.toml
+++ b/ascon-hash/Cargo.toml
@@ -28,6 +28,7 @@ hex-literal = "0.4"
 default = ["std"]
 std = ["digest/std"]
 zeroize = ["ascon/zeroize", "digest/zeroize"]
+no_unroll = ["ascon/no_unroll"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This helps when used on resource constrained systems, e.g. MCUs, to keep the binary size small.