### PR TITLE
workspace: avoid duplicates when pulling dependency from git

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,8 @@ members = [
 
 [profile.dev]
 opt-level = 2
+
+[patch.crates-io]
+sha1 = { path = "sha1" }
+sha3 = { path = "sha3" }
+whirlpool = { path = "whirlpool" }

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 digest = "0.11.0-rc.0"
-whirlpool = { version = "0.11.0-rc.0", path = "../whirlpool", default-features = false }
+whirlpool = { version = "0.11.0-rc.0", default-features = false }
 
 [dev-dependencies]
 digest = { version = "0.11.0-rc.0", features = ["dev"] }

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 digest = "0.11.0-rc.0"
-sha3 = { version = "0.11.0-rc.0", default-features = false, path = "../sha3" }
+sha3 = { version = "0.11.0-rc.0", default-features = false }
 
 [dev-dependencies]
 digest = { version = "0.11.0-rc.0", features = ["alloc", "dev"] }

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 
 [dependencies]
 digest = "0.11.0-rc.0"
-sha1 = { version = "0.11.0-rc.0", path = "../sha1", default-features = false }
+sha1 = { version = "0.11.0-rc.0", default-features = false }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
When pulling dependencies using a `patch.crates-io` to a git dependency like:
```
[dependencies]
sha1 = "0.11.0-rc.0"

[patch.crates-io]
sha1-checked = { git = "https://github.com/RustCrypto/hashes.git" }
```

Cargo will duplicate sha1 dependency:
```
[[package]]
name = "sha1"
version = "0.11.0-rc.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
checksum = "6f9318facddf9ac32a33527066936837e189b3f23ced6edc1603720ead5e2b3d"
dependencies = [
 "cfg-if",
 "cpufeatures",
 "digest 0.11.0-rc.0",
]

[[package]]
name = "sha1"
version = "0.11.0-rc.0"
source = "git+https://github.com/RustCrypto/hashes.git#2bcfb5a0a849503ed73b190538787a00c58baada"
dependencies = [
 "cfg-if",
 "cpufeatures",
 "digest 0.11.0-rc.0",
]

[[package]]
name = "sha1-checked"
version = "0.11.0-pre"
source = "git+https://github.com/RustCrypto/hashes.git#2bcfb5a0a849503ed73b190538787a00c58baada"
dependencies = [
 "digest 0.11.0-rc.0",
 "sha1 0.11.0-rc.0 (git+https://github.com/RustCrypto/hashes.git)",
 "zeroize",
]
```

This causes issues further down the line, for example when the downstream client is built with nix which does not support two copies of the same crate/version tuple.

This switches the local overrides using a workspace patch instead which are not used when the crate is consumed via git.