### PR TITLE
chore:fix cargo clippy warning

### DIFF
--- a/sha3/README.md
+++ b/sha3/README.md
@@ -18,7 +18,7 @@ There are 6 standard algorithms specified in the SHA-3 standard:
 * `SHAKE128`, an extendable output function (XOF)
 * `SHAKE256`, an extendable output function (XOF)
 * `Keccak224`, `Keccak256`, `Keccak384`, `Keccak512` (NIST submission
-   without padding changes)
+  without padding changes)
 
 This crates supports `cSHAKE128` and `cSHAKE256`, the customizable XOFs as defined in the NIST [SHA-3 Derived Functions].
 


### PR DESCRIPTION
Running `cargo clippy`  reports the following error.

```shell
    Checking jh v0.2.0-pre (/Users/xxx/yyyyy/hashes/jh)
warning: doc list item overindented
  --> sha3/src/../README.md:21:1
   |
21 |    without padding changes)
   | ^^^ help: try using `  ` (2 spaces)
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items
   = note: `#[warn(clippy::doc_overindented_list_items)]` on by default
```


 This commit resolves the issue.

