### PR TITLE
Cut pre.4 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-pre.3"
+version = "0.2.0-pre.4"
 dependencies = [
  "base16ct",
  "belt-block",
@@ -212,7 +212,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 dependencies = [
  "base16ct",
  "digest",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-pre.3"
+version = "0.5.0-pre.4"
 dependencies = [
  "base16ct",
  "digest",
@@ -341,7 +341,7 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 
 [[package]]
 name = "streebog"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 dependencies = [
  "base16ct",
  "digest",

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-hash"
-version = "0.2.0-pre.3"
+version = "0.2.0-pre.4"
 description = "BelT hash function (STB 34.101.31-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.71"
 
 [dependencies]
 digest = { version = "=0.11.0-pre.9", default-features = false, features = ["core-api"] }
-sha3 = { version = "=0.11.0-pre.3", default-features = false, path = "../sha3" }
+sha3 = { version = "=0.11.0-pre.4", default-features = false, path = "../sha3" }
 
 [dev-dependencies]
 digest = { version = "=0.11.0-pre.9", features = ["alloc", "dev"] }

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -13,13 +13,13 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.72"
 
 exclude = [
-  "sha1-checked/tests/data/shattered-1.pdf",
-  "sha1-checked/tests/data/shattered-2.pdf",
+    "sha1-checked/tests/data/shattered-1.pdf",
+    "sha1-checked/tests/data/shattered-2.pdf",
 ]
 
 [dependencies]
 digest = "=0.11.0-pre.9"
-sha1 = { version = "=0.11.0-pre.3", default-features = false }
+sha1 = { version = "=0.11.0-pre.4", default-features = false }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm3"
-version = "0.5.0-pre.3"
+version = "0.5.0-pre.4"
 description = "SM3 (OSCCA GM/T 0004-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.11.0-pre.3"
+version = "0.11.0-pre.4"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts a new release of every crate which previously received a pre.3 prerelease (in #559), i.e. is used as a (dev-)dependency in downstream projects that need to be upgraded.

This includes the following:

- `belt-hash` v0.2.0-pre.4
- `md-5` v0.11.0-pre.4
- `sha1` v0.11.0-pre.4
- `sha2` v0.11.0-pre.4
- `sha3` v0.11.0-pre.4
- `sm3` v0.5.0-pre.4
- `streebog` v0.11.0-pre.4