### PR TITLE
Use a const lookup table for the kupyna gf

### DIFF
--- a/kupyna/src/short_compress.rs
+++ b/kupyna/src/short_compress.rs
@@ -63,23 +63,16 @@ fn matrix_to_block(matrix: Matrix) -> [u8; 64] {
 
 fn rotate_rows(mut state: Matrix) -> Matrix {
     const ROWS: usize = 8;
-    let cols = 8;
+    const COLS: usize = 8;
 
-    let mut temp = [0u8; ROWS];
-    let mut shift: i32 = -1;
-    for i in 0..cols {
-        if i == cols - 1 {
-            shift = 7;
-        } else {
-            shift += 1;
-        }
-        for col in 0..ROWS {
-            temp[(col + shift as usize) % ROWS] = state[col][i];
-        }
-        for col in 0..ROWS {
-            state[col][i] = temp[col];
+    for i in 0..COLS {
+        let shift = if i == COLS - 1 { 7 } else { i + 1 }; // Calculate the shift amount
+        for row in 0..ROWS {
+            let new_row = (row + shift) % ROWS; // Calculate the new row index
+            state[new_row][i] = state[row][i];  // Perform the rotation
         }
     }
+
     state
 }
 

--- a/kupyna/src/short_compress.rs
+++ b/kupyna/src/short_compress.rs
@@ -63,16 +63,23 @@ fn matrix_to_block(matrix: Matrix) -> [u8; 64] {
 
 fn rotate_rows(mut state: Matrix) -> Matrix {
     const ROWS: usize = 8;
-    const COLS: usize = 8;
+    let cols = 8;
 
-    for i in 0..COLS {
-        let shift = if i == COLS - 1 { 7 } else { i + 1 }; // Calculate the shift amount
-        for row in 0..ROWS {
-            let new_row = (row + shift) % ROWS; // Calculate the new row index
-            state[new_row][i] = state[row][i];  // Perform the rotation
+    let mut temp = [0u8; ROWS];
+    let mut shift: i32 = -1;
+    for i in 0..cols {
+        if i == cols - 1 {
+            shift = 7;
+        } else {
+            shift += 1;
+        }
+        for col in 0..ROWS {
+            temp[(col + shift as usize) % ROWS] = state[col][i];
+        }
+        for col in 0..ROWS {
+            state[col][i] = temp[col];
         }
     }
-
     state
 }
 

--- a/kupyna/src/utils.rs
+++ b/kupyna/src/utils.rs
@@ -120,3 +120,4 @@ pub(crate) fn write_u64_le(src: &[u64], dst: &mut [u8]) {
         dst.copy_from_slice(&src.to_le_bytes())
     }
 }
+

--- a/kupyna/src/utils.rs
+++ b/kupyna/src/utils.rs
@@ -120,4 +120,3 @@ pub(crate) fn write_u64_le(src: &[u64], dst: &mut [u8]) {
         dst.copy_from_slice(&src.to_le_bytes())
     }
 }
-

--- a/kupyna/src/utils.rs
+++ b/kupyna/src/utils.rs
@@ -1,14 +1,13 @@
 use crate::consts::{MDS_MATRIX, SBOXES};
 
 const fn gf_multiply(x: u8, y: u8) -> u8 {
-    const BITS_IN_BYTE: u8 = 8;
     const REDUCTION_POLYNOMIAL: u16 = 0x011d;
 
     let mut x = x;
     let mut y = y;
     let mut r = 0u8;
     let mut i = 0;
-    while i < BITS_IN_BYTE {
+    while i < u8::BITS {
         if y & 1 == 1 {
             r ^= x;
         }
@@ -38,10 +37,10 @@ const fn generate_gf_lookup_table() -> [[u8; 256]; 256] {
     table
 }
 
-pub(crate) static GF_LOOKUP_TABLE: [[u8; 256]; 256] = generate_gf_lookup_table();
+static GF_LOOKUP_TABLE: [[u8; 256]; 256] = generate_gf_lookup_table();
 
 fn multiply_gf(x: u8, y: u8) -> u8 {
-    GF_LOOKUP_TABLE[x as usize][y as usize]
+    GF_LOOKUP_TABLE[usize::from(x)][usize::from(y)]
 }
 
 #[allow(clippy::needless_range_loop)]

--- a/kupyna/src/utils.rs
+++ b/kupyna/src/utils.rs
@@ -38,7 +38,7 @@ const fn generate_gf_lookup_table() -> [[u8; 256]; 256] {
     table
 }
 
-pub(crate) const GF_LOOKUP_TABLE: [[u8; 256]; 256] = generate_gf_lookup_table();
+pub(crate) static GF_LOOKUP_TABLE: [[u8; 256]; 256] = generate_gf_lookup_table();
 
 fn multiply_gf(x: u8, y: u8) -> u8 {
     GF_LOOKUP_TABLE[x as usize][y as usize]


### PR DESCRIPTION
The GF_LOOKUP_TABLE was being computed on each and every call. This was quite slow, but  all but the most trivial hashes are going to iterate the full 256x256 values anyway. Rust has the beautiful `const fn` syntax, which lets us easily adapt the old runtime code with few changes aside from using a `while` instead of a `for` inside.

The kupyna algo still has a lot of optimizing before it hits the same performance as the similar groetsl algo, but this simple change sees a major improvement.