### PR TITLE
sha2: provide support for `spki::AlgorithmIdentifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,14 +94,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b489fd2221710c1dd46637d66b984161fb66134f81437a8489800306bcc2ecea"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.0-pre.8"
-source = "git+https://github.com/RustCrypto/traits.git#7c7a0d2a2caa60e286835051e6ad5fd10a9a9554"
+source = "git+https://github.com/baloo/traits.git?branch=baloo/digest/expose-spki#f32b565722f2c46d2487037c8e088380beec5830"
 dependencies = [
  "blobby",
  "block-buffer",
  "const-oid",
  "crypto-common",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -313,6 +323,15 @@ name = "spectral"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
+
+[[package]]
+name = "spki"
+version = "0.8.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb2b56670f5ef52934c97efad30bf42585de0c33ec3e2a886e38b80d2db67243"
+dependencies = [
+ "der",
+]
 
 [[package]]
 name = "streebog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ opt-level = 2
 
 [patch.crates-io]
 # https://github.com/RustCrypto/traits/pull/1537 - Unreleased
-digest = { git = "https://github.com/RustCrypto/traits.git" }
+# https://github.com/RustCrypto/traits/pull/1575
+digest = { git = "https://github.com/baloo/traits.git", branch = "baloo/digest/expose-spki" }
 
 sha1 = { path = "./sha1" }

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -30,6 +30,7 @@ hex-literal = "0.4"
 default = ["oid", "std"]
 std = ["digest/std"]
 oid = ["digest/oid"] # Enable OID support
+spki = ["oid", "digest/spki"]
 zeroize = ["digest/zeroize"]
 force-soft = [] # Force software implementation
 

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -22,6 +22,8 @@ mod consts;
 mod core_api;
 mod sha256;
 mod sha512;
+#[cfg(feature = "spki")]
+mod spki;
 
 pub use sha256::compress256;
 pub use sha512::compress512;

--- a/sha2/src/spki.rs
+++ b/sha2/src/spki.rs
@@ -1,0 +1,28 @@
+//! Implements [`AlgorithmIdentifier`] according to [RFC5754 section 2]
+//!
+//! [RFC5754 section 2]: https://www.rfc-editor.org/rfc/rfc5754#section-2
+
+use digest::{
+    const_oid::AssociatedOid,
+    spki::{der::asn1::AnyRef, AlgorithmIdentifierRef, AssociatedAlgorithmIdentifier},
+};
+
+use super::{OidSha224, OidSha256, OidSha384, OidSha512};
+
+macro_rules! impl_aai {
+    ($name:ident) => {
+        impl AssociatedAlgorithmIdentifier for $name {
+            type Params = AnyRef<'static>;
+
+            const ALGORITHM_IDENTIFIER: AlgorithmIdentifierRef<'static> = AlgorithmIdentifierRef {
+                oid: Self::OID,
+                parameters: None,
+            };
+        }
+    };
+}
+
+impl_aai!(OidSha224);
+impl_aai!(OidSha256);
+impl_aai!(OidSha384);
+impl_aai!(OidSha512);


### PR DESCRIPTION
This implements `AlgorithmIdentifier` according to [RFC5754 section 2]

[RFC5754 section 2]: https://www.rfc-editor.org/rfc/rfc5754#section-2

Depends on https://github.com/RustCrypto/traits/pull/1575