### PR TITLE
Add Customized trait for blake2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+# https://github.com/RustCrypto/traits/pull/1787
+digest = { git = "https://github.com/RustCrypto/traits" }

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -17,7 +17,7 @@ pub use digest::{self, Digest};
 
 use core::{fmt, marker::PhantomData, ops::Div};
 use digest::{
-    VarOutputCustomized, FixedOutput, HashMarker, InvalidOutputSize, MacMarker, Output, Update,
+    FixedOutput, HashMarker, InvalidOutputSize, MacMarker, Output, Update, VarOutputCustomized,
     array::{Array, ArraySize},
     block_buffer::{Lazy, LazyBuffer},
     consts::{U4, U16, U32, U64, U128},

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -17,7 +17,7 @@ pub use digest::{self, Digest};
 
 use core::{fmt, marker::PhantomData, ops::Div};
 use digest::{
-    FixedOutput, HashMarker, InvalidOutputSize, MacMarker, Output, Update,
+    VarOutputCustomized, FixedOutput, HashMarker, InvalidOutputSize, MacMarker, Output, Update,
     array::{Array, ArraySize},
     block_buffer::{Lazy, LazyBuffer},
     consts::{U4, U16, U32, U64, U128},

--- a/blake2/src/macros.rs
+++ b/blake2/src/macros.rs
@@ -256,6 +256,14 @@ macro_rules! blake2_impl {
                 }
             }
         }
+
+        impl VarOutputCustomized for $name {
+            #[inline]
+            fn new_customized(customization: &[u8], output_size: usize) -> Self {
+                Self::new_with_params(&[], customization, 0, output_size)
+            }
+        }
+
         #[cfg(feature = "zeroize")]
         impl ZeroizeOnDrop for $name {}
     };

--- a/blake2/tests/persona.rs
+++ b/blake2/tests/persona.rs
@@ -1,4 +1,6 @@
-use blake2::{Blake2bMac512, Blake2sMac256, digest::FixedOutput};
+use blake2::{Blake2b128, Blake2bMac512, Blake2sMac256, digest::FixedOutput};
+use blake2::digest::CustomizedInit;
+use digest::Update;
 use hex_literal::hex;
 
 #[test]
@@ -20,6 +22,19 @@ fn blake2s_persona() {
 
 #[test]
 fn blake2b_persona() {
+    let persona = b"personal";
+    let mut ctx = Blake2b128::new_customized(persona);
+    ctx.update(b"hello");
+    assert_eq!(
+        ctx.finalize_fixed(),
+        hex!(
+            "5a5eb0aecc053af1ce6de25354c1c761"
+        ),
+    );
+}
+
+#[test]
+fn blake2b_mac_persona() {
     let key = hex!(
         "000102030405060708090a0b0c0d0e0f"
         "101112131415161718191a1b1c1d1e1f"

--- a/blake2/tests/persona.rs
+++ b/blake2/tests/persona.rs
@@ -1,5 +1,5 @@
-use blake2::{Blake2b128, Blake2bMac512, Blake2sMac256, digest::FixedOutput};
 use blake2::digest::CustomizedInit;
+use blake2::{Blake2b128, Blake2bMac512, Blake2sMac256, digest::FixedOutput};
 use digest::Update;
 use hex_literal::hex;
 
@@ -27,9 +27,7 @@ fn blake2b_persona() {
     ctx.update(b"hello");
     assert_eq!(
         ctx.finalize_fixed(),
-        hex!(
-            "5a5eb0aecc053af1ce6de25354c1c761"
-        ),
+        hex!("5a5eb0aecc053af1ce6de25354c1c761"),
     );
 }
 


### PR DESCRIPTION
Allow to use Blake2 with a customized string: `Blake2b128::new_customized(persona)` as described in the paper and as for cSHAKE. It needs a new trait `VarOutputCustomized` implemented by: https://github.com/RustCrypto/traits/pull/1787