### PR TITLE
Implement `CollisionResistance` for XOFs

### DIFF
--- a/ascon-hash/src/lib.rs
+++ b/ascon-hash/src/lib.rs
@@ -12,12 +12,12 @@ use core::marker::PhantomData;
 use ascon::State;
 pub use digest::{self, Digest, ExtendableOutput, Reset, Update, XofReader};
 use digest::{
-    HashMarker, Output, OutputSizeUser,
+    CollisionResistance, HashMarker, Output, OutputSizeUser,
     block_api::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, ExtendableOutputCore,
         FixedOutputCore, UpdateCore, XofReaderCore,
     },
-    consts::{U8, U32, U40},
+    consts::{U8, U16, U32, U40},
     crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
 };
 
@@ -294,3 +294,8 @@ digest::buffer_xof!(
     pub struct AsconXof128Reader(AsconXofReaderCore);
     impl: XofReaderTraits;
 );
+
+impl CollisionResistance for AsconXof128 {
+    // https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-232.ipd.pdf#table.caption.25
+    type CollisionResistance = U16;
+}

--- a/k12/src/lib.rs
+++ b/k12/src/lib.rs
@@ -15,10 +15,10 @@ pub mod block_api;
 
 use core::fmt;
 use digest::{
-    ExtendableOutput, HashMarker, Reset, Update, XofReader,
+    CollisionResistance, ExtendableOutput, HashMarker, Reset, Update, XofReader,
     block_api::{AlgorithmName, BlockSizeUser, ExtendableOutputCore, UpdateCore, XofReaderCore},
     block_buffer::{BlockBuffer, Eager, ReadBuffer},
-    consts::{U128, U168},
+    consts::{U16, U128, U168},
 };
 
 /// `KangarooTwelve` hasher.
@@ -80,6 +80,11 @@ impl ExtendableOutput for KangarooTwelve<'_> {
             buffer: Default::default(),
         }
     }
+}
+
+impl CollisionResistance for KangarooTwelve<'_> {
+    // https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#section-7-7
+    type CollisionResistance = U16;
 }
 
 #[cfg(feature = "zeroize")]

--- a/sha3/src/cshake.rs
+++ b/sha3/src/cshake.rs
@@ -4,12 +4,12 @@ use crate::{
 };
 use core::fmt;
 use digest::{
-    CustomizedInit, HashMarker, Reset,
+    CollisionResistance, CustomizedInit, HashMarker, Reset,
     block_api::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, ExtendableOutputCore,
         UpdateCore,
     },
-    consts::{U136, U168, U400},
+    consts::{U16, U32, U136, U168, U400},
     crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::Unsigned,
 };
@@ -212,3 +212,13 @@ macro_rules! impl_cshake {
 
 impl_cshake!(CShake128Core, CShake128, CShake128Reader, U168, "cSHAKE128");
 impl_cshake!(CShake256Core, CShake256, CShake256Reader, U136, "cSHAKE256");
+
+impl CollisionResistance for CShake128 {
+    // https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf#[{"num":68,"gen":0},{"name":"XYZ"},108,440,null]
+    type CollisionResistance = U16;
+}
+
+impl CollisionResistance for CShake256 {
+    // https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf#[{"num":68,"gen":0},{"name":"XYZ"},108,440,null]
+    type CollisionResistance = U32;
+}

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -8,7 +8,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations)]
 
-pub use digest::{self, CustomizedInit, Digest};
+pub use digest::{self, CollisionResistance, CustomizedInit, Digest};
 
 /// Block-level types
 pub mod block_api;
@@ -19,7 +19,7 @@ pub use cshake::{CShake128, CShake128Reader, CShake256, CShake256Reader};
 pub use turbo_shake::{TurboShake128, TurboShake128Reader, TurboShake256, TurboShake256Reader};
 
 use block_api::{Sha3HasherCore, Sha3ReaderCore};
-use digest::consts::{U0, U28, U32, U48, U64, U72, U104, U136, U144, U168, U200};
+use digest::consts::{U0, U16, U28, U32, U48, U64, U72, U104, U136, U144, U168, U200};
 
 // Paddings
 const KECCAK_PAD: u8 = 0x01;
@@ -98,3 +98,13 @@ digest::buffer_fixed!(
     pub struct Keccak512(Sha3HasherCore<U72, U64, KECCAK_PAD>);
     impl: FixedHashTraits;
 );
+
+impl CollisionResistance for Shake128 {
+    // https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf#page=31
+    type CollisionResistance = U16;
+}
+
+impl CollisionResistance for Shake256 {
+    // https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf#page=31
+    type CollisionResistance = U32;
+}

--- a/sha3/src/turbo_shake.rs
+++ b/sha3/src/turbo_shake.rs
@@ -1,12 +1,12 @@
 use crate::{Sha3HasherCore, Sha3ReaderCore};
 use core::fmt;
 use digest::{
-    ExtendableOutput, ExtendableOutputReset, HashMarker, Update, XofReader,
+    CollisionResistance, ExtendableOutput, ExtendableOutputReset, HashMarker, Update, XofReader,
     block_api::{
         AlgorithmName, BlockSizeUser, ExtendableOutputCore, Reset, UpdateCore, XofReaderCore,
     },
     block_buffer::{EagerBuffer, ReadBuffer},
-    consts::{U0, U136, U168},
+    consts::{U0, U16, U32, U136, U168},
 };
 
 const TURBO_SHAKE_ROUND_COUNT: usize = 12;
@@ -121,3 +121,13 @@ macro_rules! impl_turbo_shake {
 
 impl_turbo_shake!(TurboShake128, TurboShake128Reader, U168, "TurboSHAKE128");
 impl_turbo_shake!(TurboShake256, TurboShake256Reader, U136, "TurboSHAKE256");
+
+impl<const DS: u8> CollisionResistance for TurboShake128<DS> {
+    // https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#section-7-7
+    type CollisionResistance = U16;
+}
+
+impl<const DS: u8> CollisionResistance for TurboShake256<DS> {
+    // https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#section-7-8
+    type CollisionResistance = U32;
+}


### PR DESCRIPTION
This PR implements `CollisionResistance` for all XOFs. I started with those to add support for `ExpandMsgXof` in `elliptic-curve` and will do follow-up PRs for at least SHA2 and SHA3 fixed output hashes.

Companion PR: https://github.com/RustCrypto/traits/pull/1862.

See https://github.com/RustCrypto/traits/issues/1816 for previous discussions.