### PR TITLE
Bump `digest` dependency to v0.11.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-pre.5"
+version = "0.2.0-rc.0"
 dependencies = [
  "base16ct",
  "belt-block",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 dependencies = [
  "base16ct",
  "digest",
@@ -93,16 +93,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.2"
-source = "git+https://github.com/RustCrypto/traits#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+version = "0.2.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.0-pre.10"
-source = "git+https://github.com/RustCrypto/traits#915474f1ed5be0a19fd102d5f75ef8e04c765416"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460dd7f37e4950526b54a5a6b1f41b6c8e763c58eb9a8fc8fc05ba5c2f44ca7b"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -206,7 +208,7 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -261,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.2.0-pre.5"
+version = "0.2.0-rc.0"
 dependencies = [
  "base16ct",
  "digest",
@@ -270,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -292,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -303,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 dependencies = [
  "base16ct",
  "digest",
@@ -332,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-pre.5"
+version = "0.5.0-rc.0"
 dependencies = [
  "base16ct",
  "digest",
@@ -347,7 +349,7 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 
 [[package]]
 name = "streebog"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 dependencies = [
  "base16ct",
  "digest",
@@ -403,7 +405,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "whirlpool"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 dependencies = [
  "base16ct",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-# https://github.com/RustCrypto/traits/pull/1787
-# https://github.com/RustCrypto/traits/pull/1799
-digest = { git = "https://github.com/RustCrypto/traits" }

--- a/ascon-hash/Cargo.toml
+++ b/ascon-hash/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["crypto", "hash", "ascon"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 ascon = { version = "0.4", default-features = false }
 
 [dev-dependencies]

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-hash"
-version = "0.2.0-pre.5"
+version = "0.2.0-rc.0"
 description = "BelT hash function (STB 34.101.31-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ keywords = ["crypto", "belt", "stb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 belt-block = { version = "0.1.1", default-features = false }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["crypto", "blake2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["mac"] }
+digest = { version = "0.11.0-rc.0", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "fsb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
-whirlpool = { version = "=0.11.0-pre.5", path = "../whirlpool", default-features = false }
+digest = "0.11.0-rc.0"
+whirlpool = { version = "0.11.0-rc.0", path = "../whirlpool", default-features = false }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "gost94", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "groestl", "grostl", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["crypto", "jh", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 hex-literal = "1"
 simd = { package = "ppv-lite86", version = "0.2.6" }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 base16ct = { version = "0.2", features = ["alloc"] }
 
 [features]

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
-sha3 = { version = "=0.11.0-pre.5", default-features = false, path = "../sha3" }
+digest = "0.11.0-rc.0"
+sha3 = { version = "0.11.0-rc.0", default-features = false, path = "../sha3" }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["alloc", "dev"] }
+digest = { version = "0.11.0-rc.0", features = ["alloc", "dev"] }
 hex-literal = "1"
 
 [features]

--- a/kupyna/Cargo.toml
+++ b/kupyna/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "md2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "md4", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -16,11 +16,11 @@ categories = ["cryptography", "no-std"]
 name = "md5"
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 cfg-if = "1"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ripemd"
-version = "0.2.0-pre.5"
+version = "0.2.0-rc.0"
 description = "Pure Rust implementation of the RIPEMD hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["crypto", "ripemd", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -18,12 +18,12 @@ exclude = [
 ]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
-sha1 = { version = "=0.11.0-pre.5", path = "../sha1", default-features = false }
+digest = "0.11.0-rc.0"
+sha1 = { version = "0.11.0-rc.0", path = "../sha1", default-features = false }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,14 +13,14 @@ keywords = ["crypto", "sha1", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 cfg-if = "1.0"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.
@@ -16,14 +16,14 @@ keywords = ["crypto", "sha2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 cfg-if = "1"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as
@@ -17,11 +17,11 @@ keywords = ["crypto", "sha3", "keccak", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 keccak = "=0.2.0-pre.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "shabal", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "skein", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 threefish = { version = "0.5.2", default-features = false }
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm3"
-version = "0.5.0-pre.5"
+version = "0.5.0-rc.0"
 description = "SM3 (OSCCA GM/T 0004-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["crypto", "sm3", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["crypto", "streebog", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/tiger/Cargo.toml
+++ b/tiger/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "hash", "tiger", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whirlpool"
-version = "0.11.0-pre.5"
+version = "0.11.0-rc.0"
 description = "Whirlpool hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["crypto", "whirlpool", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "=0.11.0-pre.10"
+digest = "0.11.0-rc.0"
 
 [dev-dependencies]
-digest = { version = "=0.11.0-pre.10", features = ["dev"] }
+digest = { version = "0.11.0-rc.0", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 


### PR DESCRIPTION
Also includes new `rc.0` prereleases of crates we've previously done prereleases for (i.e. that are deps elsewhere in the project)