### PR TITLE
Update LICENSE-MIT

### DIFF
--- a/jh/LICENSE-MIT
+++ b/jh/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2023-2024 The RustCrypto Project Developers
+Copyright (c) 2023-2025 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
Updated the copyright year from 2024 to 2025 in the LICENSE file