### PR TITLE
sha2: simplify the soft backend

### DIFF
--- a/sha2/src/sha512/soft.rs
+++ b/sha2/src/sha512/soft.rs
@@ -1,202 +1,71 @@
-#![allow(clippy::many_single_char_names)]
 use crate::consts::K64;
 
-/// Not an intrinsic, but works like an unaligned load.
-fn sha512load(v0: [u64; 2], v1: [u64; 2]) -> [u64; 2] {
-    [v1[1], v0[0]]
-}
-
-/// Performs 2 rounds of the SHA-512 message schedule update.
-pub fn sha512_schedule_x2(v0: [u64; 2], v1: [u64; 2], v4to5: [u64; 2], v7: [u64; 2]) -> [u64; 2] {
-    // sigma 0
-    fn sigma0(x: u64) -> u64 {
-        (x.rotate_right(1)) ^ (x.rotate_right(8)) ^ (x >> 7)
-    }
-
-    // sigma 1
-    fn sigma1(x: u64) -> u64 {
-        (x.rotate_right(19)) ^ (x.rotate_left(3)) ^ (x >> 6)
-    }
-
-    let [w1, w0] = v0;
-    let [_, w2] = v1;
-    let [w10, w9] = v4to5;
-    let [w15, w14] = v7;
-
-    let w16 = sigma1(w14)
-        .wrapping_add(w9)
-        .wrapping_add(sigma0(w1))
-        .wrapping_add(w0);
-    let w17 = sigma1(w15)
-        .wrapping_add(w10)
-        .wrapping_add(sigma0(w2))
-        .wrapping_add(w1);
-
-    [w17, w16]
-}
-
-/// Performs one round of the SHA-512 message block digest.
-pub fn sha512_digest_round(
-    ae: [u64; 2],
-    bf: [u64; 2],
-    cg: [u64; 2],
-    dh: [u64; 2],
-    wk0: u64,
-) -> [u64; 2] {
-    macro_rules! big_sigma0 {
-        ($a:expr) => {
-            ($a.rotate_right(28) ^ $a.rotate_right(34) ^ $a.rotate_right(39))
-        };
-    }
-    macro_rules! big_sigma1 {
-        ($a:expr) => {
-            ($a.rotate_right(14) ^ $a.rotate_right(18) ^ $a.rotate_right(41))
-        };
-    }
-    macro_rules! bool3ary_202 {
-        ($a:expr, $b:expr, $c:expr) => {
-            $c ^ ($a & ($b ^ $c))
-        };
-    } // Choose, MD5F, SHA1C
-    macro_rules! bool3ary_232 {
-        ($a:expr, $b:expr, $c:expr) => {
-            ($a & $b) ^ ($a & $c) ^ ($b & $c)
-        };
-    } // Majority, SHA1M
-
-    let [a0, e0] = ae;
-    let [b0, f0] = bf;
-    let [c0, g0] = cg;
-    let [d0, h0] = dh;
-
-    // a round
-    let x0 = big_sigma1!(e0)
-        .wrapping_add(bool3ary_202!(e0, f0, g0))
-        .wrapping_add(wk0)
-        .wrapping_add(h0);
-    let y0 = big_sigma0!(a0).wrapping_add(bool3ary_232!(a0, b0, c0));
-    let (a1, _, _, _, e1, _, _, _) = (
-        x0.wrapping_add(y0),
-        a0,
-        b0,
-        c0,
-        x0.wrapping_add(d0),
-        e0,
-        f0,
-        g0,
-    );
-
-    [a1, e1]
-}
-
-#[inline(always)]
-fn add_rk(mut w: [u64; 2], i: usize) -> [u64; 2] {
-    fn rk(i: usize, j: usize) -> u64 {
-        // `read_volatile` forces compiler to read round constants from the static
-        // instead of inlining them, which improves codegen and performance
-        unsafe {
-            let p = K64.as_ptr().add(2 * i + j);
-            core::ptr::read_volatile(p)
-        }
-    }
-    w[1] = w[1].wrapping_add(rk(i, 0));
-    w[0] = w[0].wrapping_add(rk(i, 1));
-    w
+#[rustfmt::skip]
+macro_rules! repeat80 {
+    ($i:ident, $b:block) => {
+        let $i = 0; $b; let $i = 1; $b; let $i = 2; $b; let $i = 3; $b;
+        let $i = 4; $b; let $i = 5; $b; let $i = 6; $b; let $i = 7; $b;
+        let $i = 8; $b; let $i = 9; $b; let $i = 10; $b; let $i = 11; $b;
+        let $i = 12; $b; let $i = 13; $b; let $i = 14; $b; let $i = 15; $b;
+        let $i = 16; $b; let $i = 17; $b; let $i = 18; $b; let $i = 19; $b;
+        let $i = 20; $b; let $i = 21; $b; let $i = 22; $b; let $i = 23; $b;
+        let $i = 24; $b; let $i = 25; $b; let $i = 26; $b; let $i = 27; $b;
+        let $i = 28; $b; let $i = 29; $b; let $i = 30; $b; let $i = 31; $b;
+        let $i = 32; $b; let $i = 33; $b; let $i = 34; $b; let $i = 35; $b;
+        let $i = 36; $b; let $i = 37; $b; let $i = 38; $b; let $i = 39; $b;
+        let $i = 40; $b; let $i = 41; $b; let $i = 42; $b; let $i = 43; $b;
+        let $i = 44; $b; let $i = 45; $b; let $i = 46; $b; let $i = 47; $b;
+        let $i = 48; $b; let $i = 49; $b; let $i = 50; $b; let $i = 51; $b;
+        let $i = 52; $b; let $i = 53; $b; let $i = 54; $b; let $i = 55; $b;
+        let $i = 56; $b; let $i = 57; $b; let $i = 58; $b; let $i = 59; $b;
+        let $i = 60; $b; let $i = 61; $b; let $i = 62; $b; let $i = 63; $b;
+        let $i = 64; $b; let $i = 65; $b; let $i = 66; $b; let $i = 67; $b;
+        let $i = 68; $b; let $i = 69; $b; let $i = 70; $b; let $i = 71; $b;
+        let $i = 72; $b; let $i = 73; $b; let $i = 74; $b; let $i = 75; $b;
+        let $i = 76; $b; let $i = 77; $b; let $i = 78; $b; let $i = 79; $b;
+    };
 }
 
 /// Process a block with the SHA-512 algorithm.
-pub fn sha512_digest_block_u64(state: &mut [u64; 8], block: [u64; 16]) {
-    macro_rules! schedule {
-        ($v0:expr, $v1:expr, $v4:expr, $v5:expr, $v7:expr) => {
-            sha512_schedule_x2($v0, $v1, sha512load($v4, $v5), $v7)
+fn compress_block(state: &mut [u64; 8], block: &[u8; 128]) {
+    let mut block = super::to_u64s(block);
+    let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = *state;
+
+    repeat80!(i, {
+        let w = if i < 16 {
+            block[i]
+        } else {
+            let w15 = block[(i - 15) % 16];
+            let s0 = (w15.rotate_right(1)) ^ (w15.rotate_right(8)) ^ (w15 >> 7);
+            let w2 = block[(i - 2) % 16];
+            let s1 = (w2.rotate_right(19)) ^ (w2.rotate_right(61)) ^ (w2 >> 6);
+            block[i % 16] = block[i % 16]
+                .wrapping_add(s0)
+                .wrapping_add(block[(i - 7) % 16])
+                .wrapping_add(s1);
+            block[i % 16]
         };
-    }
 
-    macro_rules! rounds4 {
-        ($ae:ident, $bf:ident, $cg:ident, $dh:ident, $wk0:expr, $wk1:expr) => {{
-            let [u, t] = $wk0;
-            let [w, v] = $wk1;
+        let s1 = e.rotate_right(14) ^ e.rotate_right(18) ^ e.rotate_right(41);
+        let ch = (e & f) ^ ((!e) & g);
+        let t1 = s1
+            .wrapping_add(ch)
+            .wrapping_add(K64[i])
+            .wrapping_add(w)
+            .wrapping_add(h);
+        let s0 = a.rotate_right(28) ^ a.rotate_right(34) ^ a.rotate_right(39);
+        let maj = (a & b) ^ (a & c) ^ (b & c);
+        let t2 = s0.wrapping_add(maj);
 
-            $dh = sha512_digest_round($ae, $bf, $cg, $dh, t);
-            $cg = sha512_digest_round($dh, $ae, $bf, $cg, u);
-            $bf = sha512_digest_round($cg, $dh, $ae, $bf, v);
-            $ae = sha512_digest_round($bf, $cg, $dh, $ae, w);
-        }};
-    }
-
-    let mut ae = [state[0], state[4]];
-    let mut bf = [state[1], state[5]];
-    let mut cg = [state[2], state[6]];
-    let mut dh = [state[3], state[7]];
-
-    // Rounds 0..20
-    let (mut w1, mut w0) = ([block[3], block[2]], [block[1], block[0]]);
-    rounds4!(ae, bf, cg, dh, add_rk(w0, 0), add_rk(w1, 1));
-    let (mut w3, mut w2) = ([block[7], block[6]], [block[5], block[4]]);
-    rounds4!(ae, bf, cg, dh, add_rk(w2, 2), add_rk(w3, 3));
-    let (mut w5, mut w4) = ([block[11], block[10]], [block[9], block[8]]);
-    rounds4!(ae, bf, cg, dh, add_rk(w4, 4), add_rk(w5, 5));
-    let (mut w7, mut w6) = ([block[15], block[14]], [block[13], block[12]]);
-    rounds4!(ae, bf, cg, dh, add_rk(w6, 6), add_rk(w7, 7));
-    let mut w8 = schedule!(w0, w1, w4, w5, w7);
-    let mut w9 = schedule!(w1, w2, w5, w6, w8);
-    rounds4!(ae, bf, cg, dh, add_rk(w8, 8), add_rk(w9, 9));
-
-    // Rounds 20..40
-    w0 = schedule!(w2, w3, w6, w7, w9);
-    w1 = schedule!(w3, w4, w7, w8, w0);
-    rounds4!(ae, bf, cg, dh, add_rk(w0, 10), add_rk(w1, 11));
-    w2 = schedule!(w4, w5, w8, w9, w1);
-    w3 = schedule!(w5, w6, w9, w0, w2);
-    rounds4!(ae, bf, cg, dh, add_rk(w2, 12), add_rk(w3, 13));
-    w4 = schedule!(w6, w7, w0, w1, w3);
-    w5 = schedule!(w7, w8, w1, w2, w4);
-    rounds4!(ae, bf, cg, dh, add_rk(w4, 14), add_rk(w5, 15));
-    w6 = schedule!(w8, w9, w2, w3, w5);
-    w7 = schedule!(w9, w0, w3, w4, w6);
-    rounds4!(ae, bf, cg, dh, add_rk(w6, 16), add_rk(w7, 17));
-    w8 = schedule!(w0, w1, w4, w5, w7);
-    w9 = schedule!(w1, w2, w5, w6, w8);
-    rounds4!(ae, bf, cg, dh, add_rk(w8, 18), add_rk(w9, 19));
-
-    // Rounds 40..60
-    w0 = schedule!(w2, w3, w6, w7, w9);
-    w1 = schedule!(w3, w4, w7, w8, w0);
-    rounds4!(ae, bf, cg, dh, add_rk(w0, 20), add_rk(w1, 21));
-    w2 = schedule!(w4, w5, w8, w9, w1);
-    w3 = schedule!(w5, w6, w9, w0, w2);
-    rounds4!(ae, bf, cg, dh, add_rk(w2, 22), add_rk(w3, 23));
-    w4 = schedule!(w6, w7, w0, w1, w3);
-    w5 = schedule!(w7, w8, w1, w2, w4);
-    rounds4!(ae, bf, cg, dh, add_rk(w4, 24), add_rk(w5, 25));
-    w6 = schedule!(w8, w9, w2, w3, w5);
-    w7 = schedule!(w9, w0, w3, w4, w6);
-    rounds4!(ae, bf, cg, dh, add_rk(w6, 26), add_rk(w7, 27));
-    w8 = schedule!(w0, w1, w4, w5, w7);
-    w9 = schedule!(w1, w2, w5, w6, w8);
-    rounds4!(ae, bf, cg, dh, add_rk(w8, 28), add_rk(w9, 29));
-
-    // Rounds 60..80
-    w0 = schedule!(w2, w3, w6, w7, w9);
-    w1 = schedule!(w3, w4, w7, w8, w0);
-    rounds4!(ae, bf, cg, dh, add_rk(w0, 30), add_rk(w1, 31));
-    w2 = schedule!(w4, w5, w8, w9, w1);
-    w3 = schedule!(w5, w6, w9, w0, w2);
-    rounds4!(ae, bf, cg, dh, add_rk(w2, 32), add_rk(w3, 33));
-    w4 = schedule!(w6, w7, w0, w1, w3);
-    w5 = schedule!(w7, w8, w1, w2, w4);
-    rounds4!(ae, bf, cg, dh, add_rk(w4, 34), add_rk(w5, 35));
-    w6 = schedule!(w8, w9, w2, w3, w5);
-    w7 = schedule!(w9, w0, w3, w4, w6);
-    rounds4!(ae, bf, cg, dh, add_rk(w6, 36), add_rk(w7, 37));
-    w8 = schedule!(w0, w1, w4, w5, w7);
-    w9 = schedule!(w1, w2, w5, w6, w8);
-    rounds4!(ae, bf, cg, dh, add_rk(w8, 38), add_rk(w9, 39));
-
-    let [a, e] = ae;
-    let [b, f] = bf;
-    let [c, g] = cg;
-    let [d, h] = dh;
+        h = g;
+        g = f;
+        f = e;
+        e = d.wrapping_add(t1);
+        d = c;
+        c = b;
+        b = a;
+        a = t1.wrapping_add(t2);
+    });
 
     state[0] = state[0].wrapping_add(a);
     state[1] = state[1].wrapping_add(b);
@@ -209,7 +78,7 @@ pub fn sha512_digest_block_u64(state: &mut [u64; 8], block: [u64; 16]) {
 }
 
 pub fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
-    for block in blocks.iter().map(super::to_u64s) {
-        sha512_digest_block_u64(state, block);
+    for block in blocks {
+        compress_block(state, block);
     }
 }

--- a/sha2/src/sha512/soft.rs
+++ b/sha2/src/sha512/soft.rs
@@ -26,6 +26,16 @@ macro_rules! repeat80 {
     };
 }
 
+/// Read round constant
+fn rk(i: usize) -> u64 {
+    // `read_volatile` forces the compiler to read round constants from the static
+    // instead of inlining them, which improves codegen and performance
+    unsafe {
+        let p = K64.as_ptr().add(i);
+        core::ptr::read_volatile(p)
+    }
+}
+
 /// Process a block with the SHA-512 algorithm.
 fn compress_block(state: &mut [u64; 8], block: &[u8; 128]) {
     let mut block = super::to_u64s(block);
@@ -50,7 +60,7 @@ fn compress_block(state: &mut [u64; 8], block: &[u8; 128]) {
         let ch = (e & f) ^ ((!e) & g);
         let t1 = s1
             .wrapping_add(ch)
-            .wrapping_add(K64[i])
+            .wrapping_add(rk(i))
             .wrapping_add(w)
             .wrapping_add(h);
         let s0 = a.rotate_right(28) ^ a.rotate_right(34) ^ a.rotate_right(39);


### PR DESCRIPTION
This change makes it easier to read the software backend code and makes it similar to the `soft-compact` backend. It also slightly improves codegen (e.g. on x86-64 for SHA-256 it results in [~3330][0] vs [~3490][1] instructions).

[0]: https://rust.godbolt.org/z/xsees1r7r
[1]: https://rust.godbolt.org/z/5q19WYW14