### PR TITLE
Remove explicit passing of the `docsrs` configuration flag

### DIFF
--- a/ascon-hash/Cargo.toml
+++ b/ascon-hash/Cargo.toml
@@ -32,4 +32,3 @@ zeroize = ["ascon/zeroize", "digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -29,4 +29,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -32,4 +32,3 @@ size_opt = [] # Optimize for code size. Removes some `inline(always)`
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -28,4 +28,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -28,4 +28,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -27,4 +27,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -26,4 +26,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -27,4 +27,3 @@ zeroize = ["digest/zeroize", "sha3/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -28,4 +28,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -28,4 +28,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -33,4 +33,3 @@ force-soft = [] # Force software implementation
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -28,4 +28,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -36,4 +36,3 @@ zeroize = ["dep:zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -33,4 +33,3 @@ force-soft = [] # Force software implementation
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -41,4 +41,3 @@ check-cfg = [
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -35,4 +35,3 @@ reset = [] # Enable reset functionality
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -27,4 +27,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -28,4 +28,3 @@ zeroize = ["digest/zeroize", "threefish/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -27,4 +27,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -28,4 +28,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/tiger/Cargo.toml
+++ b/tiger/Cargo.toml
@@ -27,4 +27,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -27,4 +27,3 @@ zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
The flag is passed automatically by docs.rs.