### PR TITLE
sha3 v0.11.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "base16ct",
  "digest",

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as


### PR DESCRIPTION
This includes a bump of `keccak` to v0.2.0-rc.0