### PR TITLE
Cut rc.3 prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.3"
 dependencies = [
  "base16ct",
  "belt-block",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "base16ct",
  "digest",
@@ -224,7 +224,7 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.3"
 dependencies = [
  "base16ct",
  "digest",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.3"
 dependencies = [
  "base16ct",
  "digest",
@@ -365,7 +365,7 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "base16ct",
  "digest",
@@ -421,7 +421,7 @@ checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
 name = "whirlpool"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 dependencies = [
  "base16ct",
  "digest",

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-hash"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.3"
 description = "BelT hash function (STB 34.101.31-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ripemd"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.3"
 description = "Pure Rust implementation of the RIPEMD hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm3"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.3"
 description = "SM3 (OSCCA GM/T 0004-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whirlpool"
-version = "0.11.0-rc.2"
+version = "0.11.0-rc.3"
 description = "Whirlpool hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases the following:
- `belt-hash` v0.2.0-rc.3
- `blake2` v0.11.0-rc.3
- `md-5` v0.11.0-rc.3
- `ripemd` v0.2.0-rc.3
- `sha1` v0.11.0-rc.3
- `sha2` v0.11.0-rc.3
- `sm3` v0.5.0-rc.3
- `streebog` v0.11.0-rc.3
- `whirlpool` v0.11.0-rc.3