### PR TITLE
fix: replace removed sha2 compression function exports

### DIFF
--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -33,6 +33,9 @@ mod consts;
 mod sha256;
 mod sha512;
 
+pub use sha256::compress256;
+pub use sha512::compress512;
+
 digest::buffer_fixed!(
     /// SHA-256 hasher.
     pub struct Sha256(CtOutWrapper<block_api::Sha256VarCore, U32>);


### PR DESCRIPTION
Closes #732 

This PR replaces the exports for the sha2 compression functions that were removed in error.