### PR TITLE
recommend BLAKE3 instead of BLAKE2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Additionally all crates do not require the standard library (i.e. `no_std` capab
 
 ## Supported Algorithms
 
-**Note:** For new applications, or where compatibility with other existing standards is not a primary concern, we strongly recommend to use either BLAKE2, SHA-2 or SHA-3.
+**Note:** For new applications, or where compatibility with other existing standards is not a primary concern, we strongly recommend to use either BLAKE3, SHA-2 or SHA-3.
 
 | Algorithm | Crate | Crates.io | Documentation | MSRV | [Security] |
 |-----------|-------|:---------:|:-------------:|:----:|:----------:|

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Additionally all crates do not require the standard library (i.e. `no_std` capab
 
 ## Supported Algorithms
 
-**Note:** For new applications, or where compatibility with other existing standards is not a primary concern, we strongly recommend to use either BLAKE3, SHA-2 or SHA-3.
+**Note:** For new applications, or where compatibility with other existing standards is not a primary concern, we strongly recommend to use either [BLAKE3][`blake3`], SHA-2 or SHA-3.
 
 | Algorithm | Crate | Crates.io | Documentation | MSRV | [Security] |
 |-----------|-------|:---------:|:-------------:|:----:|:----------:|


### PR DESCRIPTION
Reasons:
 * BLAKE3 has been out for 5 years now.
 * No further cryptanalytic results have come out indicating that it might not be secure (nor for BLAKE2, nor BLAKE, nor ChaCha20, nor Salsa20).
 * BLAKE3 has a major, qualitative efficiency improvement, which is the Merkle Tree structure, allowing (but not requiring) any amount of parallelism.
 * BLAKE3 is already extensively adopted in many different projects in many different industries/areas/niches.
 * BLAKE3 is currently being more actively maintained, as in patches are being accepted by the chief maintainer, Jack "@oconnor663" O'Connor. https://github.com/BLAKE3-team/BLAKE3/commits/master/

P.S. Hi, Tony! :-)