### PR TITLE
Correct the type of AsconXofReader

### DIFF
--- a/ascon-hash/src/lib.rs
+++ b/ascon-hash/src/lib.rs
@@ -417,7 +417,7 @@ pub type AsconAHash = CoreWrapper<AsconACore>;
 /// ```
 pub type AsconXof = CoreWrapper<AsconXofCore>;
 /// Reader for AsconXof output
-pub type AsconAXofReader = XofReaderCoreWrapper<AsconAXofReaderCore>;
+pub type AsconXofReader = XofReaderCoreWrapper<AsconXofReaderCore>;
 /// AsconAXof
 ///
 /// ```
@@ -432,4 +432,4 @@ pub type AsconAXofReader = XofReaderCoreWrapper<AsconAXofReaderCore>;
 /// ```
 pub type AsconAXof = CoreWrapper<AsconAXofCore>;
 /// Reader for AsconAXof output
-pub type AsconXofReader = XofReaderCoreWrapper<AsconAXofReaderCore>;
+pub type AsconAXofReader = XofReaderCoreWrapper<AsconAXofReaderCore>;


### PR DESCRIPTION
Currently AsconXofReader has type XofReaderCoreWrapper<AsconAXofReaderCore>, this is incorrect the type should be XofReaderCoreWrapper<AsconXofReaderCore>.