### PR TITLE
Bump `digest` to v0.11.0-rc.1

### DIFF
--- a/.github/workflows/fsb.yml
+++ b/.github/workflows/fsb.yml
@@ -26,7 +26,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.85.0
+      msrv: 1.85.0
 
   build:
     needs: set-msrv
@@ -66,7 +66,8 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack test --feature-powerset
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-        working-directory: ${{ github.workflow }}
+# Disabled until new `whirlpool` prerelease is cut (@tarcieri)
+#  minimal-versions:
+#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+#    with:
+#        working-directory: ${{ github.workflow }}

--- a/.github/workflows/k12.yml
+++ b/.github/workflows/k12.yml
@@ -26,7 +26,7 @@ jobs:
   set-msrv:
     uses: RustCrypto/actions/.github/workflows/set-msrv.yml@master
     with:
-        msrv: 1.85.0
+      msrv: 1.85.0
 
   build:
     needs: set-msrv
@@ -66,7 +66,8 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack test --feature-powerset
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-        working-directory: ${{ github.workflow }}
+# Disabled until new `sha3` prerelease is cut (@tarcieri)
+#  minimal-versions:
+#    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+#    with:
+#        working-directory: ${{ github.workflow }}

--- a/.github/workflows/sha1-checked.yml
+++ b/.github/workflows/sha1-checked.yml
@@ -51,10 +51,11 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: cargo hack build --target ${{ matrix.target }} --each-feature --exclude-features default,std
 
-  minimal-versions:
-    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
-    with:
-      working-directory: ${{ github.workflow }}
+  # Disabled until new `sha1` prerelease is cut (@tarcieri)
+  #  minimal-versions:
+  #    uses: RustCrypto/actions/.github/workflows/minimal-versions.yml@master
+  #    with:
+  #      working-directory: ${{ github.workflow }}
 
   # Linux tests
   linux:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -61,8 +61,9 @@ source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc358
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -91,16 +92,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.3"
-source = "git+https://github.com/RustCrypto/traits#062af9bd26c388f371dfec79cdaf889b515fe381"
+version = "0.2.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits#062af9bd26c388f371dfec79cdaf889b515fe381"
+version = "0.11.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4aae35a0fcbe22ff1be50fe96df72002d5a4a6fb4aae9193cf2da0daa36da2"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -204,7 +207,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -268,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -290,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -301,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -345,7 +348,7 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -401,7 +404,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "whirlpool"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,3 @@ whirlpool = { path = "whirlpool" }
 
 # https://github.com/RustCrypto/utils/pull/1187
 blobby = { git = "https://github.com/RustCrypto/utils" }
-# https://github.com/RustCrypto/traits/pull/1976
-crypto-common = { git = "https://github.com/RustCrypto/traits" }
-# https://github.com/RustCrypto/traits/pull/1916
-# https://github.com/RustCrypto/traits/pull/1953
-# https://github.com/RustCrypto/traits/pull/1958
-# https://github.com/RustCrypto/traits/pull/1976
-digest = { git = "https://github.com/RustCrypto/traits" }
-# https://github.com/RustCrypto/utils/pull/1200
-# https://github.com/RustCrypto/traits/pull/1976
-block-buffer = { git = "https://github.com/RustCrypto/utils" }

--- a/ascon-hash/Cargo.toml
+++ b/ascon-hash/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["hash", "ascon"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 ascon = { version = "0.4", default-features = false }
 
 [dev-dependencies]

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["belt", "stb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 belt-block = { version = "0.1.1", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["blake2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.11.0-rc.0", features = ["mac"] }
+digest = { version = "0.11.0-rc.1", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["fsb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
-whirlpool = { version = "0.11.0-rc.0", default-features = false }
+digest = "0.11.0-rc.1"
+whirlpool = { version = "0.11.0-rc.1", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["gost94", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["groestl", "grostl", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["jh", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 hex-literal = "1"
 simd = { package = "ppv-lite86", version = "0.2.6" }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 base16ct = { version = "0.3", features = ["alloc"] }
 
 [features]

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
-sha3 = { version = "0.11.0-rc.0", default-features = false }
+digest = "0.11.0-rc.1"
+sha3 = { version = "0.11.0-rc.1", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["alloc", "dev"] }
+digest = { version = "0.11.0-rc.1", features = ["alloc", "dev"] }
 hex-literal = "1"
 
 [features]

--- a/kupyna/Cargo.toml
+++ b/kupyna/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["md2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["md4", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -16,11 +16,11 @@ categories = ["cryptography", "no-std"]
 name = "md5"
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 cfg-if = "1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["ripemd", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -18,12 +18,12 @@ exclude = [
 ]
 
 [dependencies]
-digest = "0.11.0-rc.0"
-sha1 = { version = "0.11.0-rc.0", default-features = false }
+digest = "0.11.0-rc.1"
+sha1 = { version = "0.11.0-rc.1", default-features = false }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,14 +13,14 @@ keywords = ["sha1", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 cfg-if = "1.0"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.
@@ -16,14 +16,14 @@ keywords = ["sha2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 cfg-if = "1"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as
@@ -17,11 +17,11 @@ keywords = ["sha3", "keccak", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 keccak = "=0.2.0-pre.0"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["shabal", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["skein", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 threefish = { version = "0.5.2", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["sm3", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["streebog", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/tiger/Cargo.toml
+++ b/tiger/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["hash", "tiger", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whirlpool"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = "Whirlpool hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["whirlpool", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.0"
+digest = "0.11.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.0", features = ["dev"] }
+digest = { version = "0.11.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "0.3", features = ["alloc"] }
 


### PR DESCRIPTION
Notably this includes `hybrid-array` v0.4 support