### PR TITLE
Remove `crypto` tags

### DIFF
--- a/ascon-hash/Cargo.toml
+++ b/ascon-hash/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/ascon-hash"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "hash", "ascon"]
+keywords = ["hash", "ascon"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/belt-hash"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "belt", "stb", "hash", "digest"]
+keywords = ["belt", "stb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/blake2"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "blake2", "hash", "digest"]
+keywords = ["blake2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/fsb"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "fsb", "hash", "digest"]
+keywords = ["fsb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/gost94"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "gost94", "gost", "hash", "digest"]
+keywords = ["gost94", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/groestl"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "groestl", "grostl", "hash", "digest"]
+keywords = ["groestl", "grostl", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/jh"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "jh", "hash", "digest"]
+keywords = ["jh", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/k12"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "hash", "digest"]
+keywords = ["hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/kupyna/Cargo.toml
+++ b/kupyna/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 edition = "2024"
 documentation = "https://docs.rs/kupyna"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "hash", "kupyna"]
+keywords = ["hash", "kupyna"]
 categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/md2"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "md2", "hash", "digest"]
+keywords = ["md2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/md4"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "md4", "hash", "digest"]
+keywords = ["md4", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/md-5"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "md5", "hash", "digest"]
+keywords = ["md5", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [lib]

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/ripemd"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "ripemd", "hash", "digest"]
+keywords = ["ripemd", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/sha1-checked"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "sha1", "hash", "digest"]
+keywords = ["sha1", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 exclude = [

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/sha1"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "sha1", "hash", "digest"]
+keywords = ["sha1", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/sha2"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "sha2", "hash", "digest"]
+keywords = ["sha2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/sha3"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "sha3", "keccak", "hash", "digest"]
+keywords = ["sha3", "keccak", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/shabal"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "shabal", "hash", "digest"]
+keywords = ["shabal", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 readme = "README.md"
 documentation = "https://docs.rs/skein"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "skein", "hash", "digest"]
+keywords = ["skein", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/sm3"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "sm3", "hash", "digest"]
+keywords = ["sm3", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/streebog"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "streebog", "gost", "hash", "digest"]
+keywords = ["streebog", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/tiger/Cargo.toml
+++ b/tiger/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/tiger"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "hash", "tiger", "digest"]
+keywords = ["hash", "tiger", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 rust-version = "1.85"
 documentation = "https://docs.rs/whirlpool"
 repository = "https://github.com/RustCrypto/hashes"
-keywords = ["crypto", "whirlpool", "hash", "digest"]
+keywords = ["whirlpool", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]


### PR DESCRIPTION
The tag effectively duplicates the cryptography category which we use for all our crates. Per discussion in #717 we decided that we should not have such duplication.