### PR TITLE
Rust 1.80 `unexpected_cfgs` lint fixes

### DIFF
--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -5,6 +5,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![allow(unexpected_cfgs)] // `simd` feature is broken
 #![warn(missing_docs, rust_2018_idioms)]
 #![cfg_attr(feature = "simd", feature(platform_intrinsics, repr_simd))]
 #![cfg_attr(feature = "simd", allow(incomplete_features))]

--- a/sha1/src/compress.rs
+++ b/sha1/src/compress.rs
@@ -4,11 +4,7 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "force-soft")] {
         mod soft;
         use soft::compress as compress_inner;
-    } else if #[cfg(all(feature = "asm", target_arch = "aarch64"))] {
-        mod soft;
-        mod aarch64;
-        use aarch64::compress as compress_inner;
-    } else if #[cfg(target_arch = "loongarch64")] {
+   } else if #[cfg(target_arch = "loongarch64")] {
         mod loongarch64_asm;
         use loongarch64_asm::compress as compress_inner;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {


### PR DESCRIPTION
- `sha1` had vestiges of a removed `asm` feature
- `blake2` has a lot of code relating to a commented out `simd` feature, so for now the lint has been ignored