### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "base16ct",
  "belt-block",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -207,7 +207,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -348,7 +348,7 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -404,7 +404,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "whirlpool"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-hash"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "BelT hash function (STB 34.101.31-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ripemd"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "Pure Rust implementation of the RIPEMD hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 
 [dependencies]
 digest = "0.11.0-rc.1"
-sha1 = { version = "0.11.0-rc.1", default-features = false }
+sha1 = { version = "0.11.0-rc.2", default-features = false }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm3"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 description = "SM3 (OSCCA GM/T 0004-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whirlpool"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = "Whirlpool hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases the following:
- `belt-hash` v0.2.0-rc.1
- `blake2` v0.11.0-rc.2
- `md-5` v0.11.0-rc.2
- `ripemd` v0.2.0-rc.1
- `sha1` v0.11.0-rc.2
- `sha2` v0.11.0-rc.2
- `sha3` v0.11.0-rc.2
- `sm3` v0.5.0-rc.1
- `streebog` v0.11.0-rc.2
- `whirlpool` v0.11.0-rc.2