### PR TITLE
sha2: add soft-compact backend (backport of #686)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.9 (2025-04-30)
+### Added
+- `force-soft-compact` crate feature to enable compact software backend (backport of [#686]) [#687]
+
+[#686]: https://github.com/RustCrypto/hashes/pull/686
+[#687]: https://github.com/RustCrypto/hashes/pull/687
+
 ## 0.10.8 (2023-09-26)
 ### Added
 - `asm!`-based backend for LoongArch64 targets gated behind `loongarch64_asm` feature [#507]

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.
@@ -36,6 +36,7 @@ asm = ["sha2-asm"] # WARNING: this feature SHOULD NOT be enabled by library crat
 loongarch64_asm = []
 compress = [] # Expose compress functions
 force-soft = [] # Force software implementation
+force-soft-compact = [] # Force compact software implementation
 asm-aarch64 = ["asm"] # DEPRECATED: use `asm` instead
 
 [package.metadata.docs.rs]

--- a/sha2/src/sha256.rs
+++ b/sha2/src/sha256.rs
@@ -1,7 +1,10 @@
 use digest::{generic_array::GenericArray, typenum::U64};
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "force-soft")] {
+    if #[cfg(feature = "force-soft-compact")] {
+        mod soft_compact;
+        use soft_compact::compress;
+    } else if #[cfg(feature = "force-soft")] {
         mod soft;
         use soft::compress;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {

--- a/sha2/src/sha256/soft_compact.rs
+++ b/sha2/src/sha256/soft_compact.rs
@@ -1,0 +1,66 @@
+use crate::consts::K32;
+
+fn to_u32s(block: &[u8; 64]) -> [u32; 16] {
+    use core::convert::TryInto;
+    let mut res = [0u32; 16];
+    for i in 0..16 {
+        let chunk = block[4 * i..][..4].try_into().unwrap();
+        res[i] = u32::from_be_bytes(chunk);
+    }
+    res
+}
+
+fn compress_u32(state: &mut [u32; 8], block: [u32; 16]) {
+    let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = *state;
+
+    let mut w = [0; 64];
+    w[..16].copy_from_slice(&block);
+
+    for i in 16..64 {
+        let w15 = w[i - 15];
+        let s0 = (w15.rotate_right(7)) ^ (w15.rotate_right(18)) ^ (w15 >> 3);
+        let w2 = w[i - 2];
+        let s1 = (w2.rotate_right(17)) ^ (w2.rotate_right(19)) ^ (w2 >> 10);
+        w[i] = w[i - 16]
+            .wrapping_add(s0)
+            .wrapping_add(w[i - 7])
+            .wrapping_add(s1);
+    }
+
+    for i in 0..64 {
+        let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+        let ch = (e & f) ^ ((!e) & g);
+        let t1 = s1
+            .wrapping_add(ch)
+            .wrapping_add(K32[i])
+            .wrapping_add(w[i])
+            .wrapping_add(h);
+        let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+        let maj = (a & b) ^ (a & c) ^ (b & c);
+        let t2 = s0.wrapping_add(maj);
+
+        h = g;
+        g = f;
+        f = e;
+        e = d.wrapping_add(t1);
+        d = c;
+        c = b;
+        b = a;
+        a = t1.wrapping_add(t2);
+    }
+
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
+    state[5] = state[5].wrapping_add(f);
+    state[6] = state[6].wrapping_add(g);
+    state[7] = state[7].wrapping_add(h);
+}
+
+pub fn compress(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
+    for block in blocks.iter() {
+        compress_u32(state, to_u32s(block));
+    }
+}

--- a/sha2/src/sha512.rs
+++ b/sha2/src/sha512.rs
@@ -1,7 +1,10 @@
 use digest::{generic_array::GenericArray, typenum::U128};
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "force-soft")] {
+    if #[cfg(feature = "force-soft-compact")] {
+        mod soft_compact;
+        use soft_compact::compress;
+    } else if #[cfg(feature = "force-soft")] {
         mod soft;
         use soft::compress;
     } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {

--- a/sha2/src/sha512/soft_compact.rs
+++ b/sha2/src/sha512/soft_compact.rs
@@ -1,0 +1,66 @@
+use crate::consts::K64;
+
+fn to_u64s(block: &[u8; 128]) -> [u64; 16] {
+    use core::convert::TryInto;
+    let mut res = [0u64; 16];
+    for i in 0..16 {
+        let chunk = block[8 * i..][..8].try_into().unwrap();
+        res[i] = u64::from_be_bytes(chunk);
+    }
+    res
+}
+
+fn compress_u64(state: &mut [u64; 8], block: [u64; 16]) {
+    let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = *state;
+
+    let mut w = [0; 80];
+    w[..16].copy_from_slice(&block);
+
+    for i in 16..80 {
+        let w15 = w[i - 15];
+        let s0 = (w15.rotate_right(1)) ^ (w15.rotate_right(8)) ^ (w15 >> 7);
+        let w2 = w[i - 2];
+        let s1 = (w2.rotate_right(19)) ^ (w2.rotate_right(61)) ^ (w2 >> 6);
+        w[i] = w[i - 16]
+            .wrapping_add(s0)
+            .wrapping_add(w[i - 7])
+            .wrapping_add(s1);
+    }
+
+    for i in 0..80 {
+        let s1 = e.rotate_right(14) ^ e.rotate_right(18) ^ e.rotate_right(41);
+        let ch = (e & f) ^ ((!e) & g);
+        let t1 = s1
+            .wrapping_add(ch)
+            .wrapping_add(K64[i])
+            .wrapping_add(w[i])
+            .wrapping_add(h);
+        let s0 = a.rotate_right(28) ^ a.rotate_right(34) ^ a.rotate_right(39);
+        let maj = (a & b) ^ (a & c) ^ (b & c);
+        let t2 = s0.wrapping_add(maj);
+
+        h = g;
+        g = f;
+        f = e;
+        e = d.wrapping_add(t1);
+        d = c;
+        c = b;
+        b = a;
+        a = t1.wrapping_add(t2);
+    }
+
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
+    state[5] = state[5].wrapping_add(f);
+    state[6] = state[6].wrapping_add(g);
+    state[7] = state[7].wrapping_add(h);
+}
+
+pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
+    for block in blocks.iter() {
+        compress_u64(state, to_u64s(block));
+    }
+}


### PR DESCRIPTION
This PR is a slightly modified backport of #686. Instead of the configuration flag it introduces the `force-soft-compact` crate feature.