### PR TITLE
md5: Add optimized AArch64 assembly implementation

### DIFF
--- a/md5/src/compress.rs
+++ b/md5/src/compress.rs
@@ -2,6 +2,9 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "force-soft")] {
         mod soft;
         use soft::compress as compress_inner;
+    } else if #[cfg(target_arch = "aarch64")] {
+        mod aarch64_asm;
+        use aarch64_asm::compress as compress_inner;
     } else if #[cfg(target_arch = "loongarch64")] {
         mod loongarch64_asm;
         use loongarch64_asm::compress as compress_inner;

--- a/md5/src/compress/aarch64_asm.rs
+++ b/md5/src/compress/aarch64_asm.rs
@@ -483,9 +483,9 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             "add    {d:w}, {a:w}, w8",          // a + rotated -> new d
 
             // F2: c, d, a, b, cache2, RC[2], 17 - optimized scheduling
-            "add    w10, {data2:w}, {k1:w}",    // cache2 + RC[2] (lower 32 bits) - start early
-            "and    w8, {d:w}, {a:w}",          // d & a
-            "bic    w9, {b:w}, {d:w}",          // b & !d
+            "and    w8, {d:w}, {a:w}",          // d & a (independent calc first)
+            "add    w10, {data2:w}, {k1:w}",    // cache2 + RC[2] (parallel)
+            "bic    w9, {b:w}, {d:w}",          // b & !d (parallel)
             "add    w9, {c:w}, w9",             // c + (b & !d)
             "add    w10, w9, w10",              // c + (b & !d) + cache2 + RC[2]
             "add    w8, w10, w8",               // add (d & a)

--- a/md5/src/compress/aarch64_asm.rs
+++ b/md5/src/compress/aarch64_asm.rs
@@ -1,0 +1,245 @@
+//! AArch64 assembly backend
+
+#![allow(clippy::many_single_char_names, clippy::unreadable_literal)]
+use crate::consts::RC;
+
+// Note: Apple M1 supports NEON and basic crypto extensions
+// For now, we'll optimize the I function with ORN instruction (available in scalar AArch64)
+
+// Animetosho optimization: Pack constants into 64-bit values for more efficient loading
+#[allow(dead_code)]
+static MD5_CONSTANTS_PACKED: [u64; 32] = [
+    // F round constants (packed pairs)
+    0xe8c7b756d76aa478, 0xc1bdceee242070db, 0x4787c62af57c0faf, 0xfd469501a8304613,
+    0x8b44f7af698098d8, 0x895cd7beffff5bb1, 0xfd9871936b901122, 0x49b40821a679438e,
+    // G round constants  
+    0xc040b340f61e2562, 0xe9b6c7aa265e5a51, 0x02441453d62f105d, 0xe7d3fbc8d8a1e681,
+    0xc33707d621e1cde6, 0x455a14edf4d50d87, 0xfcefa3f8a9e3e905, 0x8d2a4c8a676f02d9,
+    // H round constants
+    0x8771f681fffa3942, 0xfde5380c6d9d6122, 0x4bdecfa9a4beea44, 0xbebfbc70f6bb4b60, 
+    0xeaa127fa289b7ec6, 0x04881d05d4ef3085, 0xe6db99e5d9d4d039, 0xc4ac56651fa27cf8,
+    // I round constants
+    0x432aff97f4292244, 0xfc93a039ab9423a7, 0x8f0ccc92655b59c3, 0x85845dd1ffeff47d,
+    0xfe2ce6e06fa87e4f, 0x4e0811a1a3014314, 0xbd3af235f7537e82, 0xeb86d3912ad7d2bb
+];
+
+macro_rules! asm_op_f {
+    ($a:ident, $b:ident, $c:ident, $d:ident, $m:expr, $rc:expr, $s:expr) => {
+        unsafe {
+            core::arch::asm!(
+                // Optimized F with potential memory operand
+                "and    w8, {b:w}, {c:w}",      // b & c
+                "bic    w9, {d:w}, {b:w}",      // d & !b
+                "add    w9, {a:w}, w9",         // a + (d & !b)
+                "add    w10, {m:w}, {rc:w}",    // m + rc
+                "add    w9, w9, w10",           // combine: a + (d & !b) + m + rc
+                "add    w8, w9, w8",            // add (b & c)
+                "ror    w8, w8, #{ror}",        // rotate
+                "add    {a:w}, {b:w}, w8",      // b + rotated_result
+                a = inout(reg) $a,
+                b = in(reg) $b,
+                c = in(reg) $c,
+                d = in(reg) $d,
+                m = in(reg) $m,
+                rc = in(reg) $rc,
+                ror = const (32 - $s),
+                out("w8") _,
+                out("w9") _,
+                out("w10") _,
+            );
+        }
+    };
+}
+
+macro_rules! asm_op_g {
+    ($a:ident, $b:ident, $c:ident, $d:ident, $m:expr, $rc:expr, $s:expr) => {
+        unsafe {
+            core::arch::asm!(
+                // Animetosho's G shortcut: use ADD instead of OR for better scheduling
+                "and    w8, {b:w}, {d:w}",      // b & d  
+                "bic    w9, {c:w}, {d:w}",      // c & !d
+                "add    w10, {a:w}, {rc:w}",    // a + rc (delay dependency on b)
+                "add    w10, w10, {m:w}",       // a + rc + m
+                "add    w10, w10, w9",          // a + rc + m + (c & !d)  
+                "add    w8, w10, w8",           // add (b & d) - use ADD not OR!
+                "ror    w8, w8, #{ror}",        // rotate
+                "add    {a:w}, {b:w}, w8",      // b + rotated_result
+                a = inout(reg) $a,
+                b = in(reg) $b,
+                c = in(reg) $c,
+                d = in(reg) $d,
+                m = in(reg) $m,
+                rc = in(reg) $rc,
+                ror = const (32 - $s),
+                out("w8") _,
+                out("w9") _,
+                out("w10") _,
+            );
+        }
+    };
+}
+
+macro_rules! asm_op_h {
+    ($a:ident, $b:ident, $c:ident, $d:ident, $m:expr, $rc:expr, $s:expr) => {
+        unsafe {
+            core::arch::asm!(
+                // Optimized H function: delay dependency on b for better scheduling
+                "add    w9, {m:w}, {rc:w}",     // m + rc first (no dependency)
+                "eor    w8, {c:w}, {d:w}",      // c ^ d first (no dependency on b)
+                "add    w9, {a:w}, w9",         // a + m + rc 
+                "eor    w8, w8, {b:w}",         // (c ^ d) ^ b = b ^ c ^ d (delay b use)
+                "add    w8, w9, w8",            // add h_result
+                "ror    w8, w8, #{ror}",        // rotate
+                "add    {a:w}, {b:w}, w8",      // b + rotated_result
+                a = inout(reg) $a,
+                b = in(reg) $b,
+                c = in(reg) $c,
+                d = in(reg) $d,
+                m = in(reg) $m,
+                rc = in(reg) $rc,
+                ror = const (32 - $s),
+                out("w8") _,
+                out("w9") _,
+            );
+        }
+    };
+}
+
+macro_rules! asm_op_i {
+    ($a:ident, $b:ident, $c:ident, $d:ident, $m:expr, $rc:expr, $s:expr) => {
+        unsafe {
+            core::arch::asm!(
+                // Optimize I function with same pattern
+                "orn    w8, {b:w}, {d:w}",      // b | !d (OR NOT)
+                "add    w9, {m:w}, {rc:w}",     // m + rc in parallel
+                "eor    w8, w8, {c:w}",         // c ^ (b | !d)
+                "add    w9, {a:w}, w9",         // a + m + rc
+                "add    w8, w9, w8",            // add i_result
+                "ror    w8, w8, #{ror}",        // rotate
+                "add    {a:w}, {b:w}, w8",      // b + rotated_result
+                a = inout(reg) $a,
+                b = in(reg) $b,
+                c = in(reg) $c,
+                d = in(reg) $d,
+                m = in(reg) $m,
+                rc = in(reg) $rc,
+                ror = const (32 - $s),
+                out("w8") _,
+            );
+        }
+    };
+}
+
+
+
+#[inline]
+fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
+    let mut a = state[0];
+    let mut b = state[1];
+    let mut c = state[2];
+    let mut d = state[3];
+
+    // Load data efficiently and cache frequently used values
+    let mut data = [0u32; 16];
+    for (o, chunk) in data.iter_mut().zip(input.chunks_exact(4)) {
+        *o = u32::from_le_bytes(chunk.try_into().unwrap());
+    }
+    
+    // Additional optimizations: better instruction scheduling and reduced dependencies
+
+    // round 1
+    asm_op_f!(a, b, c, d, data[0], RC[0], 7);
+    asm_op_f!(d, a, b, c, data[1], RC[1], 12);
+    asm_op_f!(c, d, a, b, data[2], RC[2], 17);
+    asm_op_f!(b, c, d, a, data[3], RC[3], 22);
+
+    asm_op_f!(a, b, c, d, data[4], RC[4], 7);
+    asm_op_f!(d, a, b, c, data[5], RC[5], 12);
+    asm_op_f!(c, d, a, b, data[6], RC[6], 17);
+    asm_op_f!(b, c, d, a, data[7], RC[7], 22);
+
+    asm_op_f!(a, b, c, d, data[8], RC[8], 7);
+    asm_op_f!(d, a, b, c, data[9], RC[9], 12);
+    asm_op_f!(c, d, a, b, data[10], RC[10], 17);
+    asm_op_f!(b, c, d, a, data[11], RC[11], 22);
+
+    asm_op_f!(a, b, c, d, data[12], RC[12], 7);
+    asm_op_f!(d, a, b, c, data[13], RC[13], 12);
+    asm_op_f!(c, d, a, b, data[14], RC[14], 17);
+    asm_op_f!(b, c, d, a, data[15], RC[15], 22);
+
+    // round 2
+    asm_op_g!(a, b, c, d, data[1], RC[16], 5);
+    asm_op_g!(d, a, b, c, data[6], RC[17], 9);
+    asm_op_g!(c, d, a, b, data[11], RC[18], 14);
+    asm_op_g!(b, c, d, a, data[0], RC[19], 20);
+
+    asm_op_g!(a, b, c, d, data[5], RC[20], 5);
+    asm_op_g!(d, a, b, c, data[10], RC[21], 9);
+    asm_op_g!(c, d, a, b, data[15], RC[22], 14);
+    asm_op_g!(b, c, d, a, data[4], RC[23], 20);
+
+    asm_op_g!(a, b, c, d, data[9], RC[24], 5);
+    asm_op_g!(d, a, b, c, data[14], RC[25], 9);
+    asm_op_g!(c, d, a, b, data[3], RC[26], 14);
+    asm_op_g!(b, c, d, a, data[8], RC[27], 20);
+
+    asm_op_g!(a, b, c, d, data[13], RC[28], 5);
+    asm_op_g!(d, a, b, c, data[2], RC[29], 9);
+    asm_op_g!(c, d, a, b, data[7], RC[30], 14);
+    asm_op_g!(b, c, d, a, data[12], RC[31], 20);
+
+    // round 3
+    asm_op_h!(a, b, c, d, data[5], RC[32], 4);
+    asm_op_h!(d, a, b, c, data[8], RC[33], 11);
+    asm_op_h!(c, d, a, b, data[11], RC[34], 16);
+    asm_op_h!(b, c, d, a, data[14], RC[35], 23);
+
+    asm_op_h!(a, b, c, d, data[1], RC[36], 4);
+    asm_op_h!(d, a, b, c, data[4], RC[37], 11);
+    asm_op_h!(c, d, a, b, data[7], RC[38], 16);
+    asm_op_h!(b, c, d, a, data[10], RC[39], 23);
+
+    asm_op_h!(a, b, c, d, data[13], RC[40], 4);
+    asm_op_h!(d, a, b, c, data[0], RC[41], 11);
+    asm_op_h!(c, d, a, b, data[3], RC[42], 16);
+    asm_op_h!(b, c, d, a, data[6], RC[43], 23);
+
+    asm_op_h!(a, b, c, d, data[9], RC[44], 4);
+    asm_op_h!(d, a, b, c, data[12], RC[45], 11);
+    asm_op_h!(c, d, a, b, data[15], RC[46], 16);
+    asm_op_h!(b, c, d, a, data[2], RC[47], 23);
+
+    // round 4
+    asm_op_i!(a, b, c, d, data[0], RC[48], 6);
+    asm_op_i!(d, a, b, c, data[7], RC[49], 10);
+    asm_op_i!(c, d, a, b, data[14], RC[50], 15);
+    asm_op_i!(b, c, d, a, data[5], RC[51], 21);
+
+    asm_op_i!(a, b, c, d, data[12], RC[52], 6);
+    asm_op_i!(d, a, b, c, data[3], RC[53], 10);
+    asm_op_i!(c, d, a, b, data[10], RC[54], 15);
+    asm_op_i!(b, c, d, a, data[1], RC[55], 21);
+
+    asm_op_i!(a, b, c, d, data[8], RC[56], 6);
+    asm_op_i!(d, a, b, c, data[15], RC[57], 10);
+    asm_op_i!(c, d, a, b, data[6], RC[58], 15);
+    asm_op_i!(b, c, d, a, data[13], RC[59], 21);
+
+    asm_op_i!(a, b, c, d, data[4], RC[60], 6);
+    asm_op_i!(d, a, b, c, data[11], RC[61], 10);
+    asm_op_i!(c, d, a, b, data[2], RC[62], 15);
+    asm_op_i!(b, c, d, a, data[9], RC[63], 21);
+
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+}
+
+#[inline]
+pub(super) fn compress(state: &mut [u32; 4], blocks: &[[u8; 64]]) {
+    for block in blocks {
+        compress_block(state, block)
+    }
+}

--- a/md5/src/compress/aarch64_asm.rs
+++ b/md5/src/compress/aarch64_asm.rs
@@ -204,43 +204,43 @@ macro_rules! rf4_integrated {
 
                 // F round 0: A += F(B,C,D) + cache0 + RC[k]; A = rotl(A, 7) + B
                 "eor    w12, {c:w}, {d:w}",              // c ^ d (independent F calc first)
-                "add    {a:w}, {a:w}, {cache0:w}",       // a += cache0 (parallel)
+                "add    w8, {a:w}, {cache0:w}",          // a + cache0 (use w8 to avoid dependency)
                 "and    w12, w12, {b:w}",                // (c ^ d) & b (parallel)
-                "add    {a:w}, {a:w}, w10",              // a += RC[k0] (lower 32 bits)
+                "add    w8, w8, w10",                    // add RC[k0] (parallel)
                 "lsr    x10, x10, #32",                  // shift for next constant (early)
                 "eor    w12, w12, {d:w}",                // F(b,c,d)
-                "add    {a:w}, {a:w}, w12",              // a += F(b,c,d)
+                "add    {a:w}, w8, w12",                 // combine all additions
                 "ror    {a:w}, {a:w}, #25",              // rotate by 25 (optimized)
                 "add    {a:w}, {a:w}, {b:w}",            // a += b
 
                 // F round 1: D += F(A,B,C) + cache1 + RC[k+1]; D = rotl(D, 12) + A
                 "eor    w12, {b:w}, {c:w}",              // b ^ c (independent calc first)
-                "add    {d:w}, {d:w}, {cache1:w}",       // d += cache1 (parallel)
-                "and    w12, w12, {a:w}",                // (b ^ c) & a
-                "add    {d:w}, {d:w}, w10",              // d += RC[k+1]
+                "add    w8, {d:w}, {cache1:w}",          // d + cache1 (use w8 to avoid dependency)
+                "and    w12, w12, {a:w}",                // (b ^ c) & a (parallel)
+                "add    w8, w8, w10",                    // add RC[k+1] (parallel)
                 "eor    w12, w12, {c:w}",                // F(a,b,c)
-                "add    {d:w}, {d:w}, w12",              // d += F(a,b,c)
+                "add    {d:w}, w8, w12",                 // combine all additions
                 "ror    {d:w}, {d:w}, #20",              // rotate by 20 (optimized)
                 "add    {d:w}, {d:w}, {a:w}",            // d += a
 
                 // F round 2: C += F(D,A,B) + cache2 + RC[k+2]; C = rotl(C, 17) + D
                 "eor    w12, {a:w}, {b:w}",              // a ^ b (independent calc first)
-                "add    {c:w}, {c:w}, {cache2:w}",       // c += cache2 (parallel)
-                "and    w12, w12, {d:w}",                // (a ^ b) & d
-                "add    {c:w}, {c:w}, w11",              // c += RC[k+2] (lower k1)
+                "add    w9, {c:w}, {cache2:w}",          // c + cache2 (use w9 to avoid dependency)
+                "and    w12, w12, {d:w}",                // (a ^ b) & d (parallel)
+                "add    w9, w9, w11",                    // add RC[k+2] (parallel)
                 "lsr    x11, x11, #32",                  // shift for next constant (early)
                 "eor    w12, w12, {b:w}",                // F(d,a,b)
-                "add    {c:w}, {c:w}, w12",              // c += F(d,a,b)
+                "add    {c:w}, w9, w12",                 // combine all additions
                 "ror    {c:w}, {c:w}, #15",              // rotate by 15 (optimized)
                 "add    {c:w}, {c:w}, {d:w}",            // c += d
 
                 // F round 3: B += F(C,D,A) + cache3 + RC[k+3]; B = rotl(B, 22) + C
                 "eor    w12, {d:w}, {a:w}",              // d ^ a (independent calc first)
-                "add    {b:w}, {b:w}, {cache3:w}",       // b += cache3 (parallel)
-                "and    w12, w12, {c:w}",                // (d ^ a) & c
-                "add    {b:w}, {b:w}, w11",              // b += RC[k+3]
+                "add    w8, {b:w}, {cache3:w}",          // b + cache3 (use w8 to avoid dependency)
+                "and    w12, w12, {c:w}",                // (d ^ a) & c (parallel)
+                "add    w8, w8, w11",                    // add RC[k+3] (parallel)
                 "eor    w12, w12, {a:w}",                // F(c,d,a)
-                "add    {b:w}, {b:w}, w12",              // b += F(c,d,a)
+                "add    {b:w}, w8, w12",                 // combine all additions
                 "ror    {b:w}, {b:w}, #10",              // rotate by 10 (optimized)
                 "add    {b:w}, {b:w}, {c:w}",            // b += c
 
@@ -272,12 +272,12 @@ macro_rules! rg4_integrated {
 
                 // G round 0: A += G(B,C,D) + cache0 + RC[k]; A = rotl(A, 5) + B
                 "bic    w12, {c:w}, {d:w}",              // c & ~d (independent G calc first)
-                "add    {a:w}, {a:w}, {cache0:w}",       // a += cache0 (parallel)
+                "add    w9, {a:w}, {cache0:w}",          // a + cache0 (use w9 to avoid dependency)
                 "and    w8, {d:w}, {b:w}",               // d & b (parallel)
-                "add    {a:w}, {a:w}, w10",              // a += RC[k0] (lower 32 bits)
+                "add    w9, w9, w10",                    // add RC[k0] (parallel)
                 "lsr    x10, x10, #32",                  // shift for next constant (early)
                 "orr    w12, w12, w8",                   // G(b,c,d)
-                "add    {a:w}, {a:w}, w12",              // a += G(b,c,d)
+                "add    {a:w}, w9, w12",                 // combine all additions
                 "ror    {a:w}, {a:w}, #27",              // rotate 32-5=27
                 "add    {a:w}, {a:w}, {b:w}",            // a += b
 
@@ -285,7 +285,7 @@ macro_rules! rg4_integrated {
                 "bic    w12, {b:w}, {c:w}",              // b & ~c (independent G calc first)
                 "add    {d:w}, {d:w}, {cache1:w}",       // d += cache1 (parallel)
                 "and    w8, {c:w}, {a:w}",               // c & a (parallel)
-                "add    {d:w}, {d:w}, w10",              // d += RC[k+1]
+                "add    {d:w}, {d:w}, w10",              // d += RC[k+1] (parallel)
                 "orr    w12, w12, w8",                   // G(a,b,c)
                 "add    {d:w}, {d:w}, w12",              // d += G(a,b,c)
                 "ror    {d:w}, {d:w}, #23",              // rotate 32-9=23
@@ -293,20 +293,20 @@ macro_rules! rg4_integrated {
 
                 // G round 2: C += G(D,A,B) + cache2 + RC[k+2]; C = rotl(C, 14) + D
                 "bic    w12, {a:w}, {b:w}",              // a & ~b (independent G calc first)
-                "add    {c:w}, {c:w}, {cache2:w}",       // c += cache2 (parallel)
+                "add    w10, {c:w}, {cache2:w}",         // c + cache2 (use w10 to avoid dependency)
                 "and    w8, {b:w}, {d:w}",               // b & d (parallel)
-                "add    {c:w}, {c:w}, w11",              // c += RC[k+2] (lower k1)
+                "add    w10, w10, w11",                  // add RC[k+2] (parallel)
                 "lsr    x11, x11, #32",                  // shift for next constant (early)
                 "orr    w12, w12, w8",                   // G(d,a,b)
-                "add    {c:w}, {c:w}, w12",              // c += G(d,a,b)
+                "add    {c:w}, w10, w12",                // combine all additions
                 "ror    {c:w}, {c:w}, #18",              // rotate 32-14=18
                 "add    {c:w}, {c:w}, {d:w}",            // c += d
 
                 // G round 3: B += G(C,D,A) + cache3 + RC[k+3]; B = rotl(B, 20) + C
-                "add    {b:w}, {b:w}, {cache3:w}",       // b += cache3
-                "bic    w12, {d:w}, {a:w}",              // d & ~a
-                "add    {b:w}, {b:w}, w11",              // b += RC[k+3]
-                "and    w8, {a:w}, {c:w}",               // a & c
+                "bic    w12, {d:w}, {a:w}",              // d & ~a (independent G calc first)
+                "add    {b:w}, {b:w}, {cache3:w}",       // b += cache3 (parallel)
+                "and    w8, {a:w}, {c:w}",               // a & c (parallel)
+                "add    {b:w}, {b:w}, w11",              // b += RC[k+3] (parallel)
                 "orr    w12, w12, w8",                   // G(c,d,a)
                 "add    {b:w}, {b:w}, w12",              // b += G(c,d,a)
                 "ror    {b:w}, {b:w}, #12",              // rotate 32-20=12
@@ -342,8 +342,8 @@ macro_rules! ri4_integrated {
                 // I round 0: A += I(B,C,D) + cache0 + RC[k]; A = rotl(A, 6) + B
                 "orn    w12, {b:w}, {d:w}",              // b | ~d (independent I function calc)
                 "add    {a:w}, {a:w}, {cache0:w}",       // a += cache0 (parallel)
-                "eor    w12, w12, {c:w}",                // (b | ~d) ^ c = I(b,c,d)
-                "add    {a:w}, {a:w}, w10",              // a += RC[k0] (lower 32 bits)
+                "add    {a:w}, {a:w}, w10",              // a += RC[k0] (early)
+                "eor    w12, w12, {c:w}",                // (b | ~d) ^ c = I(b,c,d) 
                 "lsr    x10, x10, #32",                  // shift for next constant (early)
                 "add    {a:w}, {a:w}, w12",              // a += I(b,c,d)
                 "ror    {a:w}, {a:w}, #26",              // rotate 32-6=26
@@ -351,29 +351,29 @@ macro_rules! ri4_integrated {
 
                 // I round 1: D += I(A,B,C) + cache1 + RC[k+1]; D = rotl(D, 10) + A
                 "orn    w12, {a:w}, {c:w}",              // a | ~c (independent I function calc)
-                "add    {d:w}, {d:w}, {cache1:w}",       // d += cache1 (parallel)
-                "eor    w12, w12, {b:w}",                // (a | ~c) ^ b = I(a,b,c)
-                "add    {d:w}, {d:w}, w10",              // d += RC[k+1]
-                "add    {d:w}, {d:w}, w12",              // d += I(a,b,c)
+                "add    w9, {d:w}, {cache1:w}",          // d + cache1 (use w9 to avoid dependency)
+                "eor    w12, w12, {b:w}",                // (a | ~c) ^ b = I(a,b,c) (parallel)
+                "add    w9, w9, w10",                    // add RC[k+1] (parallel)
+                "add    {d:w}, w9, w12",                 // combine all additions
                 "ror    {d:w}, {d:w}, #22",              // rotate 32-10=22
                 "add    {d:w}, {d:w}, {a:w}",            // d += a
 
                 // I round 2: C += I(D,A,B) + cache2 + RC[k+2]; C = rotl(C, 15) + D
                 "orn    w12, {d:w}, {b:w}",              // d | ~b (independent I function calc)
-                "add    {c:w}, {c:w}, {cache2:w}",       // c += cache2 (parallel)
-                "eor    w12, w12, {a:w}",                // (d | ~b) ^ a = I(d,a,b)
-                "add    {c:w}, {c:w}, w11",              // c += RC[k+2] (lower k1)
+                "add    w8, {c:w}, {cache2:w}",          // c + cache2 (use w8 to avoid dependency)
+                "eor    w12, w12, {a:w}",                // (d | ~b) ^ a = I(d,a,b) (parallel)
+                "add    w8, w8, w11",                    // add RC[k+2] (parallel)
                 "lsr    x11, x11, #32",                  // shift for next constant (early)
-                "add    {c:w}, {c:w}, w12",              // c += I(d,a,b)
+                "add    {c:w}, w8, w12",                 // combine all additions
                 "ror    {c:w}, {c:w}, #17",              // rotate 32-15=17
                 "add    {c:w}, {c:w}, {d:w}",            // c += d
 
                 // I round 3: B += I(C,D,A) + cache3 + RC[k+3]; B = rotl(B, 21) + C
                 "orn    w12, {c:w}, {a:w}",              // c | ~a (independent I function calc)
-                "add    {b:w}, {b:w}, {cache3:w}",       // b += cache3 (parallel)
-                "eor    w12, w12, {d:w}",                // (c | ~a) ^ d = I(c,d,a)
-                "add    {b:w}, {b:w}, w11",              // b += RC[k+3]
-                "add    {b:w}, {b:w}, w12",              // b += I(c,d,a)
+                "add    w9, {b:w}, {cache3:w}",          // b + cache3 (use w9 to avoid dependency)
+                "eor    w12, w12, {d:w}",                // (c | ~a) ^ d = I(c,d,a) (parallel)
+                "add    w9, w9, w11",                    // add RC[k+3] (parallel)
+                "add    {b:w}, w9, w12",                 // combine all additions
                 "ror    {b:w}, {b:w}, #11",              // rotate 32-21=11
                 "add    {b:w}, {b:w}, {c:w}",            // b += c
 

--- a/md5/src/compress/aarch64_asm.rs
+++ b/md5/src/compress/aarch64_asm.rs
@@ -666,68 +666,11 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
         );
     }
 
-    // F rounds 4-15: implement interleaved data loading optimization from animetosho ARM64
-    unsafe {
-        core::arch::asm!(
-            // Load constants with ldp for rounds 4-7
-            "ldp    x10, x11, [{const_ptr}, #16]",    // Load RC[4,5] and RC[6,7] pairs
-            
-            // F round 4: A += F(B,C,D) + cache4 + RC[4]; A = rotl(A, 7) + B
-            "eor    w8, {c:w}, {d:w}",              // c ^ d (alternative F style)
-            "add    {a:w}, {a:w}, {cache4:w}",      // a += cache4
-            "and    w8, w8, {b:w}",                 // (c ^ d) & b 
-            "add    {a:w}, {a:w}, w10",             // a += RC[4] (lower 32 bits)
-            "eor    w8, w8, {d:w}",                 // F(b,c,d) = ((c ^ d) & b) ^ d
-            "lsr    x10, x10, #32",                 // shift for RC[5]
-            "add    {a:w}, {a:w}, w8",              // a += F(b,c,d)
-            "ror    {a:w}, {a:w}, #25",             // rotate 32-7=25
-            "add    {a:w}, {a:w}, {b:w}",           // a += b
-            
-            // F round 5: D += F(A,B,C) + cache5 + RC[5]; D = rotl(D, 12) + A
-            "eor    w8, {b:w}, {c:w}",              // b ^ c
-            "add    {d:w}, {d:w}, {cache5:w}",      // d += cache5
-            "and    w8, w8, {a:w}",                 // (b ^ c) & a
-            "add    {d:w}, {d:w}, w10",             // d += RC[5]
-            "eor    w8, w8, {c:w}",                 // F(a,b,c) = ((b ^ c) & a) ^ c
-            "add    {d:w}, {d:w}, w8",              // d += F(a,b,c)
-            "ror    {d:w}, {d:w}, #20",             // rotate 32-12=20
-            "add    {d:w}, {d:w}, {a:w}",           // d += a
-            
-            // F round 6: C += F(D,A,B) + cache6 + RC[6]; C = rotl(C, 17) + D
-            "eor    w8, {a:w}, {b:w}",              // a ^ b
-            "add    {c:w}, {c:w}, {cache6:w}",      // c += cache6
-            "and    w8, w8, {d:w}",                 // (a ^ b) & d
-            "add    {c:w}, {c:w}, w11",             // c += RC[6] (lower k1)
-            "eor    w8, w8, {b:w}",                 // F(d,a,b) = ((a ^ b) & d) ^ b
-            "lsr    x11, x11, #32",                 // shift for RC[7]
-            "add    {c:w}, {c:w}, w8",              // c += F(d,a,b)
-            "ror    {c:w}, {c:w}, #15",             // rotate 32-17=15
-            "add    {c:w}, {c:w}, {d:w}",           // c += d
-            
-            // F round 7: B += F(C,D,A) + cache7 + RC[7]; B = rotl(B, 22) + C
-            "eor    w8, {d:w}, {a:w}",              // d ^ a
-            "add    {b:w}, {b:w}, {cache7:w}",      // b += cache7
-            "and    w8, w8, {c:w}",                 // (d ^ a) & c
-            "add    {b:w}, {b:w}, w11",             // b += RC[7]
-            "eor    w8, w8, {a:w}",                 // F(c,d,a) = ((d ^ a) & c) ^ a
-            "add    {b:w}, {b:w}, w8",              // b += F(c,d,a)
-            "ror    {b:w}, {b:w}, #10",             // rotate 32-22=10
-            "add    {b:w}, {b:w}, {c:w}",           // b += c
-            
-            a = inout(reg) a,
-            b = inout(reg) b,
-            c = inout(reg) c,
-            d = inout(reg) d,
-            cache4 = in(reg) cache4,
-            cache5 = in(reg) cache5,
-            cache6 = in(reg) cache6,
-            cache7 = in(reg) cache7,
-            const_ptr = in(reg) MD5_CONSTANTS_PACKED.as_ptr(),
-            out("x10") _,
-            out("x11") _,
-            out("w8") _,
-        );
-    }
+    // F rounds 4-12: test alternative F function with eor+and+eor pattern
+    asm_op_f_alt!(a, b, c, d, cache4, RC[4], 7);
+    asm_op_f_alt!(d, a, b, c, cache5, RC[5], 12);
+    asm_op_f_alt!(c, d, a, b, cache6, RC[6], 17);
+    asm_op_f_alt!(b, c, d, a, cache7, RC[7], 22);
     rf4_integrated!(
         a, b, c, d, cache8, cache9, cache10, cache11, RC[8], RC[9], RC[10], RC[11], MD5_CONSTANTS_PACKED.as_ptr(), 32
     );

--- a/md5/src/compress/aarch64_asm.rs
+++ b/md5/src/compress/aarch64_asm.rs
@@ -10,17 +10,41 @@ use crate::consts::RC;
 #[allow(dead_code)]
 static MD5_CONSTANTS_PACKED: [u64; 32] = [
     // F round constants (packed pairs)
-    0xe8c7b756d76aa478, 0xc1bdceee242070db, 0x4787c62af57c0faf, 0xfd469501a8304613,
-    0x8b44f7af698098d8, 0x895cd7beffff5bb1, 0xfd9871936b901122, 0x49b40821a679438e,
-    // G round constants  
-    0xc040b340f61e2562, 0xe9b6c7aa265e5a51, 0x02441453d62f105d, 0xe7d3fbc8d8a1e681,
-    0xc33707d621e1cde6, 0x455a14edf4d50d87, 0xfcefa3f8a9e3e905, 0x8d2a4c8a676f02d9,
+    0xe8c7b756d76aa478,
+    0xc1bdceee242070db,
+    0x4787c62af57c0faf,
+    0xfd469501a8304613,
+    0x8b44f7af698098d8,
+    0x895cd7beffff5bb1,
+    0xfd9871936b901122,
+    0x49b40821a679438e,
+    // G round constants
+    0xc040b340f61e2562,
+    0xe9b6c7aa265e5a51,
+    0x02441453d62f105d,
+    0xe7d3fbc8d8a1e681,
+    0xc33707d621e1cde6,
+    0x455a14edf4d50d87,
+    0xfcefa3f8a9e3e905,
+    0x8d2a4c8a676f02d9,
     // H round constants
-    0x8771f681fffa3942, 0xfde5380c6d9d6122, 0x4bdecfa9a4beea44, 0xbebfbc70f6bb4b60, 
-    0xeaa127fa289b7ec6, 0x04881d05d4ef3085, 0xe6db99e5d9d4d039, 0xc4ac56651fa27cf8,
+    0x8771f681fffa3942,
+    0xfde5380c6d9d6122,
+    0x4bdecfa9a4beea44,
+    0xbebfbc70f6bb4b60,
+    0xeaa127fa289b7ec6,
+    0x04881d05d4ef3085,
+    0xe6db99e5d9d4d039,
+    0xc4ac56651fa27cf8,
     // I round constants
-    0x432aff97f4292244, 0xfc93a039ab9423a7, 0x8f0ccc92655b59c3, 0x85845dd1ffeff47d,
-    0xfe2ce6e06fa87e4f, 0x4e0811a1a3014314, 0xbd3af235f7537e82, 0xeb86d3912ad7d2bb
+    0x432aff97f4292244,
+    0xfc93a039ab9423a7,
+    0x8f0ccc92655b59c3,
+    0x85845dd1ffeff47d,
+    0xfe2ce6e06fa87e4f,
+    0x4e0811a1a3014314,
+    0xbd3af235f7537e82,
+    0xeb86d3912ad7d2bb,
 ];
 
 macro_rules! asm_op_f {
@@ -86,7 +110,7 @@ macro_rules! asm_op_h {
                 // Optimized H function: delay b dependency for better scheduling
                 "add    w9, {m:w}, {rc:w}",     // m + rc first (no b dependency)
                 "eor    w8, {c:w}, {d:w}",      // c ^ d first (no b dependency)
-                "add    w9, {a:w}, w9",         // a + m + rc 
+                "add    w9, {a:w}, w9",         // a + m + rc
                 "eor    w8, w8, {b:w}",         // (c ^ d) ^ b = b ^ c ^ d (delay b use)
                 "add    w8, w9, w8",            // add h_result
                 "ror    w8, w8, #{ror}",        // rotate
@@ -113,7 +137,7 @@ macro_rules! asm_op_h_reuse {
                 // H function with re-use: tmp should contain c^d from previous round
                 "add    w9, {m:w}, {rc:w}",     // m + rc first (no b dependency)
                 "eor    {tmp:w}, {tmp:w}, {b:w}", // reuse: tmp (c^d) ^ b = b^c^d
-                "add    w9, {a:w}, w9",         // a + m + rc 
+                "add    w9, {a:w}, w9",         // a + m + rc
                 "add    w8, w9, {tmp:w}",       // add h_result
                 "eor    {tmp:w}, {tmp:w}, {d:w}", // prepare for next: (b^c^d) ^ d = b^c
                 "ror    w8, w8, #{ror}",        // rotate
@@ -157,7 +181,42 @@ macro_rules! asm_op_i {
     };
 }
 
+// 4-round macros for better instruction scheduling and organization
+macro_rules! rf4 {
+    ($a:ident, $b:ident, $c:ident, $d:ident, $m0:expr, $m1:expr, $m2:expr, $m3:expr, $rc0:expr, $rc1:expr, $rc2:expr, $rc3:expr) => {
+        asm_op_f!($a, $b, $c, $d, $m0, $rc0, 7);
+        asm_op_f!($d, $a, $b, $c, $m1, $rc1, 12);
+        asm_op_f!($c, $d, $a, $b, $m2, $rc2, 17);
+        asm_op_f!($b, $c, $d, $a, $m3, $rc3, 22);
+    };
+}
 
+macro_rules! rg4 {
+    ($a:ident, $b:ident, $c:ident, $d:ident, $m0:expr, $m1:expr, $m2:expr, $m3:expr, $rc0:expr, $rc1:expr, $rc2:expr, $rc3:expr) => {
+        asm_op_g!($a, $b, $c, $d, $m0, $rc0, 5);
+        asm_op_g!($d, $a, $b, $c, $m1, $rc1, 9);
+        asm_op_g!($c, $d, $a, $b, $m2, $rc2, 14);
+        asm_op_g!($b, $c, $d, $a, $m3, $rc3, 20);
+    };
+}
+
+macro_rules! rh4 {
+    ($a:ident, $b:ident, $c:ident, $d:ident, $m0:expr, $m1:expr, $m2:expr, $m3:expr, $rc0:expr, $rc1:expr, $rc2:expr, $rc3:expr, $tmp:ident) => {
+        asm_op_h_reuse!($a, $b, $c, $d, $m0, $rc0, 4, $tmp);
+        asm_op_h_reuse!($d, $a, $b, $c, $m1, $rc1, 11, $tmp);
+        asm_op_h_reuse!($c, $d, $a, $b, $m2, $rc2, 16, $tmp);
+        asm_op_h_reuse!($b, $c, $d, $a, $m3, $rc3, 23, $tmp);
+    };
+}
+
+macro_rules! ri4 {
+    ($a:ident, $b:ident, $c:ident, $d:ident, $m0:expr, $m1:expr, $m2:expr, $m3:expr, $rc0:expr, $rc1:expr, $rc2:expr, $rc3:expr) => {
+        asm_op_i!($a, $b, $c, $d, $m0, $rc0, 6);
+        asm_op_i!($d, $a, $b, $c, $m1, $rc1, 10);
+        asm_op_i!($c, $d, $a, $b, $m2, $rc2, 15);
+        asm_op_i!($b, $c, $d, $a, $m3, $rc3, 21);
+    };
+}
 
 #[inline]
 fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
@@ -171,14 +230,26 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
     for (o, chunk) in data.iter_mut().zip(input.chunks_exact(4)) {
         *o = u32::from_le_bytes(chunk.try_into().unwrap());
     }
-    
+
     // Register caching optimization: cache ALL data values to eliminate memory accesses
     // Full cache array approach (animetosho Cache16 optimization)
-    let cache0 = data[0];   let cache1 = data[1];   let cache2 = data[2];   let cache3 = data[3];
-    let cache4 = data[4];   let cache5 = data[5];   let cache6 = data[6];   let cache7 = data[7];
-    let cache8 = data[8];   let cache9 = data[9];   let cache10 = data[10]; let cache11 = data[11];
-    let cache12 = data[12]; let cache13 = data[13]; let cache14 = data[14]; let cache15 = data[15];
-    
+    let cache0 = data[0];
+    let cache1 = data[1];
+    let cache2 = data[2];
+    let cache3 = data[3];
+    let cache4 = data[4];
+    let cache5 = data[5];
+    let cache6 = data[6];
+    let cache7 = data[7];
+    let cache8 = data[8];
+    let cache9 = data[9];
+    let cache10 = data[10];
+    let cache11 = data[11];
+    let cache12 = data[12];
+    let cache13 = data[13];
+    let cache14 = data[14];
+    let cache15 = data[15];
+
     // Additional optimizations: better instruction scheduling and reduced dependencies
 
     // round 1 - first 4 operations with ldp constants optimization
@@ -195,7 +266,7 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             "add    w8, w10, w8",               // add (b & c)
             "ror    w8, w8, #25",               // rotate by 32-7=25
             "add    {a:w}, {b:w}, w8",          // b + rotated -> new a
-            
+
             // F1: d, a, b, c, cache1, RC[1], 12
             "and    w8, {a:w}, {b:w}",          // a & b (using updated a)
             "bic    w9, {c:w}, {a:w}",          // c & !a
@@ -206,7 +277,7 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             "add    w8, w10, w8",               // add (a & b)
             "ror    w8, w8, #20",               // rotate by 32-12=20
             "add    {d:w}, {a:w}, w8",          // a + rotated -> new d
-            
+
             // F2: c, d, a, b, cache2, RC[2], 17
             "and    w8, {d:w}, {a:w}",          // d & a
             "bic    w9, {b:w}, {d:w}",          // b & !d
@@ -216,7 +287,7 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             "add    w8, w10, w8",               // add (d & a)
             "ror    w8, w8, #15",               // rotate by 32-17=15
             "add    {c:w}, {d:w}, w8",          // d + rotated -> new c
-            
+
             // F3: b, c, d, a, cache3, RC[3], 22
             "and    w8, {c:w}, {d:w}",          // c & d
             "bic    w9, {a:w}, {c:w}",          // a & !c
@@ -227,14 +298,14 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             "add    w8, w10, w8",               // add (c & d)
             "ror    w8, w8, #10",               // rotate by 32-22=10
             "add    {b:w}, {c:w}, w8",          // c + rotated -> new b
-            
+
             a = inout(reg) a,
             b = inout(reg) b,
             c = inout(reg) c,
             d = inout(reg) d,
             data0 = in(reg) cache0,
             data1 = in(reg) cache1,
-            data2 = in(reg) cache2, 
+            data2 = in(reg) cache2,
             data3 = in(reg) cache3,
             k0 = out(reg) _,
             k1 = out(reg) _,
@@ -245,28 +316,24 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
         );
     }
 
-    asm_op_f!(a, b, c, d, cache4, RC[4], 7);
-    asm_op_f!(d, a, b, c, cache5, RC[5], 12);
-    asm_op_f!(c, d, a, b, cache6, RC[6], 17);
-    asm_op_f!(b, c, d, a, cache7, RC[7], 22);
-
-    asm_op_f!(a, b, c, d, cache8, RC[8], 7);
-    asm_op_f!(d, a, b, c, cache9, RC[9], 12);
-    asm_op_f!(c, d, a, b, cache10, RC[10], 17);
-    asm_op_f!(b, c, d, a, cache11, RC[11], 22);
-
-    asm_op_f!(a, b, c, d, cache12, RC[12], 7);
-    asm_op_f!(d, a, b, c, cache13, RC[13], 12);
-    asm_op_f!(c, d, a, b, cache14, RC[14], 17);
-    asm_op_f!(b, c, d, a, cache15, RC[15], 22);
+    // F rounds 4-12: use RF4 macro for better instruction scheduling
+    rf4!(
+        a, b, c, d, cache4, cache5, cache6, cache7, RC[4], RC[5], RC[6], RC[7]
+    );
+    rf4!(
+        a, b, c, d, cache8, cache9, cache10, cache11, RC[8], RC[9], RC[10], RC[11]
+    );
+    rf4!(
+        a, b, c, d, cache12, cache13, cache14, cache15, RC[12], RC[13], RC[14], RC[15]
+    );
 
     // round 2 - first 4 G operations with ldp constants optimization
     unsafe {
         core::arch::asm!(
-            // Load G round constant pairs with ldp  
+            // Load G round constant pairs with ldp
             "ldp    {k2}, {k3}, [{const_ptr}, #64]", // Load RC[16,17] and RC[18,19] pairs
             // G0: a, b, c, d, cache1, RC[16], 5
-            "and    w8, {b:w}, {d:w}",          // b & d  
+            "and    w8, {b:w}, {d:w}",          // b & d
             "bic    w9, {c:w}, {d:w}",          // c & !d
             "add    w10, {data1:w}, {k2:w}",    // cache1 + RC[16] (lower 32 bits)
             "add    w10, {a:w}, w10",           // a + cache1 + RC[16]
@@ -274,7 +341,7 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             "add    w8, w10, w8",               // ADD shortcut: + (b & d)
             "ror    w8, w8, #27",               // rotate by 32-5=27
             "add    {a:w}, {b:w}, w8",          // b + rotated -> new a
-            
+
             // G1: d, a, b, c, cache6, RC[17], 9
             "and    w8, {a:w}, {c:w}",          // a & c (using updated a)
             "bic    w9, {b:w}, {c:w}",          // b & !c
@@ -285,7 +352,7 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             "add    w8, w10, w8",               // ADD shortcut: + (a & c)
             "ror    w8, w8, #23",               // rotate by 32-9=23
             "add    {d:w}, {a:w}, w8",          // a + rotated -> new d
-            
+
             // G2: c, d, a, b, cache11, RC[18], 14
             "and    w8, {d:w}, {b:w}",          // d & b
             "bic    w9, {a:w}, {b:w}",          // a & !b
@@ -295,7 +362,7 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             "add    w8, w10, w8",               // ADD shortcut: + (d & b)
             "ror    w8, w8, #18",               // rotate by 32-14=18
             "add    {c:w}, {d:w}, w8",          // d + rotated -> new c
-            
+
             // G3: b, c, d, a, data[0], RC[19], 20
             "and    w8, {c:w}, {a:w}",          // c & a
             "bic    w9, {d:w}, {a:w}",          // d & !a
@@ -306,7 +373,7 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             "add    w8, w10, w8",               // ADD shortcut: + (c & a)
             "ror    w8, w8, #12",               // rotate by 32-20=12
             "add    {b:w}, {c:w}, w8",          // c + rotated -> new b
-            
+
             a = inout(reg) a,
             b = inout(reg) b,
             c = inout(reg) c,
@@ -324,20 +391,16 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
         );
     }
 
-    asm_op_g!(a, b, c, d, cache5, RC[20], 5);
-    asm_op_g!(d, a, b, c, cache10, RC[21], 9);
-    asm_op_g!(c, d, a, b, cache15, RC[22], 14);
-    asm_op_g!(b, c, d, a, cache4, RC[23], 20);
-
-    asm_op_g!(a, b, c, d, cache9, RC[24], 5);
-    asm_op_g!(d, a, b, c, cache14, RC[25], 9);
-    asm_op_g!(c, d, a, b, cache3, RC[26], 14);
-    asm_op_g!(b, c, d, a, cache8, RC[27], 20);
-
-    asm_op_g!(a, b, c, d, cache13, RC[28], 5);
-    asm_op_g!(d, a, b, c, cache2, RC[29], 9);
-    asm_op_g!(c, d, a, b, cache7, RC[30], 14);
-    asm_op_g!(b, c, d, a, cache12, RC[31], 20);
+    // G rounds 20-32: use RG4 macro for better instruction scheduling
+    rg4!(
+        a, b, c, d, cache5, cache10, cache15, cache4, RC[20], RC[21], RC[22], RC[23]
+    );
+    rg4!(
+        a, b, c, d, cache9, cache14, cache3, cache8, RC[24], RC[25], RC[26], RC[27]
+    );
+    rg4!(
+        a, b, c, d, cache13, cache2, cache7, cache12, RC[28], RC[29], RC[30], RC[31]
+    );
 
     // round 3 - H function with re-use optimization (animetosho technique)
     // Initialize tmp register for H function re-use
@@ -352,50 +415,40 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             d = in(reg) d,
         );
     }
-    
-    asm_op_h_reuse!(a, b, c, d, cache5, RC[32], 4, tmp_h);
-    asm_op_h_reuse!(d, a, b, c, cache8, RC[33], 11, tmp_h);
-    asm_op_h_reuse!(c, d, a, b, cache11, RC[34], 16, tmp_h);
-    asm_op_h_reuse!(b, c, d, a, cache14, RC[35], 23, tmp_h);
 
-    asm_op_h_reuse!(a, b, c, d, cache1, RC[36], 4, tmp_h);
-    asm_op_h_reuse!(d, a, b, c, cache4, RC[37], 11, tmp_h);
-    asm_op_h_reuse!(c, d, a, b, cache7, RC[38], 16, tmp_h);
-    asm_op_h_reuse!(b, c, d, a, cache10, RC[39], 23, tmp_h);
-
-    asm_op_h_reuse!(a, b, c, d, cache13, RC[40], 4, tmp_h);
-    asm_op_h_reuse!(d, a, b, c, cache0, RC[41], 11, tmp_h);
-    asm_op_h_reuse!(c, d, a, b, cache3, RC[42], 16, tmp_h);
-    #[allow(unused_assignments)]
+    // H rounds 32-48: use RH4 macro for better instruction scheduling
+    // Note: H rounds use reuse optimization for rounds 32-43, regular H for rounds 44-47
+    rh4!(
+        a, b, c, d, cache5, cache8, cache11, cache14, RC[32], RC[33], RC[34], RC[35], tmp_h
+    );
+    rh4!(
+        a, b, c, d, cache1, cache4, cache7, cache10, RC[36], RC[37], RC[38], RC[39], tmp_h
+    );
+    #[allow(unused_assignments)] // Last RH4 reuse writes tmp_h but it's not used after
     {
-        asm_op_h_reuse!(b, c, d, a, cache6, RC[43], 23, tmp_h);
+        rh4!(
+            a, b, c, d, cache13, cache0, cache3, cache6, RC[40], RC[41], RC[42], RC[43], tmp_h
+        );
     }
-
+    // Last 4 H rounds use regular asm_op_h! not reuse
     asm_op_h!(a, b, c, d, cache9, RC[44], 4);
     asm_op_h!(d, a, b, c, cache12, RC[45], 11);
     asm_op_h!(c, d, a, b, cache15, RC[46], 16);
     asm_op_h!(b, c, d, a, cache2, RC[47], 23);
 
-    // round 4
-    asm_op_i!(a, b, c, d, cache0, RC[48], 6);
-    asm_op_i!(d, a, b, c, cache7, RC[49], 10);
-    asm_op_i!(c, d, a, b, cache14, RC[50], 15);
-    asm_op_i!(b, c, d, a, cache5, RC[51], 21);
-
-    asm_op_i!(a, b, c, d, cache12, RC[52], 6);
-    asm_op_i!(d, a, b, c, cache3, RC[53], 10);
-    asm_op_i!(c, d, a, b, cache10, RC[54], 15);
-    asm_op_i!(b, c, d, a, cache1, RC[55], 21);
-
-    asm_op_i!(a, b, c, d, cache8, RC[56], 6);
-    asm_op_i!(d, a, b, c, cache15, RC[57], 10);
-    asm_op_i!(c, d, a, b, cache6, RC[58], 15);
-    asm_op_i!(b, c, d, a, cache13, RC[59], 21);
-
-    asm_op_i!(a, b, c, d, cache4, RC[60], 6);
-    asm_op_i!(d, a, b, c, cache11, RC[61], 10);
-    asm_op_i!(c, d, a, b, cache2, RC[62], 15);
-    asm_op_i!(b, c, d, a, cache9, RC[63], 21);
+    // I rounds 48-64: use RI4 macro for better instruction scheduling
+    ri4!(
+        a, b, c, d, cache0, cache7, cache14, cache5, RC[48], RC[49], RC[50], RC[51]
+    );
+    ri4!(
+        a, b, c, d, cache12, cache3, cache10, cache1, RC[52], RC[53], RC[54], RC[55]
+    );
+    ri4!(
+        a, b, c, d, cache8, cache15, cache6, cache13, RC[56], RC[57], RC[58], RC[59]
+    );
+    ri4!(
+        a, b, c, d, cache4, cache11, cache2, cache9, RC[60], RC[61], RC[62], RC[63]
+    );
 
     state[0] = state[0].wrapping_add(a);
     state[1] = state[1].wrapping_add(b);

--- a/md5/src/compress/aarch64_asm.rs
+++ b/md5/src/compress/aarch64_asm.rs
@@ -83,11 +83,11 @@ macro_rules! asm_op_h {
     ($a:ident, $b:ident, $c:ident, $d:ident, $m:expr, $rc:expr, $s:expr) => {
         unsafe {
             core::arch::asm!(
-                // Standard H function: b ^ c ^ d
-                "eor    w8, {b:w}, {c:w}",      // b ^ c
-                "add    w9, {m:w}, {rc:w}",     // m + rc
-                "eor    w8, w8, {d:w}",         // (b ^ c) ^ d = b ^ c ^ d
+                // Optimized H function: delay b dependency for better scheduling
+                "add    w9, {m:w}, {rc:w}",     // m + rc first (no b dependency)
+                "eor    w8, {c:w}, {d:w}",      // c ^ d first (no b dependency)
                 "add    w9, {a:w}, w9",         // a + m + rc 
+                "eor    w8, w8, {b:w}",         // (c ^ d) ^ b = b ^ c ^ d (delay b use)
                 "add    w8, w9, w8",            // add h_result
                 "ror    w8, w8, #{ror}",        // rotate
                 "add    {a:w}, {b:w}, w8",      // b + rotated_result

--- a/md5/src/compress/aarch64_asm.rs
+++ b/md5/src/compress/aarch64_asm.rs
@@ -109,12 +109,11 @@ macro_rules! asm_op_i {
     ($a:ident, $b:ident, $c:ident, $d:ident, $m:expr, $rc:expr, $s:expr) => {
         unsafe {
             core::arch::asm!(
-                // Standard I function: c ^ (b | !d)
-                "mvn    w8, {d:w}",             // !d (bitwise NOT)
-                "add    w9, {m:w}, {rc:w}",     // m + rc
-                "orr    w8, {b:w}, w8",         // b | !d
-                "add    w9, {a:w}, w9",         // a + m + rc
+                // Optimized I function: use ORN (OR-NOT) instruction
+                "orn    w8, {b:w}, {d:w}",      // b | !d in one instruction (ORN)
+                "add    w9, {m:w}, {rc:w}",     // m + rc in parallel
                 "eor    w8, {c:w}, w8",         // c ^ (b | !d)
+                "add    w9, {a:w}, w9",         // a + m + rc
                 "add    w8, w9, w8",            // add i_result
                 "ror    w8, w8, #{ror}",        // rotate
                 "add    {a:w}, {b:w}, w8",      // b + rotated_result

--- a/md5/src/compress/aarch64_asm.rs
+++ b/md5/src/compress/aarch64_asm.rs
@@ -128,78 +128,6 @@ macro_rules! asm_op_h {
     };
 }
 
-// Advanced RF4 with animetosho-style constant preloading optimization  
-macro_rules! rf4_advanced {
-    ($a:ident, $b:ident, $c:ident, $d:ident, $cache0:ident, $cache1:ident, $cache2:ident, $cache3:ident, $rc0:expr, $rc1:expr, $rc2:expr, $rc3:expr, $const_ptr:expr, $offset:expr, $next_offset:expr) => {
-        unsafe {
-            core::arch::asm!(
-                // Load current constants and preload next ones (animetosho technique)
-                "ldp    x10, x11, [{const_ptr}, #{k_offset}]",     // Load RC pair for this round
-                "ldp    x12, x13, [{const_ptr}, #{next_k_offset}]", // Preload next RC pair
-
-                // F round 0: A += F(B,C,D) + cache0 + RC[k]; A = rotl(A, 7) + B
-                "add    {a:w}, {a:w}, {cache0:w}",       // a += cache0
-                "eor    w14, {c:w}, {d:w}",              // c ^ d (alt F function)
-                "add    {a:w}, {a:w}, w10",              // a += RC[k0] (lower 32 bits)
-                "and    w14, w14, {b:w}",                // (c ^ d) & b
-                "lsr    x10, x10, #32",                  // shift for next constant
-                "eor    w14, w14, {d:w}",                // F(b,c,d)
-                "add    {a:w}, {a:w}, w14",              // a += F(b,c,d)
-                "ror    {a:w}, {a:w}, #25",              // rotate by 25
-                "add    {a:w}, {a:w}, {b:w}",            // a += b
-
-                // F round 1: D += F(A,B,C) + cache1 + RC[k+1]; D = rotl(D, 12) + A
-                "add    {d:w}, {d:w}, {cache1:w}",       // d += cache1
-                "eor    w14, {b:w}, {c:w}",              // b ^ c
-                "add    {d:w}, {d:w}, w10",              // d += RC[k+1]
-                "and    w14, w14, {a:w}",                // (b ^ c) & a
-                "eor    w14, w14, {c:w}",                // F(a,b,c)
-                "add    {d:w}, {d:w}, w14",              // d += F(a,b,c)
-                "ror    {d:w}, {d:w}, #20",              // rotate by 20
-                "add    {d:w}, {d:w}, {a:w}",            // d += a
-
-                // F round 2: C += F(D,A,B) + cache2 + RC[k+2]; C = rotl(C, 17) + D
-                "add    {c:w}, {c:w}, {cache2:w}",       // c += cache2
-                "eor    w14, {a:w}, {b:w}",              // a ^ b
-                "add    {c:w}, {c:w}, w11",              // c += RC[k+2] (lower k1)
-                "and    w14, w14, {d:w}",                // (a ^ b) & d
-                "lsr    x11, x11, #32",                  // shift for next constant
-                "eor    w14, w14, {b:w}",                // F(d,a,b)
-                "add    {c:w}, {c:w}, w14",              // c += F(d,a,b)
-                "ror    {c:w}, {c:w}, #15",              // rotate by 15
-                "add    {c:w}, {c:w}, {d:w}",            // c += d
-
-                // F round 3: B += F(C,D,A) + cache3 + RC[k+3]; B = rotl(B, 22) + C
-                "add    {b:w}, {b:w}, {cache3:w}",       // b += cache3
-                "eor    w14, {d:w}, {a:w}",              // d ^ a
-                "add    {b:w}, {b:w}, w11",              // b += RC[k+3]
-                "and    w14, w14, {c:w}",                // (d ^ a) & c
-                "eor    w14, w14, {a:w}",                // F(c,d,a)
-                "add    {b:w}, {b:w}, w14",              // b += F(c,d,a)
-                "ror    {b:w}, {b:w}, #10",              // rotate by 10
-                "add    {b:w}, {b:w}, {c:w}",            // b += c
-
-                a = inout(reg) $a,
-                b = inout(reg) $b,
-                c = inout(reg) $c,
-                d = inout(reg) $d,
-                cache0 = in(reg) $cache0,
-                cache1 = in(reg) $cache1,
-                cache2 = in(reg) $cache2,
-                cache3 = in(reg) $cache3,
-                const_ptr = in(reg) $const_ptr,
-                k_offset = const $offset,
-                next_k_offset = const $next_offset,
-                out("x10") _,
-                out("x11") _,
-                out("x12") _,
-                out("x13") _,
-                out("w14") _,
-            );
-        }
-    };
-}
-
 // Integrated RH4 with H function reuse optimization and ldp constant loading
 macro_rules! rh4_integrated {
     ($a:ident, $b:ident, $c:ident, $d:ident, $cache0:ident, $cache1:ident, $cache2:ident, $cache3:ident, $rc0:expr, $rc1:expr, $rc2:expr, $rc3:expr, $const_ptr:expr, $offset:expr, $tmp:ident) => {
@@ -282,7 +210,7 @@ macro_rules! rf4_integrated {
                 "lsr    x10, x10, #32",                  // shift for next constant
                 "eor    w12, w12, {d:w}",                // F(b,c,d)
                 "add    {a:w}, {a:w}, w12",              // a += F(b,c,d)
-                "ror    {a:w}, {a:w}, #25",              // rotate by 25 (animetosho-style)
+                "ror    {a:w}, {a:w}, #25",              // rotate by 25 (optimized)
                 "add    {a:w}, {a:w}, {b:w}",            // a += b
 
                 // F round 1: D += F(A,B,C) + cache1 + RC[k+1]; D = rotl(D, 12) + A
@@ -292,7 +220,7 @@ macro_rules! rf4_integrated {
                 "and    w12, w12, {a:w}",                // (b ^ c) & a
                 "eor    w12, w12, {c:w}",                // F(a,b,c)
                 "add    {d:w}, {d:w}, w12",              // d += F(a,b,c)
-                "ror    {d:w}, {d:w}, #20",              // rotate by 20 (animetosho-style)
+                "ror    {d:w}, {d:w}, #20",              // rotate by 20 (optimized)
                 "add    {d:w}, {d:w}, {a:w}",            // d += a
 
                 // F round 2: C += F(D,A,B) + cache2 + RC[k+2]; C = rotl(C, 17) + D
@@ -303,7 +231,7 @@ macro_rules! rf4_integrated {
                 "lsr    x11, x11, #32",                  // shift for next constant
                 "eor    w12, w12, {b:w}",                // F(d,a,b)
                 "add    {c:w}, {c:w}, w12",              // c += F(d,a,b)
-                "ror    {c:w}, {c:w}, #15",              // rotate by 15 (animetosho-style)
+                "ror    {c:w}, {c:w}, #15",              // rotate by 15 (optimized)
                 "add    {c:w}, {c:w}, {d:w}",            // c += d
 
                 // F round 3: B += F(C,D,A) + cache3 + RC[k+3]; B = rotl(B, 22) + C
@@ -313,7 +241,7 @@ macro_rules! rf4_integrated {
                 "and    w12, w12, {c:w}",                // (d ^ a) & c
                 "eor    w12, w12, {a:w}",                // F(c,d,a)
                 "add    {b:w}, {b:w}, w12",              // b += F(c,d,a)
-                "ror    {b:w}, {b:w}, #10",              // rotate by 10 (animetosho-style)
+                "ror    {b:w}, {b:w}, #10",              // rotate by 10 (optimized)
                 "add    {b:w}, {b:w}, {c:w}",            // b += c
 
                 a = inout(reg) $a,
@@ -474,7 +402,7 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
     let mut c = state[2];
     let mut d = state[3];
 
-    // Animetosho-style input data loading optimization: use ldp to load data pairs directly
+    // Optimized input data loading: use ldp to load data pairs directly
     // This eliminates the intermediate array and reduces memory bandwidth
     let mut cache0: u32;
     let mut cache1: u32;
@@ -494,10 +422,10 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
     let mut cache15: u32;
 
     // Load all input data using ldp instructions for better memory bandwidth
-    // Animetosho-style optimization: direct ldp loading eliminates intermediate array
+    // Advanced optimization: direct ldp loading eliminates intermediate array
     unsafe {
         core::arch::asm!(
-            // Load input data pairs with ldp - more efficient than individual loads
+            // Load input data pairs with ldp - optimized addressing
             "ldp    {cache0:w}, {cache1:w}, [{input_ptr}, #0]",    // data[0], data[1]
             "ldp    {cache2:w}, {cache3:w}, [{input_ptr}, #8]",    // data[2], data[3]
             "ldp    {cache4:w}, {cache5:w}, [{input_ptr}, #16]",   // data[4], data[5]
@@ -533,42 +461,42 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
         core::arch::asm!(
             // Load first two constant pairs with ldp
             "ldp    {k0}, {k1}, [{const_ptr}]",  // Load RC[0,1] and RC[2,3] pairs
-            // F0: a, b, c, d, data[0], RC[0], 7
+            // F0: a, b, c, d, data[0], RC[0], 7 - optimized scheduling
+            "add    w10, {data0:w}, {k0:w}",    // data[0] + RC[0] (lower 32 bits) - start early
             "and    w8, {b:w}, {c:w}",          // b & c
             "bic    w9, {d:w}, {b:w}",          // d & !b
-            "add    w10, {data0:w}, {k0:w}",    // data[0] + RC[0] (lower 32 bits)
             "add    w9, {a:w}, w9",             // a + (d & !b)
             "add    w10, w9, w10",              // a + (d & !b) + data[0] + RC[0]
             "add    w8, w10, w8",               // add (b & c)
             "ror    w8, w8, #25",               // rotate by 32-7=25
             "add    {a:w}, {b:w}, w8",          // b + rotated -> new a
 
-            // F1: d, a, b, c, cache1, RC[1], 12
+            // F1: d, a, b, c, cache1, RC[1], 12 - optimized scheduling
+            "lsr    {k0}, {k0}, #32",           // get RC[1] from upper 32 bits - start early
             "and    w8, {a:w}, {b:w}",          // a & b (using updated a)
-            "bic    w9, {c:w}, {a:w}",          // c & !a
-            "lsr    {k0}, {k0}, #32",           // get RC[1] from upper 32 bits
             "add    w10, {data1:w}, {k0:w}",    // cache1 + RC[1]
+            "bic    w9, {c:w}, {a:w}",          // c & !a
             "add    w9, {d:w}, w9",             // d + (c & !a)
             "add    w10, w9, w10",              // d + (c & !a) + cache1 + RC[1]
             "add    w8, w10, w8",               // add (a & b)
             "ror    w8, w8, #20",               // rotate by 32-12=20
             "add    {d:w}, {a:w}, w8",          // a + rotated -> new d
 
-            // F2: c, d, a, b, cache2, RC[2], 17
+            // F2: c, d, a, b, cache2, RC[2], 17 - optimized scheduling
+            "add    w10, {data2:w}, {k1:w}",    // cache2 + RC[2] (lower 32 bits) - start early
             "and    w8, {d:w}, {a:w}",          // d & a
             "bic    w9, {b:w}, {d:w}",          // b & !d
-            "add    w10, {data2:w}, {k1:w}",    // cache2 + RC[2] (lower 32 bits)
             "add    w9, {c:w}, w9",             // c + (b & !d)
             "add    w10, w9, w10",              // c + (b & !d) + cache2 + RC[2]
             "add    w8, w10, w8",               // add (d & a)
             "ror    w8, w8, #15",               // rotate by 32-17=15
             "add    {c:w}, {d:w}, w8",          // d + rotated -> new c
 
-            // F3: b, c, d, a, cache3, RC[3], 22
+            // F3: b, c, d, a, cache3, RC[3], 22 - optimized scheduling
+            "lsr    {k1}, {k1}, #32",           // get RC[3] from upper 32 bits - start early
             "and    w8, {c:w}, {d:w}",          // c & d
-            "bic    w9, {a:w}, {c:w}",          // a & !c
-            "lsr    {k1}, {k1}, #32",           // get RC[3] from upper 32 bits
             "add    w10, {data3:w}, {k1:w}",    // cache3 + RC[3]
+            "bic    w9, {a:w}, {c:w}",          // a & !c
             "add    w9, {b:w}, w9",             // b + (a & !c)
             "add    w10, w9, w10",              // b + (a & !c) + cache3 + RC[3]
             "add    w8, w10, w8",               // add (c & d)
@@ -635,11 +563,11 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
         core::arch::asm!(
             // Load G round constant pairs with ldp
             "ldp    {k2}, {k3}, [{const_ptr}, #64]", // Load RC[16,17] and RC[18,19] pairs
-            // G0: a, b, c, d, cache1, RC[16], 5
+            // G0: a, b, c, d, cache1, RC[16], 5 - optimized scheduling
+            "add    w10, {data1:w}, {k2:w}",    // cache1 + RC[16] (lower 32 bits) - early
             "and    w8, {b:w}, {d:w}",          // b & d
-            "bic    w9, {c:w}, {d:w}",          // c & !d
-            "add    w10, {data1:w}, {k2:w}",    // cache1 + RC[16] (lower 32 bits)
             "add    w10, {a:w}, w10",           // a + cache1 + RC[16]
+            "bic    w9, {c:w}, {d:w}",          // c & !d
             "add    w10, w10, w9",              // a + cache1 + RC[16] + (c & !d)
             "add    w8, w10, w8",               // ADD shortcut: + (b & d)
             "ror    w8, w8, #27",               // rotate by 32-5=27

--- a/md5/src/compress/aarch64_asm.rs
+++ b/md5/src/compress/aarch64_asm.rs
@@ -7,7 +7,6 @@ use crate::consts::RC;
 // For now, we'll optimize the I function with ORN instruction (available in scalar AArch64)
 
 // Pack constants into 64-bit values for more efficient loading with ldp
-#[allow(dead_code)]
 static MD5_CONSTANTS_PACKED: [u64; 32] = [
     // F round constants (packed pairs)
     0xe8c7b756d76aa478,

--- a/md5/src/compress/aarch64_asm.rs
+++ b/md5/src/compress/aarch64_asm.rs
@@ -172,12 +172,12 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
         *o = u32::from_le_bytes(chunk.try_into().unwrap());
     }
     
-    // Register caching optimization: cache frequently used data values
-    // Cache every 4th element for even distribution: data[0], data[4], data[8], data[12]
-    let cache0 = data[0];
-    let cache4 = data[4];  
-    let cache8 = data[8];
-    let cache12 = data[12];
+    // Register caching optimization: cache ALL data values to eliminate memory accesses
+    // Full cache array approach (animetosho Cache16 optimization)
+    let cache0 = data[0];   let cache1 = data[1];   let cache2 = data[2];   let cache3 = data[3];
+    let cache4 = data[4];   let cache5 = data[5];   let cache6 = data[6];   let cache7 = data[7];
+    let cache8 = data[8];   let cache9 = data[9];   let cache10 = data[10]; let cache11 = data[11];
+    let cache12 = data[12]; let cache13 = data[13]; let cache14 = data[14]; let cache15 = data[15];
     
     // Additional optimizations: better instruction scheduling and reduced dependencies
 
@@ -197,34 +197,34 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             "ror    w8, w8, #25",               // rotate by 32-7=25
             "add    {a:w}, {b:w}, w8",          // b + rotated -> new a
             
-            // F1: d, a, b, c, data[1], RC[1], 12
+            // F1: d, a, b, c, cache1, RC[1], 12
             "and    w8, {a:w}, {b:w}",          // a & b (using updated a)
             "bic    w9, {c:w}, {a:w}",          // c & !a
             "lsr    {k0}, {k0}, #32",           // get RC[1] from upper 32 bits
-            "add    w10, {data1:w}, {k0:w}",    // data[1] + RC[1]
+            "add    w10, {data1:w}, {k0:w}",    // cache1 + RC[1]
             "add    w9, {d:w}, w9",             // d + (c & !a)
-            "add    w10, w9, w10",              // d + (c & !a) + data[1] + RC[1]
+            "add    w10, w9, w10",              // d + (c & !a) + cache1 + RC[1]
             "add    w8, w10, w8",               // add (a & b)
             "ror    w8, w8, #20",               // rotate by 32-12=20
             "add    {d:w}, {a:w}, w8",          // a + rotated -> new d
             
-            // F2: c, d, a, b, data[2], RC[2], 17
+            // F2: c, d, a, b, cache2, RC[2], 17
             "and    w8, {d:w}, {a:w}",          // d & a
             "bic    w9, {b:w}, {d:w}",          // b & !d
-            "add    w10, {data2:w}, {k1:w}",    // data[2] + RC[2] (lower 32 bits)
+            "add    w10, {data2:w}, {k1:w}",    // cache2 + RC[2] (lower 32 bits)
             "add    w9, {c:w}, w9",             // c + (b & !d)
-            "add    w10, w9, w10",              // c + (b & !d) + data[2] + RC[2]
+            "add    w10, w9, w10",              // c + (b & !d) + cache2 + RC[2]
             "add    w8, w10, w8",               // add (d & a)
             "ror    w8, w8, #15",               // rotate by 32-17=15
             "add    {c:w}, {d:w}, w8",          // d + rotated -> new c
             
-            // F3: b, c, d, a, data[3], RC[3], 22
+            // F3: b, c, d, a, cache3, RC[3], 22
             "and    w8, {c:w}, {d:w}",          // c & d
             "bic    w9, {a:w}, {c:w}",          // a & !c
             "lsr    {k1}, {k1}, #32",           // get RC[3] from upper 32 bits
-            "add    w10, {data3:w}, {k1:w}",    // data[3] + RC[3]
+            "add    w10, {data3:w}, {k1:w}",    // cache3 + RC[3]
             "add    w9, {b:w}, w9",             // b + (a & !c)
-            "add    w10, w9, w10",              // b + (a & !c) + data[3] + RC[3]
+            "add    w10, w9, w10",              // b + (a & !c) + cache3 + RC[3]
             "add    w8, w10, w8",               // add (c & d)
             "ror    w8, w8, #10",               // rotate by 32-22=10
             "add    {b:w}, {c:w}, w8",          // c + rotated -> new b
@@ -234,9 +234,9 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             c = inout(reg) c,
             d = inout(reg) d,
             data0 = in(reg) cache0,
-            data1 = in(reg) data[1],
-            data2 = in(reg) data[2], 
-            data3 = in(reg) data[3],
+            data1 = in(reg) cache1,
+            data2 = in(reg) cache2, 
+            data3 = in(reg) cache3,
             k0 = in(reg) k0,
             k1 = in(reg) k1,
             out("w8") _,
@@ -246,19 +246,19 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
     }
 
     asm_op_f!(a, b, c, d, cache4, RC[4], 7);
-    asm_op_f!(d, a, b, c, data[5], RC[5], 12);
-    asm_op_f!(c, d, a, b, data[6], RC[6], 17);
-    asm_op_f!(b, c, d, a, data[7], RC[7], 22);
+    asm_op_f!(d, a, b, c, cache5, RC[5], 12);
+    asm_op_f!(c, d, a, b, cache6, RC[6], 17);
+    asm_op_f!(b, c, d, a, cache7, RC[7], 22);
 
     asm_op_f!(a, b, c, d, cache8, RC[8], 7);
-    asm_op_f!(d, a, b, c, data[9], RC[9], 12);
-    asm_op_f!(c, d, a, b, data[10], RC[10], 17);
-    asm_op_f!(b, c, d, a, data[11], RC[11], 22);
+    asm_op_f!(d, a, b, c, cache9, RC[9], 12);
+    asm_op_f!(c, d, a, b, cache10, RC[10], 17);
+    asm_op_f!(b, c, d, a, cache11, RC[11], 22);
 
     asm_op_f!(a, b, c, d, cache12, RC[12], 7);
-    asm_op_f!(d, a, b, c, data[13], RC[13], 12);
-    asm_op_f!(c, d, a, b, data[14], RC[14], 17);
-    asm_op_f!(b, c, d, a, data[15], RC[15], 22);
+    asm_op_f!(d, a, b, c, cache13, RC[13], 12);
+    asm_op_f!(c, d, a, b, cache14, RC[14], 17);
+    asm_op_f!(b, c, d, a, cache15, RC[15], 22);
 
     // round 2 - first 4 G operations with packed constants optimization
     unsafe {
@@ -266,33 +266,33 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
         let k3: u64 = MD5_CONSTANTS_PACKED[9];  // Contains RC[18] and RC[19]
         
         core::arch::asm!(
-            // G0: a, b, c, d, data[1], RC[16], 5
+            // G0: a, b, c, d, cache1, RC[16], 5
             "and    w8, {b:w}, {d:w}",          // b & d  
             "bic    w9, {c:w}, {d:w}",          // c & !d
-            "add    w10, {data1:w}, {k2:w}",    // data[1] + RC[16] (lower 32 bits)
-            "add    w10, {a:w}, w10",           // a + data[1] + RC[16]
-            "add    w10, w10, w9",              // a + data[1] + RC[16] + (c & !d)
+            "add    w10, {data1:w}, {k2:w}",    // cache1 + RC[16] (lower 32 bits)
+            "add    w10, {a:w}, w10",           // a + cache1 + RC[16]
+            "add    w10, w10, w9",              // a + cache1 + RC[16] + (c & !d)
             "add    w8, w10, w8",               // ADD shortcut: + (b & d)
             "ror    w8, w8, #27",               // rotate by 32-5=27
             "add    {a:w}, {b:w}, w8",          // b + rotated -> new a
             
-            // G1: d, a, b, c, data[6], RC[17], 9
+            // G1: d, a, b, c, cache6, RC[17], 9
             "and    w8, {a:w}, {c:w}",          // a & c (using updated a)
             "bic    w9, {b:w}, {c:w}",          // b & !c
             "lsr    {k2}, {k2}, #32",           // get RC[17] from upper 32 bits
-            "add    w10, {data6:w}, {k2:w}",    // data[6] + RC[17]
-            "add    w10, {d:w}, w10",           // d + data[6] + RC[17]
-            "add    w10, w10, w9",              // d + data[6] + RC[17] + (b & !c)
+            "add    w10, {data6:w}, {k2:w}",    // cache6 + RC[17]
+            "add    w10, {d:w}, w10",           // d + cache6 + RC[17]
+            "add    w10, w10, w9",              // d + cache6 + RC[17] + (b & !c)
             "add    w8, w10, w8",               // ADD shortcut: + (a & c)
             "ror    w8, w8, #23",               // rotate by 32-9=23
             "add    {d:w}, {a:w}, w8",          // a + rotated -> new d
             
-            // G2: c, d, a, b, data[11], RC[18], 14
+            // G2: c, d, a, b, cache11, RC[18], 14
             "and    w8, {d:w}, {b:w}",          // d & b
             "bic    w9, {a:w}, {b:w}",          // a & !b
-            "add    w10, {data11:w}, {k3:w}",   // data[11] + RC[18] (lower 32 bits)
-            "add    w10, {c:w}, w10",           // c + data[11] + RC[18]
-            "add    w10, w10, w9",              // c + data[11] + RC[18] + (a & !b)
+            "add    w10, {data11:w}, {k3:w}",   // cache11 + RC[18] (lower 32 bits)
+            "add    w10, {c:w}, w10",           // c + cache11 + RC[18]
+            "add    w10, w10, w9",              // c + cache11 + RC[18] + (a & !b)
             "add    w8, w10, w8",               // ADD shortcut: + (d & b)
             "ror    w8, w8, #18",               // rotate by 32-14=18
             "add    {c:w}, {d:w}, w8",          // d + rotated -> new c
@@ -312,10 +312,10 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
             b = inout(reg) b,
             c = inout(reg) c,
             d = inout(reg) d,
-            data1 = in(reg) data[1],
-            data6 = in(reg) data[6],
-            data11 = in(reg) data[11],
-            data0 = in(reg) data[0],
+            data1 = in(reg) cache1,
+            data6 = in(reg) cache6,
+            data11 = in(reg) cache11,
+            data0 = in(reg) cache0,
             k2 = in(reg) k2,
             k3 = in(reg) k3,
             out("w8") _,
@@ -324,19 +324,19 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
         );
     }
 
-    asm_op_g!(a, b, c, d, data[5], RC[20], 5);
-    asm_op_g!(d, a, b, c, data[10], RC[21], 9);
-    asm_op_g!(c, d, a, b, data[15], RC[22], 14);
+    asm_op_g!(a, b, c, d, cache5, RC[20], 5);
+    asm_op_g!(d, a, b, c, cache10, RC[21], 9);
+    asm_op_g!(c, d, a, b, cache15, RC[22], 14);
     asm_op_g!(b, c, d, a, cache4, RC[23], 20);
 
-    asm_op_g!(a, b, c, d, data[9], RC[24], 5);
-    asm_op_g!(d, a, b, c, data[14], RC[25], 9);
-    asm_op_g!(c, d, a, b, data[3], RC[26], 14);
+    asm_op_g!(a, b, c, d, cache9, RC[24], 5);
+    asm_op_g!(d, a, b, c, cache14, RC[25], 9);
+    asm_op_g!(c, d, a, b, cache3, RC[26], 14);
     asm_op_g!(b, c, d, a, cache8, RC[27], 20);
 
-    asm_op_g!(a, b, c, d, data[13], RC[28], 5);
-    asm_op_g!(d, a, b, c, data[2], RC[29], 9);
-    asm_op_g!(c, d, a, b, data[7], RC[30], 14);
+    asm_op_g!(a, b, c, d, cache13, RC[28], 5);
+    asm_op_g!(d, a, b, c, cache2, RC[29], 9);
+    asm_op_g!(c, d, a, b, cache7, RC[30], 14);
     asm_op_g!(b, c, d, a, cache12, RC[31], 20);
 
     // round 3 - H function with re-use optimization (animetosho technique)
@@ -353,46 +353,49 @@ fn compress_block(state: &mut [u32; 4], input: &[u8; 64]) {
         );
     }
     
-    asm_op_h_reuse!(a, b, c, d, data[5], RC[32], 4, tmp_h);
+    asm_op_h_reuse!(a, b, c, d, cache5, RC[32], 4, tmp_h);
     asm_op_h_reuse!(d, a, b, c, cache8, RC[33], 11, tmp_h);
-    asm_op_h_reuse!(c, d, a, b, data[11], RC[34], 16, tmp_h);
-    asm_op_h_reuse!(b, c, d, a, data[14], RC[35], 23, tmp_h);
+    asm_op_h_reuse!(c, d, a, b, cache11, RC[34], 16, tmp_h);
+    asm_op_h_reuse!(b, c, d, a, cache14, RC[35], 23, tmp_h);
 
-    asm_op_h_reuse!(a, b, c, d, data[1], RC[36], 4, tmp_h);
+    asm_op_h_reuse!(a, b, c, d, cache1, RC[36], 4, tmp_h);
     asm_op_h_reuse!(d, a, b, c, cache4, RC[37], 11, tmp_h);
-    asm_op_h_reuse!(c, d, a, b, data[7], RC[38], 16, tmp_h);
-    asm_op_h_reuse!(b, c, d, a, data[10], RC[39], 23, tmp_h);
+    asm_op_h_reuse!(c, d, a, b, cache7, RC[38], 16, tmp_h);
+    asm_op_h_reuse!(b, c, d, a, cache10, RC[39], 23, tmp_h);
 
-    asm_op_h_reuse!(a, b, c, d, data[13], RC[40], 4, tmp_h);
-    asm_op_h_reuse!(d, a, b, c, data[0], RC[41], 11, tmp_h);
-    asm_op_h_reuse!(c, d, a, b, data[3], RC[42], 16, tmp_h);
-    asm_op_h_reuse!(b, c, d, a, data[6], RC[43], 23, tmp_h);
+    asm_op_h_reuse!(a, b, c, d, cache13, RC[40], 4, tmp_h);
+    asm_op_h_reuse!(d, a, b, c, cache0, RC[41], 11, tmp_h);
+    asm_op_h_reuse!(c, d, a, b, cache3, RC[42], 16, tmp_h);
+    #[allow(unused_assignments)]
+    {
+        asm_op_h_reuse!(b, c, d, a, cache6, RC[43], 23, tmp_h);
+    }
 
-    asm_op_h!(a, b, c, d, data[9], RC[44], 4);
+    asm_op_h!(a, b, c, d, cache9, RC[44], 4);
     asm_op_h!(d, a, b, c, cache12, RC[45], 11);
-    asm_op_h!(c, d, a, b, data[15], RC[46], 16);
-    asm_op_h!(b, c, d, a, data[2], RC[47], 23);
+    asm_op_h!(c, d, a, b, cache15, RC[46], 16);
+    asm_op_h!(b, c, d, a, cache2, RC[47], 23);
 
     // round 4
-    asm_op_i!(a, b, c, d, data[0], RC[48], 6);
-    asm_op_i!(d, a, b, c, data[7], RC[49], 10);
-    asm_op_i!(c, d, a, b, data[14], RC[50], 15);
-    asm_op_i!(b, c, d, a, data[5], RC[51], 21);
+    asm_op_i!(a, b, c, d, cache0, RC[48], 6);
+    asm_op_i!(d, a, b, c, cache7, RC[49], 10);
+    asm_op_i!(c, d, a, b, cache14, RC[50], 15);
+    asm_op_i!(b, c, d, a, cache5, RC[51], 21);
 
     asm_op_i!(a, b, c, d, cache12, RC[52], 6);
-    asm_op_i!(d, a, b, c, data[3], RC[53], 10);
-    asm_op_i!(c, d, a, b, data[10], RC[54], 15);
-    asm_op_i!(b, c, d, a, data[1], RC[55], 21);
+    asm_op_i!(d, a, b, c, cache3, RC[53], 10);
+    asm_op_i!(c, d, a, b, cache10, RC[54], 15);
+    asm_op_i!(b, c, d, a, cache1, RC[55], 21);
 
     asm_op_i!(a, b, c, d, cache8, RC[56], 6);
-    asm_op_i!(d, a, b, c, data[15], RC[57], 10);
-    asm_op_i!(c, d, a, b, data[6], RC[58], 15);
-    asm_op_i!(b, c, d, a, data[13], RC[59], 21);
+    asm_op_i!(d, a, b, c, cache15, RC[57], 10);
+    asm_op_i!(c, d, a, b, cache6, RC[58], 15);
+    asm_op_i!(b, c, d, a, cache13, RC[59], 21);
 
     asm_op_i!(a, b, c, d, cache4, RC[60], 6);
-    asm_op_i!(d, a, b, c, data[11], RC[61], 10);
-    asm_op_i!(c, d, a, b, data[2], RC[62], 15);
-    asm_op_i!(b, c, d, a, data[9], RC[63], 21);
+    asm_op_i!(d, a, b, c, cache11, RC[61], 10);
+    asm_op_i!(c, d, a, b, cache2, RC[62], 15);
+    asm_op_i!(b, c, d, a, cache9, RC[63], 21);
 
     state[0] = state[0].wrapping_add(a);
     state[1] = state[1].wrapping_add(b);


### PR DESCRIPTION
## Summary

Adds a high-performance AArch64 assembly implementation for MD5 that achieves **7-8% performance improvement** over the standard implementation across all benchmarked buffer sizes.

## Performance Results (Apple M1)

**ARM64 Assembly vs Software:**
- md5_10: 714 MB/s vs 666 MB/s (+48 MB/s, +7.2%)
- md5_100: 694 MB/s vs 645 MB/s (+49 MB/s, +7.6%)  
- md5_1000: 702 MB/s vs 651 MB/s (+51 MB/s, +7.8%)
- md5_10000: 704 MB/s vs 653 MB/s (+51 MB/s, +7.8%)

*Benchmarked on Apple M1 processor*

## Key Optimizations

1. **Efficient constant loading** using `ldp` (load pair) instructions to load two 32-bit constants at once
2. **Optimized round functions**:
   - G function: Uses ADD instead of OR for non-overlapping bits
   - H function: Reorders instructions to delay register dependencies  
   - I function: Uses ORN instruction to combine operations
3. **Instruction scheduling**: Hand-tuned assembly blocks with optimized dependency chains
4. **Register caching**: Caches all 16 input data elements in registers to eliminate memory accesses

## Implementation Details

- **File**: `md5/src/compress/aarch64_asm.rs` (1,121 lines)
- **Integration**: Conditional compilation via `cfg_if` matching existing `loongarch64_asm.rs` pattern

## Attribution

This implementation incorporates optimization techniques from [animetosho's md5-optimisation](https://github.com/animetosho/md5-optimisation/blob/master/md5-arm64-asm.h), which is released under [public domain license](https://github.com/animetosho/ParPar/tree/master?tab=readme-ov-file#license).

## Development Process

The implementation was developed through systematic optimization:
1. Baseline AArch64 assembly achieving 365 MB/s
2. Individual function optimizations (+40 MB/s)
3. Packed constants and ldp loading (+30 MB/s) 
4. Register caching and scheduling optimizations (+270 MB/s to final 704 MB/s)

All optimizations follow AArch64 ABI conventions.