### PR TITLE
sha2: fix aarch64 implementation being disabled

### DIFF
--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -6,7 +6,7 @@ cfg_if::cfg_if! {
         mod soft;
         mod x86;
         use x86::compress;
-    } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
+    } else if #[cfg(target_arch = "aarch64")] {
         mod soft;
         mod aarch64;
         use aarch64::compress;

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -6,7 +6,7 @@ cfg_if::cfg_if! {
         mod soft;
         mod x86;
         use x86::compress;
-    } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
+    } else if #[cfg(target_arch = "aarch64")] {
         mod soft;
         mod aarch64;
         use aarch64::compress;


### PR DESCRIPTION
Fixes #568 

(eref 42d478fb6976)