### PR TITLE
sha2: add soft-compact backend

### DIFF
--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -79,6 +79,9 @@ jobs:
       - run: cargo test --all-features
         env:
           RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft"
+      - run: cargo test --all-features
+        env:
+          RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft-compact"
 
   # macOS tests
   macos:
@@ -102,6 +105,9 @@ jobs:
       - run: cargo test --all-features
         env:
           RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft"
+      - run: cargo test --all-features
+        env:
+          RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft-compact"
 
   # Windows tests
   windows:
@@ -126,6 +132,9 @@ jobs:
       - run: cargo test --all-features
         env:
           RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft"
+      - run: cargo test --all-features
+        env:
+          RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft-compact"
 
   # Cross-compiled tests
   cross:
@@ -176,6 +185,9 @@ jobs:
           RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft" -C target-feature=+zknh,+zbkb
       - run: cross test --package sha2 --all-features --target riscv64gc-unknown-linux-gnu
         env:
+          RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft-compact" -C target-feature=+zknh,+zbkb
+      - run: cross test --package sha2 --all-features --target riscv64gc-unknown-linux-gnu
+        env:
           RUSTFLAGS: -Dwarnings --cfg sha2_backend="riscv-zknh" -C target-feature=+zknh,+zbkb
       - run: cross test --package sha2 --all-features --target riscv64gc-unknown-linux-gnu
         env:
@@ -193,6 +205,9 @@ jobs:
       - run: cargo build --all-features --target riscv32gc-unknown-linux-gnu -Z build-std
         env:
           RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft" -C target-feature=+zknh,+zbkb
+      - run: cargo build --all-features --target riscv32gc-unknown-linux-gnu -Z build-std
+        env:
+          RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft-compact" -C target-feature=+zknh,+zbkb
       - run: cargo build --all-features --target riscv32gc-unknown-linux-gnu -Z build-std
         env:
           RUSTFLAGS: -Dwarnings --cfg sha2_backend="riscv-zknh" -C target-feature=+zknh,+zbkb

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -14,15 +14,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - RISC-V scalar crypto extension support gated behind `sha2_backend = "riscv-zknh"` or
   `sha2_backend = "riscv-zknh-compact"` configuration flags ([#614])
+- `sha2_backend = "soft"` configuration flag ([#615])
+- `sha2_backend = "soft-compact"` configuration flag ([#686])
 
 ### Removed
 - `asm`, `asm-aarch64`, `loongarch64_asm`, and `compress` crate features ([#542])
-- `soft` crate feature. Replaced with `sha2_backend = "soft"` configuration flag ([#615])
+- `soft` crate feature ([#615])
+- `force-soft-compact` crate feature ([#686])
 
 [#542]: https://github.com/RustCrypto/hashes/pull/542
 [#614]: https://github.com/RustCrypto/hashes/pull/614
 [#615]: https://github.com/RustCrypto/hashes/pull/615
 [#652]: https://github.com/RustCrypto/hashes/pull/652
+[#686]: https://github.com/RustCrypto/hashes/pull/686
+
+## 0.10.9 (2025-04-30)
+### Added
+- `force-soft-compact` crate feature to enable compact software backend (backport of [#686]) [#687]
+
+[#687]: https://github.com/RustCrypto/hashes/pull/687
 
 ## 0.10.8 (2023-09-26)
 ### Added

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -36,7 +36,7 @@ oid = ["digest/oid"]
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(sha2_backend, values("soft", "riscv-zknh", "riscv-zknh-compact"))',
+    'cfg(sha2_backend, values("soft", "soft-compact", "riscv-zknh", "riscv-zknh-compact"))',
 ]
 
 [package.metadata.docs.rs]

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -42,14 +42,10 @@ cfg_if::cfg_if! {
 #[inline(always)]
 #[allow(dead_code)]
 fn to_u32s(block: &[u8; 64]) -> [u32; 16] {
-    let mut res = [0u32; 16];
-    // note: we intentionally do not use `zip`-based code here since
-    // it results in a suboptimal codegen for `opt-level = "s"`
-    for i in 0..16 {
+    core::array::from_fn(|i| {
         let chunk = block[4 * i..][..4].try_into().unwrap();
-        res[i] = u32::from_be_bytes(chunk);
-    }
-    res
+        u32::from_be_bytes(chunk)
+    })
 }
 
 /// Raw SHA-256 compression function.

--- a/sha2/src/sha256/soft_compact.rs
+++ b/sha2/src/sha256/soft_compact.rs
@@ -1,0 +1,56 @@
+use crate::consts::K32;
+
+fn compress_u32(state: &mut [u32; 8], block: [u32; 16]) {
+    let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = *state;
+
+    let mut w = [0; 64];
+    w[..16].copy_from_slice(&block);
+
+    for i in 16..64 {
+        let w15 = w[i - 15];
+        let s0 = (w15.rotate_right(7)) ^ (w15.rotate_right(18)) ^ (w15 >> 3);
+        let w2 = w[i - 2];
+        let s1 = (w2.rotate_right(17)) ^ (w2.rotate_right(19)) ^ (w2 >> 10);
+        w[i] = w[i - 16]
+            .wrapping_add(s0)
+            .wrapping_add(w[i - 7])
+            .wrapping_add(s1);
+    }
+
+    for i in 0..64 {
+        let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+        let ch = (e & f) ^ ((!e) & g);
+        let t1 = s1
+            .wrapping_add(ch)
+            .wrapping_add(K32[i])
+            .wrapping_add(w[i])
+            .wrapping_add(h);
+        let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+        let maj = (a & b) ^ (a & c) ^ (b & c);
+        let t2 = s0.wrapping_add(maj);
+
+        h = g;
+        g = f;
+        f = e;
+        e = d.wrapping_add(t1);
+        d = c;
+        c = b;
+        b = a;
+        a = t1.wrapping_add(t2);
+    }
+
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
+    state[5] = state[5].wrapping_add(f);
+    state[6] = state[6].wrapping_add(g);
+    state[7] = state[7].wrapping_add(h);
+}
+
+pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+    for block in blocks.iter() {
+        compress_u32(state, super::to_u32s(block));
+    }
+}

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -2,6 +2,9 @@ cfg_if::cfg_if! {
     if #[cfg(sha2_backend = "soft")] {
         mod soft;
         use soft::compress;
+    } else if #[cfg(sha2_backend = "soft-compact")] {
+        mod soft_compact;
+        use soft_compact::compress;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
         mod soft;
         mod x86_avx2;
@@ -40,8 +43,11 @@ cfg_if::cfg_if! {
 #[allow(dead_code)]
 fn to_u64s(block: &[u8; 128]) -> [u64; 16] {
     let mut res = [0u64; 16];
-    for (src, dst) in block.chunks_exact(8).zip(res.iter_mut()) {
-        *dst = u64::from_be_bytes(src.try_into().unwrap());
+    // note: we intentionally do not use `zip`-based code here since
+    // it results in a suboptimal codegen for `opt-level = "s"`
+    for i in 0..16 {
+        let chunk = block[8 * i..][..8].try_into().unwrap();
+        res[i] = u64::from_be_bytes(chunk);
     }
     res
 }

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -42,14 +42,10 @@ cfg_if::cfg_if! {
 #[inline(always)]
 #[allow(dead_code)]
 fn to_u64s(block: &[u8; 128]) -> [u64; 16] {
-    let mut res = [0u64; 16];
-    // note: we intentionally do not use `zip`-based code here since
-    // it results in a suboptimal codegen for `opt-level = "s"`
-    for i in 0..16 {
+    core::array::from_fn(|i| {
         let chunk = block[8 * i..][..8].try_into().unwrap();
-        res[i] = u64::from_be_bytes(chunk);
-    }
-    res
+        u64::from_be_bytes(chunk)
+    })
 }
 
 /// Raw SHA-512 compression function.

--- a/sha2/src/sha512/soft_compact.rs
+++ b/sha2/src/sha512/soft_compact.rs
@@ -1,0 +1,56 @@
+use crate::consts::K64;
+
+fn compress_u64(state: &mut [u64; 8], block: [u64; 16]) {
+    let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = *state;
+
+    let mut w = [0; 80];
+    w[..16].copy_from_slice(&block);
+
+    for i in 16..80 {
+        let w15 = w[i - 15];
+        let s0 = (w15.rotate_right(1)) ^ (w15.rotate_right(8)) ^ (w15 >> 7);
+        let w2 = w[i - 2];
+        let s1 = (w2.rotate_right(19)) ^ (w2.rotate_right(61)) ^ (w2 >> 6);
+        w[i] = w[i - 16]
+            .wrapping_add(s0)
+            .wrapping_add(w[i - 7])
+            .wrapping_add(s1);
+    }
+
+    for i in 0..80 {
+        let s1 = e.rotate_right(14) ^ e.rotate_right(18) ^ e.rotate_right(41);
+        let ch = (e & f) ^ ((!e) & g);
+        let t1 = s1
+            .wrapping_add(ch)
+            .wrapping_add(K64[i])
+            .wrapping_add(w[i])
+            .wrapping_add(h);
+        let s0 = a.rotate_right(28) ^ a.rotate_right(34) ^ a.rotate_right(39);
+        let maj = (a & b) ^ (a & c) ^ (b & c);
+        let t2 = s0.wrapping_add(maj);
+
+        h = g;
+        g = f;
+        f = e;
+        e = d.wrapping_add(t1);
+        d = c;
+        c = b;
+        b = a;
+        a = t1.wrapping_add(t2);
+    }
+
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
+    state[5] = state[5].wrapping_add(f);
+    state[6] = state[6].wrapping_add(g);
+    state[7] = state[7].wrapping_add(h);
+}
+
+pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+    for block in blocks.iter() {
+        compress_u64(state, super::to_u64s(block));
+    }
+}


### PR DESCRIPTION
The new backend results in a much smaller binary code (e.g. for SHA-256 on `thumbv7em-none-eabi` we get [~150 instructions][0] vs [~1680 instructions][1], for SHA-512 it's [~330][2] vs [~7950][3]) while being somewhat slower on non-embedded CPUs (e.g. for SHA-256 on my x86-64 laptop with `opt-level=s` it results in 289 MB/s vs 315 MB/s).

We probably should also backport this PR to the `backports/digest-v0.10` branch and release sha2 v0.10.9 with this addition.

Closes #561

[0]: https://rust.godbolt.org/z/c5cT5chGz
[1]: https://rust.godbolt.org/z/rWMTqaxdc
[2]: https://rust.godbolt.org/z/EKoxxdqrv
[3]: https://rust.godbolt.org/z/Td81PxsdW