### PR TITLE
Replace dead Tiger hash link with official project page

### DIFF
--- a/tiger/README.md
+++ b/tiger/README.md
@@ -59,5 +59,5 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, without 
 
 [//]: # (general links)
 
-[Tiger]: http://www.cs.technion.ac.il/~biham/Reports/Tiger/tiger/tiger.html
+[Tiger]: https://biham.cs.technion.ac.il/Reports/Tiger/
 [examples section]: https://github.com/RustCrypto/hashes#Examples


### PR DESCRIPTION
The outdated and non-working link to the Tiger hash function specification was replaced with the official project page (https://biham.cs.technion.ac.il/Reports/Tiger/). This update ensures that users have access to the authoritative source for the Tiger algorithm, including its description, reference implementation, and related resources.