### PR TITLE
ci: remove pre-1.56 jobs and other fixes

### DIFF
--- a/.github/workflows/blake2.yml
+++ b/.github/workflows/blake2.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.56.0
 
   build:
     needs: set-msrv
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51 # 1.41-1.50 `--features` can't be used inside virtual manifest
+          - 1.56
           - stable
         target:
           - aarch64-unknown-linux-gnu

--- a/.github/workflows/fsb.yml
+++ b/.github/workflows/fsb.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.56.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/gost94.yml
+++ b/.github/workflows/gost94.yml
@@ -65,19 +65,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: merge with test on MSRV bump to 1.57 or higher
-  test-msrv-41:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.41.0 # MSRV
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo test
-      - run: cargo test --no-default-features

--- a/.github/workflows/groestl.yml
+++ b/.github/workflows/groestl.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.56.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/jh.yml
+++ b/.github/workflows/jh.yml
@@ -15,7 +15,6 @@ defaults:
 
 env:
   CARGO_INCREMENTAL: 0
-  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   set-msrv:

--- a/.github/workflows/jh.yml
+++ b/.github/workflows/jh.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.57.0
+        msrv: 1.61.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/md2.yml
+++ b/.github/workflows/md2.yml
@@ -66,18 +66,3 @@ jobs:
     with:
         working-directory: ${{ github.workflow }}
 
-  # TODO: merge with test on MSRV bump to 1.57 or higher
-  test-msrv-41:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.41.0 # MSRV
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/md4.yml
+++ b/.github/workflows/md4.yml
@@ -65,19 +65,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: merge with test on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.41.0 # MSRV
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -80,18 +80,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: merge with test on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.41.0 # MSRV
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo test

--- a/.github/workflows/ripemd.yml
+++ b/.github/workflows/ripemd.yml
@@ -66,18 +66,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: merge with test on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.41.0 # MSRV
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-      - run: cargo test --no-default-features

--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.51.0 # 1.41-1.50 `--features` can't be used inside virtual manifest
+          - 1.56.0
           - stable
         target:
           - aarch64-unknown-linux-gnu
@@ -176,15 +176,3 @@ jobs:
           package: ${{ github.workflow }}
           target: ${{ matrix.target }}
           features: ${{ matrix.features }}
-
-  # TODO: remove on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.41.0
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - ${{needs.set-msrv.outputs.msrv}}
+          - 1.79
           - stable
     runs-on: macos-latest
     steps:

--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -168,15 +168,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # TODO: remove on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.41.0
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/sha3.yml
+++ b/.github/workflows/sha3.yml
@@ -95,15 +95,3 @@ jobs:
           package: ${{ github.workflow }}
           target: ${{ matrix.target }}
           features: ${{ matrix.features }}
-
-  # TODO: remove on MSRV bump to 1.57 or higher
-  test-msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.41.0
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/shabal.yml
+++ b/.github/workflows/shabal.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.56.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/sm3.yml
+++ b/.github/workflows/sm3.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.56.0
 
   build:
     needs: set-msrv

--- a/.github/workflows/streebog.yml
+++ b/.github/workflows/streebog.yml
@@ -65,17 +65,3 @@ jobs:
     uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
     with:
         working-directory: ${{ github.workflow }}
-
-  # `oid` feature bumps MSRV to 1.57, so we temporarily split this job.
-  test-msrv:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: RustCrypto/actions/cargo-cache@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          profile: minimal
-          toolchain: 1.41.0
-          override: true
-      - run: cargo test --no-default-features
-      - run: cargo test

--- a/.github/workflows/whirlpool.yml
+++ b/.github/workflows/whirlpool.yml
@@ -21,7 +21,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.41.0
+        msrv: 1.56.0
 
   build:
     needs: set-msrv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "md-5"

--- a/blake2/src/as_bytes.rs
+++ b/blake2/src/as_bytes.rs
@@ -13,18 +13,12 @@ pub unsafe trait Safe {}
 
 pub trait AsBytes {
     fn as_bytes(&self) -> &[u8];
-    fn as_mut_bytes(&mut self) -> &mut [u8];
 }
 
 impl<T: Safe> AsBytes for [T] {
     #[inline]
     fn as_bytes(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.as_ptr() as *const u8, mem::size_of_val(self)) }
-    }
-
-    #[inline]
-    fn as_mut_bytes(&mut self) -> &mut [u8] {
-        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr() as *mut u8, mem::size_of_val(self)) }
     }
 }
 

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -19,3 +19,7 @@ simd = { package = "ppv-lite86", version = "0.2.6" }
 
 [dev-dependencies]
 digest = { version = "0.10", features = ["dev"] }
+
+[features]
+default = ["std"]
+std = ["digest/std"]

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -19,7 +19,3 @@ simd = { package = "ppv-lite86", version = "0.2.6" }
 
 [dev-dependencies]
 digest = { version = "0.10", features = ["dev"] }
-
-[features]
-default = ["std"]
-std = ["digest/std"]


### PR DESCRIPTION
These jobs result in broken CI since the old version of `cpufeatures` results in compiler warnings on recent compiler versions, while by updating it we pull newer `libc` which requires the 2018 edition.