### PR TITLE
Fix typos in `mod.rs` and `CHANGELOG.md`

### DIFF
--- a/blake2/tests/mod.rs
+++ b/blake2/tests/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "reset")]
-use digest::dev::{fixed_reset_test as fixed_fn, variable_reset_test as varaible_fn};
+use digest::dev::{fixed_reset_test as fixed_fn, variable_reset_test as variable_fn};
 #[cfg(not(feature = "reset"))]
-use digest::dev::{fixed_test as fixed_fn, variable_test as varaible_fn};
+use digest::dev::{fixed_test as fixed_fn, variable_test as variable_fn};
 use digest::new_test;
 
 new_test!(blake2b_fixed, "blake2b/fixed", blake2::Blake2b512, fixed_fn,);
@@ -9,11 +9,11 @@ new_test!(
     blake2b_variable,
     "blake2b/variable",
     blake2::Blake2bVar,
-    varaible_fn,
+    variable_fn,
 );
 new_test!(
     blake2s_variable,
     "blake2s/variable",
     blake2::Blake2sVar,
-    varaible_fn,
+    variable_fn,
 );

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -131,7 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9.1 (2020-06-24)
 ### Added
-- x86 hardware acceleration of SHA-256 via SHA extension instrinsics. ([#167])
+- x86 hardware acceleration of SHA-256 via SHA extension intrinsics. ([#167])
 
 [#167]: https://github.com/RustCrypto/hashes/pull/167
 


### PR DESCRIPTION
1. **In `mod.rs`**:
   - "varaible_fn" corrected to "variable_fn" in the function aliasing to ensure consistency and prevent any potential errors during code execution.

2. **In `CHANGELOG.md`**:
   - "instrinsics" corrected to "intrinsics" to fix a spelling error in the hardware acceleration description.
