### PR TITLE
CI: fix `sha2` build

### DIFF
--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -163,7 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: RustCrypto/actions/cross-install@master
+      - run: cargo install cross --git https://github.com/cross-rs/cross
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -163,10 +163,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
+      - uses: RustCrypto/actions/cross-install@master
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-      - run: cargo install cross --git https://github.com/cross-rs/cross
       - run: cross test --package sha2 --all-features --target riscv64gc-unknown-linux-gnu
         env:
           RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft" -C target-feature=+zknh,+zbkb


### PR DESCRIPTION
The `riscv64-zknh` job was trying to install `cross` from git, and it no longer compiles.

This changes it to use our shared `cross-install` shared action