### PR TITLE
sm3: add `AssociatedOid` implementation

### DIFF
--- a/sm3/CHANGELOG.md
+++ b/sm3/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.5.0 (UNRELEASED)
 ### Added
 - `alloc` crate feature ([#678])
+- `oid` crate feature and `AssociatedOid` trait implementation ([#706])
 
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#652])
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#652]: https://github.com/RustCrypto/hashes/pull/652
 [#678]: https://github.com/RustCrypto/hashes/pull/678
+[#706]: https://github.com/RustCrypto/hashes/pull/706
 
 ## 0.4.2 (2023-05-16)
 ### Changed

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -21,8 +21,9 @@ hex-literal = "1"
 base16ct = { version = "0.2", features = ["alloc"] }
 
 [features]
-default = ["alloc"]
+default = ["alloc", "oid"]
 alloc = ["digest/alloc"]
+oid = ["digest/oid"] # Enable OID support
 zeroize = ["digest/zeroize"]
 
 [package.metadata.docs.rs]

--- a/sm3/src/lib.rs
+++ b/sm3/src/lib.rs
@@ -20,5 +20,8 @@ pub use block_api::Sm3Core;
 digest::buffer_fixed!(
     /// ShangMi 3 (SM3) hasher.
     pub struct Sm3(block_api::Sm3Core);
+    // Note that we use the GM/T OID here.
+    // SM3 has also an alternative ISO OID assigned to it.
+    oid: "1.2.156.10197.1.401";
     impl: FixedHashTraits;
 );

--- a/sm3/tests/mod.rs
+++ b/sm3/tests/mod.rs
@@ -29,3 +29,13 @@ fn sm3_rand() {
         hex!("ad154967b08d636a148dd4c688a6df7add1ed1946af18eb358a9b320de2aca86"),
     );
 }
+
+#[cfg(feature = "oid")]
+#[test]
+fn sm3_oid() {
+    use sm3::digest::const_oid::{AssociatedOid, ObjectIdentifier};
+    assert_eq!(
+        Sm3::OID,
+        ObjectIdentifier::new_unwrap("1.2.156.10197.1.401")
+    );
+}


### PR DESCRIPTION
The implementation uses the GM/T OID. SM3 also has an alternative ISO OID assigned to it (and IIRC several others), but we have to select one. If necessary, in future we may introduce different wrappers (e.g. `Sm3Iso`).

Closes #705 