### PR TITLE
sha2: use stabilized `core::arch::aarch64` intrinsics

### DIFF
--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - ${{needs.set-msrv.outputs.msrv}}
+          #- ${{needs.set-msrv.outputs.msrv}}
           - stable
         target:
           - aarch64-unknown-linux-gnu

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -1,6 +1,6 @@
 //! SHA-256 `aarch64` backend.
-
-// Implementation adapted from mbedtls.
+//!
+//! Implementation adapted from mbedtls.
 
 // TODO: stdarch intrinsics: RustCrypto/hashes#257
 
@@ -102,58 +102,4 @@ unsafe fn sha256_compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     // Store vectors into state.
     vst1q_u32(state[0..4].as_mut_ptr(), abcd);
     vst1q_u32(state[4..8].as_mut_ptr(), efgh);
-}
-
-// TODO remove these polyfills once SHA2 intrinsics land
-
-#[inline(always)]
-unsafe fn vsha256hq_u32(
-    mut hash_efgh: uint32x4_t,
-    hash_abcd: uint32x4_t,
-    wk: uint32x4_t,
-) -> uint32x4_t {
-    asm!(
-        "SHA256H {:q}, {:q}, {:v}.4S",
-        inout(vreg) hash_efgh, in(vreg) hash_abcd, in(vreg) wk,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    hash_efgh
-}
-
-#[inline(always)]
-unsafe fn vsha256h2q_u32(
-    mut hash_efgh: uint32x4_t,
-    hash_abcd: uint32x4_t,
-    wk: uint32x4_t,
-) -> uint32x4_t {
-    asm!(
-        "SHA256H2 {:q}, {:q}, {:v}.4S",
-        inout(vreg) hash_efgh, in(vreg) hash_abcd, in(vreg) wk,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    hash_efgh
-}
-
-#[inline(always)]
-unsafe fn vsha256su0q_u32(mut w0_3: uint32x4_t, w4_7: uint32x4_t) -> uint32x4_t {
-    asm!(
-        "SHA256SU0 {:v}.4S, {:v}.4S",
-        inout(vreg) w0_3, in(vreg) w4_7,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    w0_3
-}
-
-#[inline(always)]
-unsafe fn vsha256su1q_u32(
-    mut tw0_3: uint32x4_t,
-    w8_11: uint32x4_t,
-    w12_15: uint32x4_t,
-) -> uint32x4_t {
-    asm!(
-        "SHA256SU1 {:v}.4S, {:v}.4S, {:v}.4S",
-        inout(vreg) tw0_3, in(vreg) w8_11, in(vreg) w12_15,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    tw0_3
 }

--- a/sha2/src/sha512/aarch64.rs
+++ b/sha2/src/sha512/aarch64.rs
@@ -1,4 +1,6 @@
-// Implementation adapted from mbedtls.
+//! SHA-256 `aarch64` backend.
+//!
+//! Implementation adapted from mbedtls.
 
 use core::arch::{aarch64::*, asm};
 
@@ -178,58 +180,4 @@ unsafe fn sha512_compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
     vst1q_u64(state[2..4].as_mut_ptr(), cd);
     vst1q_u64(state[4..6].as_mut_ptr(), ef);
     vst1q_u64(state[6..8].as_mut_ptr(), gh);
-}
-
-// TODO remove these polyfills once SHA3 intrinsics land
-
-#[inline(always)]
-unsafe fn vsha512hq_u64(
-    mut hash_ed: uint64x2_t,
-    hash_gf: uint64x2_t,
-    kwh_kwh2: uint64x2_t,
-) -> uint64x2_t {
-    asm!(
-        "SHA512H {:q}, {:q}, {:v}.2D",
-        inout(vreg) hash_ed, in(vreg) hash_gf, in(vreg) kwh_kwh2,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    hash_ed
-}
-
-#[inline(always)]
-unsafe fn vsha512h2q_u64(
-    mut sum_ab: uint64x2_t,
-    hash_c_: uint64x2_t,
-    hash_ab: uint64x2_t,
-) -> uint64x2_t {
-    asm!(
-        "SHA512H2 {:q}, {:q}, {:v}.2D",
-        inout(vreg) sum_ab, in(vreg) hash_c_, in(vreg) hash_ab,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    sum_ab
-}
-
-#[inline(always)]
-unsafe fn vsha512su0q_u64(mut w0_1: uint64x2_t, w2_: uint64x2_t) -> uint64x2_t {
-    asm!(
-        "SHA512SU0 {:v}.2D, {:v}.2D",
-        inout(vreg) w0_1, in(vreg) w2_,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    w0_1
-}
-
-#[inline(always)]
-unsafe fn vsha512su1q_u64(
-    mut s01_s02: uint64x2_t,
-    w14_15: uint64x2_t,
-    w9_10: uint64x2_t,
-) -> uint64x2_t {
-    asm!(
-        "SHA512SU1 {:v}.2D, {:v}.2D, {:v}.2D",
-        inout(vreg) s01_s02, in(vreg) w14_15, in(vreg) w9_10,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    s01_s02
 }


### PR DESCRIPTION
We were previously using inline assembly to "emulate" these intrinsics since the ones in `core::arch` had not yet been stabilized.

Given the new 1.72 MSRV, we should now be able to use the intrinsics.