### PR TITLE
sha2: use stabilized `core::arch::aarch64` intrinsics

### DIFF
--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.72.0
+      msrv: 1.79.0
 
   # Builds for no_std platforms
   build:
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-      # Cross mounts only current package, i.e. by default it ignores workspace's Cargo.toml
+        # Cross mounts only current package, i.e. by default it ignores workspace's Cargo.toml
         working-directory: .
     steps:
       - uses: actions/checkout@v4
@@ -149,4 +149,4 @@ jobs:
   minimal-versions:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
-        working-directory: ${{ github.workflow }}
+      working-directory: ${{ github.workflow }}

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.75.0
+          toolchain: 1.79.0
           components: clippy
       - run: cargo clippy --all -- -D warnings
 

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sha2"
 repository = "https://github.com/RustCrypto/hashes"
 keywords = ["crypto", "sha2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
-rust-version = "1.72"
+rust-version = "1.79"
 
 [dependencies]
 digest = "=0.11.0-pre.9"

--- a/sha2/README.md
+++ b/sha2/README.md
@@ -61,7 +61,7 @@ Also, see the [examples section] in the RustCrypto/hashes readme.
 
 ## Minimum Supported Rust Version
 
-Rust **1.72** or higher.
+Rust **1.79** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be
 done with a minor version bump.
@@ -93,7 +93,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/sha2/badge.svg
 [docs-link]: https://docs.rs/sha2/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.72+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.79+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260041-hashes
 [build-image]: https://github.com/RustCrypto/hashes/workflows/sha2/badge.svg?branch=master

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -4,7 +4,7 @@
 
 // TODO: stdarch intrinsics: RustCrypto/hashes#257
 
-use core::arch::{aarch64::*, asm};
+use core::arch::aarch64::*;
 
 use crate::consts::K32;
 
@@ -102,58 +102,4 @@ unsafe fn sha256_compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
     // Store vectors into state.
     vst1q_u32(state[0..4].as_mut_ptr(), abcd);
     vst1q_u32(state[4..8].as_mut_ptr(), efgh);
-}
-
-// TODO remove these polyfills once SHA2 intrinsics land
-
-#[inline(always)]
-unsafe fn vsha256hq_u32(
-    mut hash_efgh: uint32x4_t,
-    hash_abcd: uint32x4_t,
-    wk: uint32x4_t,
-) -> uint32x4_t {
-    asm!(
-        "SHA256H {:q}, {:q}, {:v}.4S",
-        inout(vreg) hash_efgh, in(vreg) hash_abcd, in(vreg) wk,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    hash_efgh
-}
-
-#[inline(always)]
-unsafe fn vsha256h2q_u32(
-    mut hash_efgh: uint32x4_t,
-    hash_abcd: uint32x4_t,
-    wk: uint32x4_t,
-) -> uint32x4_t {
-    asm!(
-        "SHA256H2 {:q}, {:q}, {:v}.4S",
-        inout(vreg) hash_efgh, in(vreg) hash_abcd, in(vreg) wk,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    hash_efgh
-}
-
-#[inline(always)]
-unsafe fn vsha256su0q_u32(mut w0_3: uint32x4_t, w4_7: uint32x4_t) -> uint32x4_t {
-    asm!(
-        "SHA256SU0 {:v}.4S, {:v}.4S",
-        inout(vreg) w0_3, in(vreg) w4_7,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    w0_3
-}
-
-#[inline(always)]
-unsafe fn vsha256su1q_u32(
-    mut tw0_3: uint32x4_t,
-    w8_11: uint32x4_t,
-    w12_15: uint32x4_t,
-) -> uint32x4_t {
-    asm!(
-        "SHA256SU1 {:v}.4S, {:v}.4S, {:v}.4S",
-        inout(vreg) tw0_3, in(vreg) w8_11, in(vreg) w12_15,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    tw0_3
 }

--- a/sha2/src/sha256/aarch64.rs
+++ b/sha2/src/sha256/aarch64.rs
@@ -2,8 +2,6 @@
 
 // Implementation adapted from mbedtls.
 
-// TODO: stdarch intrinsics: RustCrypto/hashes#257
-
 use core::arch::aarch64::*;
 
 use crate::consts::K32;

--- a/sha2/src/sha512/aarch64.rs
+++ b/sha2/src/sha512/aarch64.rs
@@ -1,6 +1,6 @@
 // Implementation adapted from mbedtls.
 
-use core::arch::{aarch64::*, asm};
+use core::arch::aarch64::*;
 
 use crate::consts::K64;
 
@@ -178,58 +178,4 @@ unsafe fn sha512_compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
     vst1q_u64(state[2..4].as_mut_ptr(), cd);
     vst1q_u64(state[4..6].as_mut_ptr(), ef);
     vst1q_u64(state[6..8].as_mut_ptr(), gh);
-}
-
-// TODO remove these polyfills once SHA3 intrinsics land
-
-#[inline(always)]
-unsafe fn vsha512hq_u64(
-    mut hash_ed: uint64x2_t,
-    hash_gf: uint64x2_t,
-    kwh_kwh2: uint64x2_t,
-) -> uint64x2_t {
-    asm!(
-        "SHA512H {:q}, {:q}, {:v}.2D",
-        inout(vreg) hash_ed, in(vreg) hash_gf, in(vreg) kwh_kwh2,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    hash_ed
-}
-
-#[inline(always)]
-unsafe fn vsha512h2q_u64(
-    mut sum_ab: uint64x2_t,
-    hash_c_: uint64x2_t,
-    hash_ab: uint64x2_t,
-) -> uint64x2_t {
-    asm!(
-        "SHA512H2 {:q}, {:q}, {:v}.2D",
-        inout(vreg) sum_ab, in(vreg) hash_c_, in(vreg) hash_ab,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    sum_ab
-}
-
-#[inline(always)]
-unsafe fn vsha512su0q_u64(mut w0_1: uint64x2_t, w2_: uint64x2_t) -> uint64x2_t {
-    asm!(
-        "SHA512SU0 {:v}.2D, {:v}.2D",
-        inout(vreg) w0_1, in(vreg) w2_,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    w0_1
-}
-
-#[inline(always)]
-unsafe fn vsha512su1q_u64(
-    mut s01_s02: uint64x2_t,
-    w14_15: uint64x2_t,
-    w9_10: uint64x2_t,
-) -> uint64x2_t {
-    asm!(
-        "SHA512SU1 {:v}.2D, {:v}.2D, {:v}.2D",
-        inout(vreg) s01_s02, in(vreg) w14_15, in(vreg) w9_10,
-        options(pure, nomem, nostack, preserves_flags)
-    );
-    s01_s02
 }


### PR DESCRIPTION
We were previously using inline assembly to "emulate" these intrinsics since the ones in `core::arch` had not yet been stabilized.

They are now stable as of Rust 1.79.

Redux of #570.