### PR TITLE
sha1-checked: fix rogue cfg

### DIFF
--- a/sha1-checked/src/lib.rs
+++ b/sha1-checked/src/lib.rs
@@ -240,7 +240,6 @@ impl Drop for DetectionState {
 impl ZeroizeOnDrop for DetectionState {}
 
 #[cfg(feature = "oid")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oid")))]
 impl digest::const_oid::AssociatedOid for Sha1 {
     const OID: digest::const_oid::ObjectIdentifier = sha1::Sha1Core::OID;
 }


### PR DESCRIPTION
This leftover `cfg` [breaks](https://docs.rs/crate/sha1-checked/0.10.0/builds/1171741) doc builds on docs.rs.