### PR TITLE
fix(simd): correct variable naming from efgh to hgfe in SHA-256 imple…

### DIFF
--- a/sha2/src/sha256/x86_shani.rs
+++ b/sha2/src/sha256/x86_shani.rs
@@ -48,10 +48,10 @@ unsafe fn digest_blocks(state: &mut [u32; 8], blocks: &[[u8; 64]]) {
 
     let state_ptr: *const __m128i = state.as_ptr().cast();
     let dcba = _mm_loadu_si128(state_ptr.add(0));
-    let efgh = _mm_loadu_si128(state_ptr.add(1));
+    let hgfe = _mm_loadu_si128(state_ptr.add(1));
 
     let cdab = _mm_shuffle_epi32(dcba, 0xB1);
-    let efgh = _mm_shuffle_epi32(efgh, 0x1B);
+    let efgh = _mm_shuffle_epi32(hgfe, 0x1B);
     let mut abef = _mm_alignr_epi8(cdab, efgh, 8);
     let mut cdgh = _mm_blend_epi16(efgh, cdab, 0xF0);
 


### PR DESCRIPTION
 i think the variable name is incorrect, it make me confusing, 
 I've reviewed the code and believe this variable should be renamed from efghto hgfe.
 
<img width="1065" height="170" alt="image" src="https://github.com/user-attachments/assets/6dedb3f7-0fe8-4d28-a633-707a0c2c1adf" />
<img width="928" height="434" alt="image" src="https://github.com/user-attachments/assets/b1d16877-00c6-4aa9-8689-6cab665db8c3" />
