### PR TITLE
blake2: add unkeyed hashing

### DIFF
--- a/blake2/tests/mac.rs
+++ b/blake2/tests/mac.rs
@@ -30,6 +30,10 @@ fn blake2b_new_test() {
 
 #[test]
 fn mac_refuses_empty_keys() {
-    assert!(blake2::Blake2bMac512::new_with_salt_and_personal(&[], b"salt", b"persona").is_err());
-    assert!(blake2::Blake2sMac256::new_with_salt_and_personal(&[], b"salt", b"persona").is_err());
+    assert!(
+        blake2::Blake2bMac512::new_with_salt_and_personal(Some(&[]), b"salt", b"persona").is_err()
+    );
+    assert!(
+        blake2::Blake2sMac256::new_with_salt_and_personal(Some(&[]), b"salt", b"persona").is_err()
+    );
 }

--- a/blake2/tests/persona.rs
+++ b/blake2/tests/persona.rs
@@ -8,7 +8,7 @@ fn blake2s_persona() {
         "101112131415161718191a1b1c1d1e1f"
     );
     let persona = b"personal";
-    let ctx = Blake2sMac256::new_with_salt_and_personal(&key, &[], persona).unwrap();
+    let ctx = Blake2sMac256::new_with_salt_and_personal(Some(&key), &[], persona).unwrap();
     assert_eq!(
         ctx.finalize_fixed(),
         hex!(
@@ -25,7 +25,7 @@ fn blake2b_persona() {
         "101112131415161718191a1b1c1d1e1f"
     );
     let persona = b"personal";
-    let ctx = Blake2bMac512::new_with_salt_and_personal(&key, &[], persona).unwrap();
+    let ctx = Blake2bMac512::new_with_salt_and_personal(Some(&key), &[], persona).unwrap();
     assert_eq!(
         ctx.finalize_fixed(),
         hex!(

--- a/blake2/tests/unkeyed.rs
+++ b/blake2/tests/unkeyed.rs
@@ -1,0 +1,28 @@
+use blake2::{digest::FixedOutput, Blake2bMac512, Blake2sMac256};
+use hex_literal::hex;
+
+#[test]
+fn blake2s_unkeyed() {
+    let ctx = Blake2sMac256::new_with_salt_and_personal(None, b"salt", b"persona").unwrap();
+    assert_eq!(
+        ctx.finalize_fixed(),
+        hex!(
+            "d7de83e2b1fedd9755db747235b7ba4b"
+            "f9773a16b91c6b241e4b1d926160d9eb"
+        ),
+    );
+}
+
+#[test]
+fn blake2b_unkeyed() {
+    let ctx = Blake2bMac512::new_with_salt_and_personal(None, b"salt", b"persona").unwrap();
+    assert_eq!(
+        ctx.finalize_fixed(),
+        hex!(
+            "fa3cd38902ae0602d8f0066f18c579fa"
+            "e8068074fbe91f9f5774f841f5ab51fe"
+            "39140ad78d6576f8a0b9f8f4c2642211"
+            "11c9911d8ba1dbefcd034acdbedb8cde"
+        ),
+    );
+}


### PR DESCRIPTION
This introduces unkeyed hashing for blake2 as specified in [Section 2.5 of RFC 7693](https://www.rfc-editor.org/rfc/rfc7693.html#section-2.5) states the following:

    The second (little-endian) byte of the parameter block, "kk", specifies the key size in bytes. Set kk = 00 for unkeyed hashing.

I propose to make the key an `Option<&[u8]>`:
```rust
pub fn new_with_salt_and_personal(
    key: Option<&[u8]>, 
    salt: &[u8], 
    persona: &[u8],
) -> Result<Self, InvalidLength>
```

By making the key an `Option<&[u8]>` - rather than opting for the unkeyed usage in case of an empty `key` - we make the unkeyed usage explicit and avoid inadvertent usages.

This closes #482.
See also #509.