### PR TITLE
sha1-checked: implement BlockSizeUser

### DIFF
--- a/sha1-checked/src/lib.rs
+++ b/sha1-checked/src/lib.rs
@@ -197,6 +197,10 @@ impl OutputSizeUser for Sha1 {
     type OutputSize = U20;
 }
 
+impl BlockSizeUser for Sha1 {
+    type BlockSize = U64;
+}
+
 impl FixedOutput for Sha1 {
     #[inline]
     fn finalize_into(mut self, out: &mut Output<Self>) {


### PR DESCRIPTION
Implementing this trait makes it possible to use `sha1-checked` with [dsa::signing_key::SigningKey::sign_prehashed_rfc6979](https://docs.rs/dsa/0.6.3/dsa/struct.SigningKey.html#method.sign_prehashed_rfc6979)