### PR TITLE
sha: make compress consume blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ name = "ascon-hash"
 version = "0.3.0-pre"
 dependencies = [
  "ascon",
- "digest 0.11.0-pre.8",
+ "digest",
  "hex",
  "hex-literal",
  "spectral",
@@ -33,7 +33,7 @@ name = "belt-hash"
 version = "0.2.0-pre.3"
 dependencies = [
  "belt-block",
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -41,7 +41,7 @@ dependencies = [
 name = "blake2"
 version = "0.11.0-pre.3"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -53,20 +53,11 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.11.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
 dependencies = [
- "crypto-common 0.2.0-pre.5",
+ "crypto-common",
  "zeroize",
 ]
 
@@ -75,12 +66,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -99,16 +84,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
@@ -120,25 +95,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "blobby",
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.6",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.0-pre.8"
 source = "git+https://github.com/RustCrypto/traits.git#7c7a0d2a2caa60e286835051e6ad5fd10a9a9554"
 dependencies = [
  "blobby",
- "block-buffer 0.11.0-pre.5",
- "const-oid 0.10.0-pre.2",
- "crypto-common 0.2.0-pre.5",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
  "subtle",
  "zeroize",
 ]
@@ -147,19 +110,9 @@ dependencies = [
 name = "fsb"
 version = "0.2.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
  "whirlpool",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -177,7 +130,7 @@ dependencies = [
 name = "gost94"
 version = "0.11.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -185,7 +138,7 @@ dependencies = [
 name = "groestl"
 version = "0.11.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -214,7 +167,7 @@ dependencies = [
 name = "jh"
 version = "0.2.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
  "ppv-lite86",
 ]
@@ -223,7 +176,7 @@ dependencies = [
 name = "k12"
 version = "0.4.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
  "sha3",
 ]
@@ -248,7 +201,7 @@ name = "md-5"
 version = "0.11.0-pre.3"
 dependencies = [
  "cfg-if",
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -256,7 +209,7 @@ dependencies = [
 name = "md2"
 version = "0.11.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -264,7 +217,7 @@ dependencies = [
 name = "md4"
 version = "0.11.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -287,19 +240,8 @@ dependencies = [
 name = "ripemd"
 version = "0.2.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -308,17 +250,17 @@ version = "0.11.0-pre.3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
 [[package]]
 name = "sha1-checked"
-version = "0.10.0"
+version = "0.11.0-pre"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "hex-literal",
- "sha1 0.10.6",
+ "sha1",
  "zeroize",
 ]
 
@@ -328,7 +270,7 @@ version = "0.11.0-pre.3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -336,7 +278,7 @@ dependencies = [
 name = "sha3"
 version = "0.11.0-pre.3"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
  "keccak",
 ]
@@ -345,7 +287,7 @@ dependencies = [
 name = "shabal"
 version = "0.5.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -353,7 +295,7 @@ dependencies = [
 name = "skein"
 version = "0.2.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
  "threefish",
 ]
@@ -362,7 +304,7 @@ dependencies = [
 name = "sm3"
 version = "0.5.0-pre.3"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -376,7 +318,7 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 name = "streebog"
 version = "0.11.0-pre.3"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -399,7 +341,7 @@ dependencies = [
 name = "tiger"
 version = "0.3.0-pre"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 
@@ -408,12 +350,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -425,7 +361,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 name = "whirlpool"
 version = "0.11.0-pre.2"
 dependencies = [
- "digest 0.11.0-pre.8",
+ "digest",
  "hex-literal",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ opt-level = 2
 [patch.crates-io]
 # https://github.com/RustCrypto/traits/pull/1537 - Unreleased
 digest = { git = "https://github.com/RustCrypto/traits.git" }
+
+sha1 = { path = "./sha1" }

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1-checked"
-version = "0.10.0"
+version = "0.11.0-pre"
 description = "SHA-1 hash function with collision detection"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -18,12 +18,12 @@ exclude = [
 ]
 
 [dependencies]
-digest = "0.10.7"
-sha1 = { version = "0.10.6", default-features = false, features = ["compress"] }
+digest = "=0.11.0-pre.8"
+sha1 = { version = "=0.11.0-pre.3", default-features = false }
 zeroize = { version = "1.7", default-features = false, optional = true }
 
 [dev-dependencies]
-digest = { version = "0.10.7", features = ["dev"] }
+digest = { version = "=0.11.0-pre.8", features = ["dev"] }
 hex-literal = "0.4"
 
 [features]

--- a/sha1/src/compress.rs
+++ b/sha1/src/compress.rs
@@ -1,4 +1,4 @@
-use crate::BLOCK_SIZE;
+use crate::Block;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "force-soft")] {
@@ -22,6 +22,6 @@ cfg_if::cfg_if! {
 }
 
 /// SHA-1 compression function
-pub fn compress(state: &mut [u32; 5], blocks: &[[u8; BLOCK_SIZE]]) {
+pub fn compress(state: &mut [u32; 5], blocks: &[Block]) {
     compress_inner(state, blocks);
 }

--- a/sha1/src/compress/aarch64.rs
+++ b/sha1/src/compress/aarch64.rs
@@ -1,5 +1,7 @@
 //! SHA-1 `aarch64` backend.
 
+use crate::Block;
+
 // Per rustc target feature docs for `aarch64-unknown-linux-gnu` and
 // `aarch64-apple-darwin` platforms, the `sha2` target feature enables
 // SHA-1 as well:
@@ -7,7 +9,7 @@
 // > Enable SHA1 and SHA256 support.
 cpufeatures::new!(sha1_hwcap, "sha2");
 
-pub fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+pub fn compress(state: &mut [u32; 5], blocks: &[Block]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if sha1_hwcap::get() {

--- a/sha1/src/compress/loongarch64_asm.rs
+++ b/sha1/src/compress/loongarch64_asm.rs
@@ -2,6 +2,8 @@
 
 use core::arch::asm;
 
+use crate::Block;
+
 const K: [u32; 4] = [0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6];
 
 macro_rules! c {
@@ -102,7 +104,7 @@ macro_rules! roundtail {
     };
 }
 
-pub fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+pub fn compress(state: &mut [u32; 5], blocks: &[Block]) {
     if blocks.is_empty() {
         return;
     }

--- a/sha1/src/compress/soft.rs
+++ b/sha1/src/compress/soft.rs
@@ -1,6 +1,10 @@
 #![allow(clippy::many_single_char_names)]
-use super::BLOCK_SIZE;
 
+use digest::{core_api::BlockSizeUser, typenum::Unsigned};
+
+use crate::{Block, Sha1Core};
+
+const BLOCK_SIZE: usize = <Sha1Core as BlockSizeUser>::BlockSize::USIZE;
 const K: [u32; 4] = [0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6];
 
 #[inline(always)]
@@ -244,7 +248,7 @@ fn sha1_digest_block_u32(state: &mut [u32; 5], block: &[u32; 16]) {
     state[4] = state[4].wrapping_add(e);
 }
 
-pub fn compress(state: &mut [u32; 5], blocks: &[[u8; BLOCK_SIZE]]) {
+pub fn compress(state: &mut [u32; 5], blocks: &[Block]) {
     let mut block_u32 = [0u32; BLOCK_SIZE / 4];
     // since LLVM can't properly use aliasing yet it will make
     // unnecessary state stores without this copy

--- a/sha1/src/compress/x86.rs
+++ b/sha1/src/compress/x86.rs
@@ -7,6 +7,8 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+use crate::Block;
+
 macro_rules! rounds4 {
     ($h0:ident, $h1:ident, $wk:expr, $i:expr) => {
         _mm_sha1rnds4_epu32($h0, _mm_sha1nexte_epu32($h1, $wk), $i)
@@ -31,7 +33,7 @@ macro_rules! schedule_rounds4 {
 }
 
 #[target_feature(enable = "sha,sse2,ssse3,sse4.1")]
-unsafe fn digest_blocks(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+unsafe fn digest_blocks(state: &mut [u32; 5], blocks: &[Block]) {
     #[allow(non_snake_case)]
     let MASK: __m128i = _mm_set_epi64x(0x0001_0203_0405_0607, 0x0809_0A0B_0C0D_0E0F);
 
@@ -91,7 +93,7 @@ unsafe fn digest_blocks(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
 
 cpufeatures::new!(shani_cpuid, "sha", "sse2", "ssse3", "sse4.1");
 
-pub fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+pub fn compress(state: &mut [u32; 5], blocks: &[Block]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if shani_cpuid::get() {

--- a/sha2/src/core_api.rs
+++ b/sha2/src/core_api.rs
@@ -1,7 +1,6 @@
 use crate::{consts, sha256::compress256, sha512::compress512};
 use core::{convert::TryInto, fmt, slice::from_ref};
 use digest::{
-    array::Array,
     block_buffer::Eager,
     core_api::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, OutputSizeUser, TruncSide,
@@ -39,7 +38,6 @@ impl UpdateCore for Sha256VarCore {
     #[inline]
     fn update_blocks(&mut self, blocks: &[Block<Self>]) {
         self.block_len += blocks.len() as u64;
-        let blocks = Array::cast_slice_to_core(blocks);
         compress256(&mut self.state, blocks);
     }
 }
@@ -66,7 +64,7 @@ impl VariableOutputCore for Sha256VarCore {
     fn finalize_variable_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
         let bs = Self::BlockSize::U64;
         let bit_len = 8 * (buffer.get_pos() as u64 + bs * self.block_len);
-        buffer.len64_padding_be(bit_len, |b| compress256(&mut self.state, from_ref(&b.0)));
+        buffer.len64_padding_be(bit_len, |b| compress256(&mut self.state, from_ref(b)));
 
         for (chunk, v) in out.chunks_exact_mut(4).zip(self.state.iter()) {
             chunk.copy_from_slice(&v.to_be_bytes());
@@ -155,7 +153,6 @@ impl UpdateCore for Sha512VarCore {
     #[inline]
     fn update_blocks(&mut self, blocks: &[Block<Self>]) {
         self.block_len += blocks.len() as u128;
-        let blocks = Array::cast_slice_to_core(blocks);
         compress512(&mut self.state, blocks);
     }
 }
@@ -184,7 +181,7 @@ impl VariableOutputCore for Sha512VarCore {
     fn finalize_variable_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
         let bs = Self::BlockSize::U64 as u128;
         let bit_len = 8 * (buffer.get_pos() as u128 + bs * self.block_len);
-        buffer.len128_padding_be(bit_len, |b| compress512(&mut self.state, from_ref(&b.0)));
+        buffer.len128_padding_be(bit_len, |b| compress512(&mut self.state, from_ref(b)));
 
         for (chunk, v) in out.chunks_exact_mut(8).zip(self.state.iter()) {
             chunk.copy_from_slice(&v.to_be_bytes());

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -1,3 +1,7 @@
+use crate::Sha256VarCore;
+
+type Block = digest::core_api::Block<Sha256VarCore>;
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "force-soft")] {
         mod soft;
@@ -24,6 +28,6 @@ cfg_if::cfg_if! {
 /// This is a low-level "hazmat" API which provides direct access to the core
 /// functionality of SHA-256.
 #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
-pub fn compress256(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+pub fn compress256(state: &mut [u32; 8], blocks: &[Block]) {
     compress(state, blocks)
 }

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -6,11 +6,12 @@
 
 use core::arch::{aarch64::*, asm};
 
+use super::Block;
 use crate::consts::K32;
 
 cpufeatures::new!(sha2_hwcap, "sha2");
 
-pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+pub fn compress(state: &mut [u32; 8], blocks: &[Block]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if sha2_hwcap::get() {
@@ -21,7 +22,7 @@ pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
 }
 
 #[target_feature(enable = "sha2")]
-unsafe fn sha256_compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+unsafe fn sha256_compress(state: &mut [u32; 8], blocks: &[Block]) {
     // SAFETY: Requires the sha2 feature.
 
     // Load state into vectors.

--- a/sha2/src/sha256/loongarch64_asm.rs
+++ b/sha2/src/sha256/loongarch64_asm.rs
@@ -1,5 +1,7 @@
 //! LoongArch64 assembly backend
 
+use super::Block;
+
 macro_rules! c {
     ($($l:expr)*) => {
         concat!($($l ,)*)
@@ -78,7 +80,7 @@ macro_rules! roundtail {
     };
 }
 
-pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+pub fn compress(state: &mut [u32; 8], blocks: &[Block]) {
     if blocks.is_empty() {
         return;
     }

--- a/sha2/src/sha256/soft.rs
+++ b/sha2/src/sha256/soft.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::many_single_char_names)]
 use crate::consts::K32;
 
+use super::Block;
+
 #[inline(always)]
 fn shr(v: [u32; 4], o: u32) -> [u32; 4] {
     [v[0] >> o, v[1] >> o, v[2] >> o, v[3] >> o]
@@ -227,7 +229,7 @@ fn sha256_digest_block_u32(state: &mut [u32; 8], block: &[u32; 16]) {
     state[7] = state[7].wrapping_add(h);
 }
 
-pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+pub fn compress(state: &mut [u32; 8], blocks: &[Block]) {
     for block in blocks {
         let mut block_u32 = [0u32; 16];
         for (o, chunk) in block_u32.iter_mut().zip(block.chunks_exact(4)) {

--- a/sha2/src/sha256/x86.rs
+++ b/sha2/src/sha256/x86.rs
@@ -7,6 +7,8 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+use super::Block;
+
 unsafe fn schedule(v0: __m128i, v1: __m128i, v2: __m128i, v3: __m128i) -> __m128i {
     let t1 = _mm_sha256msg1_epu32(v0, v1);
     let t2 = _mm_alignr_epi8(v3, v2, 4);
@@ -39,7 +41,7 @@ macro_rules! schedule_rounds4 {
 // we use unaligned loads with `__m128i` pointers
 #[allow(clippy::cast_ptr_alignment)]
 #[target_feature(enable = "sha,sse2,ssse3,sse4.1")]
-unsafe fn digest_blocks(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+unsafe fn digest_blocks(state: &mut [u32; 8], blocks: &[Block]) {
     #[allow(non_snake_case)]
     let MASK: __m128i = _mm_set_epi64x(
         0x0C0D_0E0F_0809_0A0Bu64 as i64,
@@ -99,7 +101,7 @@ unsafe fn digest_blocks(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
 
 cpufeatures::new!(shani_cpuid, "sha", "sse2", "ssse3", "sse4.1");
 
-pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+pub fn compress(state: &mut [u32; 8], blocks: &[Block]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if shani_cpuid::get() {

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -1,3 +1,7 @@
+use crate::Sha512VarCore;
+
+type Block = digest::core_api::Block<Sha512VarCore>;
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "force-soft")] {
         mod soft;
@@ -24,6 +28,6 @@ cfg_if::cfg_if! {
 /// This is a low-level "hazmat" API which provides direct access to the core
 /// functionality of SHA-512.
 #[cfg_attr(docsrs, doc(cfg(feature = "compress")))]
-pub fn compress512(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+pub fn compress512(state: &mut [u64; 8], blocks: &[Block]) {
     compress(state, blocks)
 }

--- a/sha2/src/sha512/aarch64.rs
+++ b/sha2/src/sha512/aarch64.rs
@@ -2,11 +2,12 @@
 
 use core::arch::{aarch64::*, asm};
 
+use super::Block;
 use crate::consts::K64;
 
 cpufeatures::new!(sha3_hwcap, "sha3");
 
-pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+pub fn compress(state: &mut [u64; 8], blocks: &[Block]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if sha3_hwcap::get() {
@@ -17,7 +18,7 @@ pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
 }
 
 #[target_feature(enable = "sha3")]
-unsafe fn sha512_compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+unsafe fn sha512_compress(state: &mut [u64; 8], blocks: &[Block]) {
     // SAFETY: Requires the sha3 feature.
 
     // Load state into vectors.

--- a/sha2/src/sha512/loongarch64_asm.rs
+++ b/sha2/src/sha512/loongarch64_asm.rs
@@ -1,5 +1,7 @@
 //! LoongArch64 assembly backend
 
+use super::Block;
+
 macro_rules! c {
     ($($l:expr)*) => {
         concat!($($l ,)*)
@@ -77,7 +79,7 @@ macro_rules! roundtail {
     };
 }
 
-pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+pub fn compress(state: &mut [u64; 8], blocks: &[Block]) {
     if blocks.is_empty() {
         return;
     }

--- a/sha2/src/sha512/soft.rs
+++ b/sha2/src/sha512/soft.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::many_single_char_names)]
 use crate::consts::K64;
 
+use super::Block;
+
 /// Not an intrinsic, but works like an unaligned load.
 fn sha512load(v0: [u64; 2], v1: [u64; 2]) -> [u64; 2] {
     [v1[1], v0[0]]
@@ -208,7 +210,7 @@ pub fn sha512_digest_block_u64(state: &mut [u64; 8], block: &[u64; 16]) {
     state[7] = state[7].wrapping_add(h);
 }
 
-pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+pub fn compress(state: &mut [u64; 8], blocks: &[Block]) {
     for block in blocks {
         let mut block_u32 = [0u64; 16];
         for (o, chunk) in block_u32.iter_mut().zip(block.chunks_exact(8)) {

--- a/sha2/src/sha512/x86.rs
+++ b/sha2/src/sha512/x86.rs
@@ -9,11 +9,12 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+use super::Block;
 use crate::consts::K64;
 
 cpufeatures::new!(avx2_cpuid, "avx2");
 
-pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+pub fn compress(state: &mut [u64; 8], blocks: &[Block]) {
     // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
     // after stabilization
     if avx2_cpuid::get() {
@@ -26,7 +27,7 @@ pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
 }
 
 #[target_feature(enable = "avx2")]
-unsafe fn sha512_compress_x86_64_avx2(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+unsafe fn sha512_compress_x86_64_avx2(state: &mut [u64; 8], blocks: &[Block]) {
     let mut start_block = 0;
 
     if blocks.len() & 0b1 != 0 {
@@ -55,7 +56,7 @@ unsafe fn sha512_compress_x86_64_avx2(state: &mut [u64; 8], blocks: &[[u8; 128]]
 }
 
 #[inline(always)]
-unsafe fn sha512_compress_x86_64_avx(state: &mut [u64; 8], block: &[u8; 128]) {
+unsafe fn sha512_compress_x86_64_avx(state: &mut [u64; 8], block: &Block) {
     let mut ms = [_mm_setzero_si128(); 8];
     let mut x = [_mm_setzero_si128(); 8];
 


### PR DESCRIPTION
To align with the semantics of `block_buffer::BlockBuffer::digest_blocks` signature which works with `&[Block]` and not `&[[u8; N]]`.