### PR TITLE
md5: minor optimization in software backend

### DIFF
--- a/md5/src/compress/soft.rs
+++ b/md5/src/compress/soft.rs
@@ -12,10 +12,10 @@ fn op_f(w: u32, x: u32, y: u32, z: u32, m: u32, c: u32, s: u32) -> u32 {
 }
 #[inline(always)]
 fn op_g(w: u32, x: u32, y: u32, z: u32, m: u32, c: u32, s: u32) -> u32 {
-    // Here we replace the logical OR in `(x & z) | (y & !z)` with addition.
+    // We replace the logical OR in `(x & z) | (y & !z)` with addition.
     // Since masked bits do not overlap, the expressions are equivalent;
     // however, addition results in better performance on high-end CPUs,
-    // likely due to improved ALU utilization..
+    // likely due to improved ALU utilization.
     ((x & z).wrapping_add(y & !z))
         .wrapping_add(w)
         .wrapping_add(m)

--- a/md5/src/compress/soft.rs
+++ b/md5/src/compress/soft.rs
@@ -12,7 +12,11 @@ fn op_f(w: u32, x: u32, y: u32, z: u32, m: u32, c: u32, s: u32) -> u32 {
 }
 #[inline(always)]
 fn op_g(w: u32, x: u32, y: u32, z: u32, m: u32, c: u32, s: u32) -> u32 {
-    ((x & z) | (y & !z))
+    // Here we replace the logical OR in `(x & z) | (y & !z)` with addition.
+    // Since masked bits do not overlap, the expressions are equivalent;
+    // however, addition results in better performance on high-end CPUs,
+    // likely due to improved ALU utilization..
+    ((x & z).wrapping_add(y & !z))
         .wrapping_add(w)
         .wrapping_add(m)
         .wrapping_add(c)


### PR DESCRIPTION
Replaces the logical OR in the G function with addition. It seemingly results in a better ALU utilization and improves performance by several percents. From 699 MB/s to 753 MB/s on my x86 PC and from 910 MB/s to 960 MB/s on Mac M4.

Based on #749