### PR TITLE
Implement HAS-160

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "has160"
+version = "0.1.0"
+dependencies = [
+ "base16ct",
+ "digest",
+ "hex-literal",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "fsb",
     "gost94",
     "groestl",
+    "has160",
     "jh",
     "k12",
     "kupyna",

--- a/has160/Cargo.toml
+++ b/has160/Cargo.toml
@@ -30,3 +30,8 @@ force-soft = [] # Reserved for potential future software-only toggle
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[bench]]
+name = "digest_bench"
+path = "benches/digest_bench.rs"
+harness = true

--- a/has160/Cargo.toml
+++ b/has160/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "has160"
+version = "0.1.0"
+description = "HAS-160 hash function"
+authors = ["RustCrypto Developers"]
+license = "MIT OR Apache-2.0"
+edition = "2024"
+rust-version = "1.85"
+repository = "https://github.com/RustCrypto/hashes"
+documentation = "https://docs.rs/has160"
+keywords = ["has160", "hash", "digest"]
+categories = ["cryptography", "no-std"]
+
+[lib]
+name = "has160"
+
+[dependencies]
+digest = "0.11.0-rc.4"
+
+[dev-dependencies]
+digest = { version = "0.11.0-rc.4", features = ["dev"] }
+hex-literal = "1"
+base16ct = { version = "0.3", features = ["alloc"] }
+
+[features]
+default = ["alloc"]
+alloc = ["digest/alloc"]
+zeroize = ["digest/zeroize"]
+force-soft = [] # Reserved for potential future software-only toggle
+
+[package.metadata.docs.rs]
+all-features = true

--- a/has160/benches/digest_bench.rs
+++ b/has160/benches/digest_bench.rs
@@ -1,0 +1,15 @@
+#![feature(test)]
+extern crate test;
+
+use digest::bench_update;
+use has160::Has160;
+use test::Bencher;
+
+bench_update!(
+    Has160::default();
+    has160_10      10;
+    has160_100     100;
+    has160_1000    1000;
+    has160_10000   10000;
+    has160_100000  100000;
+);

--- a/has160/src/block_api.rs
+++ b/has160/src/block_api.rs
@@ -1,0 +1,143 @@
+use core::fmt;
+use digest::{
+    HashMarker, Output,
+    array::Array,
+    block_api::{
+        AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
+        OutputSizeUser, Reset, UpdateCore,
+    },
+    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    typenum::{U20, U28, U64, Unsigned},
+};
+
+#[cfg(feature = "zeroize")]
+use digest::zeroize::{Zeroize, ZeroizeOnDrop};
+
+pub use crate::compress::compress;
+
+/// Initial state values imported from `consts` to avoid duplication.
+use crate::consts::STATE_INIT;
+use crate::consts::STATE_LEN;
+
+/// Core HAS-160 hasher state.
+#[derive(Clone)]
+pub struct Has160Core {
+    h: [u32; STATE_LEN],
+    /// Number of 512-bit message blocks processed (not including the buffer)
+    block_len: u64,
+}
+
+impl HashMarker for Has160Core {}
+
+impl BlockSizeUser for Has160Core {
+    type BlockSize = U64; // 512-bit blocks
+}
+
+impl BufferKindUser for Has160Core {
+    type BufferKind = Eager;
+}
+
+impl OutputSizeUser for Has160Core {
+    type OutputSize = U20; // 160-bit output
+}
+
+impl UpdateCore for Has160Core {
+    fn update_blocks(&mut self, blocks: &[Block<Self>]) {
+        // Count full blocks processed
+        self.block_len = self.block_len.wrapping_add(blocks.len() as u64);
+
+        // Cast slice of generic blocks to array-of-64-byte blocks
+        let blocks = Array::cast_slice_to_core(blocks);
+        compress(&mut self.h, blocks);
+    }
+}
+
+impl FixedOutputCore for Has160Core {
+    fn finalize_fixed_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
+        // Total bit length (processed blocks * 64 + buffer length) * 8 bits.
+        // HAS-160 uses little-endian length encoding unlike SHA-1.
+        let bs = Self::BlockSize::U64;
+        let bit_len = 8 * (buffer.get_pos() as u64 + bs * self.block_len);
+
+        // Copy current state
+        let mut h = self.h;
+
+        // Apply Merkle–Damgård padding with 64-bit little-endian length
+        buffer.len64_padding_le(bit_len, |b| compress(&mut h, &[b.0]));
+
+        // Write final 160-bit digest as little-endian words (HAS-160 specification)
+        for (chunk, v) in out.chunks_exact_mut(4).zip(h.iter()) {
+            chunk.copy_from_slice(&v.to_le_bytes());
+        }
+    }
+}
+
+impl Default for Has160Core {
+    fn default() -> Self {
+        Self {
+            h: STATE_INIT,
+            block_len: 0,
+        }
+    }
+}
+
+impl Reset for Has160Core {
+    fn reset(&mut self) {
+        *self = Default::default();
+    }
+}
+
+impl AlgorithmName for Has160Core {
+    fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Has160")
+    }
+}
+
+impl fmt::Debug for Has160Core {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Has160Core { ... }")
+    }
+}
+
+impl Drop for Has160Core {
+    fn drop(&mut self) {
+        #[cfg(feature = "zeroize")]
+        {
+            self.h.zeroize();
+            self.block_len.zeroize();
+        }
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl ZeroizeOnDrop for Has160Core {}
+
+impl SerializableState for Has160Core {
+    // Serialized state size: 28 bytes
+    type SerializedStateSize = U28;
+
+    fn serialize(&self) -> SerializedState<Self> {
+        let mut ser = SerializedState::<Self>::default();
+
+        // Serialize state words little-endian for consistency with other implementations
+        for (val, chunk) in self.h.iter().zip(ser.chunks_exact_mut(4)) {
+            chunk.copy_from_slice(&val.to_le_bytes());
+        }
+
+        ser[20..].copy_from_slice(&self.block_len.to_le_bytes());
+        ser
+    }
+
+    fn deserialize(serialized: &SerializedState<Self>) -> Result<Self, DeserializeStateError> {
+        let (ser_state, ser_block_len) = serialized.split::<U20>();
+
+        let mut h = [0u32; STATE_LEN];
+        for (val, chunk) in h.iter_mut().zip(ser_state.chunks_exact(4)) {
+            *val = u32::from_le_bytes(chunk.try_into().unwrap());
+        }
+
+        let block_len = u64::from_le_bytes(*ser_block_len.as_ref());
+
+        Ok(Self { h, block_len })
+    }
+}

--- a/has160/src/compress.rs
+++ b/has160/src/compress.rs
@@ -16,19 +16,19 @@ fn compress_block(hash: &mut [u32; 5], block: &[u8; 64]) {
     }
 
     // Derive words 16..31
-    x[16] = x[0] ^ x[1] ^ x[2] ^ x[3];      // rounds  1..20
+    x[16] = x[0] ^ x[1] ^ x[2] ^ x[3]; // rounds  1..20
     x[17] = x[4] ^ x[5] ^ x[6] ^ x[7];
     x[18] = x[8] ^ x[9] ^ x[10] ^ x[11];
     x[19] = x[12] ^ x[13] ^ x[14] ^ x[15];
-    x[20] = x[3] ^ x[6] ^ x[9] ^ x[12];     // rounds 21..40
+    x[20] = x[3] ^ x[6] ^ x[9] ^ x[12]; // rounds 21..40
     x[21] = x[2] ^ x[5] ^ x[8] ^ x[15];
     x[22] = x[1] ^ x[4] ^ x[11] ^ x[14];
     x[23] = x[0] ^ x[7] ^ x[10] ^ x[13];
-    x[24] = x[5] ^ x[7] ^ x[12] ^ x[14];    // rounds 41..60
+    x[24] = x[5] ^ x[7] ^ x[12] ^ x[14]; // rounds 41..60
     x[25] = x[0] ^ x[2] ^ x[9] ^ x[11];
     x[26] = x[4] ^ x[6] ^ x[13] ^ x[15];
     x[27] = x[1] ^ x[3] ^ x[8] ^ x[10];
-    x[28] = x[2] ^ x[7] ^ x[8] ^ x[13];     // rounds 61..80
+    x[28] = x[2] ^ x[7] ^ x[8] ^ x[13]; // rounds 61..80
     x[29] = x[3] ^ x[4] ^ x[9] ^ x[14];
     x[30] = x[0] ^ x[5] ^ x[10] ^ x[15];
     x[31] = x[1] ^ x[6] ^ x[11] ^ x[12];
@@ -182,13 +182,7 @@ mod tests {
 
     #[test]
     fn state_changes_on_zero_block() {
-        let mut st = [
-            0x67452301,
-            0xEFCDAB89,
-            0x98BADCFE,
-            0x10325476,
-            0xC3D2E1F0,
-        ];
+        let mut st = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0];
         let before = st;
         let blk = [0u8; 64];
         compress(&mut st, &[blk]);

--- a/has160/src/compress.rs
+++ b/has160/src/compress.rs
@@ -1,0 +1,214 @@
+//! HAS-160 compression function.
+
+/// Compress a sequence of 512-bit (64-byte) message blocks into the in-place
+/// 160-bit chaining `state`.
+///
+/// Each block is interpreted as 16 little-endian 32-bit words; a fixed
+/// schedule of 32 derived words is then used for 80 HAS-160 rounds
+/// (four groups of twenty) updating `state`.
+///
+/// Parameters:
+/// - `state`: mutable reference to the 5-word chaining state (little-endian)
+/// - `blocks`: slice of 64-byte blocks to be processed sequentially
+///
+/// This function is internal to the `Has160Core` update/finalize path and
+/// mirrors the signature style used by other hash implementations in
+/// the workspace (e.g. SHA-1, MD5). It assumes correct block sizing and
+/// performs no padding; padding is handled in the core finalization.
+#[inline(always)]
+pub fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+    for block in blocks {
+        compress_block(state, block);
+    }
+}
+
+#[inline(always)]
+fn compress_block(hash: &mut [u32; 5], block: &[u8; 64]) {
+    // Load 16 little-endian 32-bit words
+    let mut x = [0u32; 32];
+    for (i, chunk) in block.chunks_exact(4).enumerate() {
+        x[i] = u32::from_le_bytes(chunk.try_into().unwrap());
+    }
+
+    // Derive words 16..31 exactly as per HAS-160 spec
+    x[16] = x[0] ^ x[1] ^ x[2] ^ x[3];      // rounds  1..20
+    x[17] = x[4] ^ x[5] ^ x[6] ^ x[7];
+    x[18] = x[8] ^ x[9] ^ x[10] ^ x[11];
+    x[19] = x[12] ^ x[13] ^ x[14] ^ x[15];
+    x[20] = x[3] ^ x[6] ^ x[9] ^ x[12];     // rounds 21..40
+    x[21] = x[2] ^ x[5] ^ x[8] ^ x[15];
+    x[22] = x[1] ^ x[4] ^ x[11] ^ x[14];
+    x[23] = x[0] ^ x[7] ^ x[10] ^ x[13];
+    x[24] = x[5] ^ x[7] ^ x[12] ^ x[14];    // rounds 41..60
+    x[25] = x[0] ^ x[2] ^ x[9] ^ x[11];
+    x[26] = x[4] ^ x[6] ^ x[13] ^ x[15];
+    x[27] = x[1] ^ x[3] ^ x[8] ^ x[10];
+    x[28] = x[2] ^ x[7] ^ x[8] ^ x[13];     // rounds 61..80
+    x[29] = x[3] ^ x[4] ^ x[9] ^ x[14];
+    x[30] = x[0] ^ x[5] ^ x[10] ^ x[15];
+    x[31] = x[1] ^ x[6] ^ x[11] ^ x[12];
+
+    // Working variables
+    let mut a = hash[0];
+    let mut b = hash[1];
+    let mut c = hash[2];
+    let mut d = hash[3];
+    let mut e = hash[4];
+
+    // Boolean/round macros translated directly.
+    macro_rules! step_f1 {
+        ($A:ident,$B:ident,$C:ident,$D:ident,$E:ident,$msg:expr,$rot:expr) => {{
+            $E = $E
+                .wrapping_add($A.rotate_left($rot))
+                .wrapping_add($D ^ ($B & ($C ^ $D)))
+                .wrapping_add($msg);
+            $B = $B.rotate_left(10);
+        }};
+    }
+    macro_rules! step_f2 {
+        ($A:ident,$B:ident,$C:ident,$D:ident,$E:ident,$msg:expr,$rot:expr) => {{
+            $E = $E
+                .wrapping_add($A.rotate_left($rot))
+                .wrapping_add($B ^ $C ^ $D)
+                .wrapping_add($msg)
+                .wrapping_add(0x5A827999);
+            $B = $B.rotate_left(17);
+        }};
+    }
+    macro_rules! step_f3 {
+        ($A:ident,$B:ident,$C:ident,$D:ident,$E:ident,$msg:expr,$rot:expr) => {{
+            $E = $E
+                .wrapping_add($A.rotate_left($rot))
+                .wrapping_add($C ^ ($B | !$D))
+                .wrapping_add($msg)
+                .wrapping_add(0x6ED9EBA1);
+            $B = $B.rotate_left(25);
+        }};
+    }
+    macro_rules! step_f4 {
+        ($A:ident,$B:ident,$C:ident,$D:ident,$E:ident,$msg:expr,$rot:expr) => {{
+            $E = $E
+                .wrapping_add($A.rotate_left($rot))
+                .wrapping_add($B ^ $C ^ $D)
+                .wrapping_add($msg)
+                .wrapping_add(0x8F1BBCDC);
+            $B = $B.rotate_left(30);
+        }};
+    }
+
+    // Round sequence (20 steps per group) exactly matching reference.
+    // Group F1 (rounds 1..20)
+    step_f1!(a, b, c, d, e, x[18], 5);
+    step_f1!(e, a, b, c, d, x[0], 11);
+    step_f1!(d, e, a, b, c, x[1], 7);
+    step_f1!(c, d, e, a, b, x[2], 15);
+    step_f1!(b, c, d, e, a, x[3], 6);
+    step_f1!(a, b, c, d, e, x[19], 13);
+    step_f1!(e, a, b, c, d, x[4], 8);
+    step_f1!(d, e, a, b, c, x[5], 14);
+    step_f1!(c, d, e, a, b, x[6], 7);
+    step_f1!(b, c, d, e, a, x[7], 12);
+    step_f1!(a, b, c, d, e, x[16], 9);
+    step_f1!(e, a, b, c, d, x[8], 11);
+    step_f1!(d, e, a, b, c, x[9], 8);
+    step_f1!(c, d, e, a, b, x[10], 15);
+    step_f1!(b, c, d, e, a, x[11], 6);
+    step_f1!(a, b, c, d, e, x[17], 12);
+    step_f1!(e, a, b, c, d, x[12], 9);
+    step_f1!(d, e, a, b, c, x[13], 14);
+    step_f1!(c, d, e, a, b, x[14], 5);
+    step_f1!(b, c, d, e, a, x[15], 13);
+
+    // Group F2 (rounds 21..40)
+    step_f2!(a, b, c, d, e, x[22], 5);
+    step_f2!(e, a, b, c, d, x[3], 11);
+    step_f2!(d, e, a, b, c, x[6], 7);
+    step_f2!(c, d, e, a, b, x[9], 15);
+    step_f2!(b, c, d, e, a, x[12], 6);
+    step_f2!(a, b, c, d, e, x[23], 13);
+    step_f2!(e, a, b, c, d, x[15], 8);
+    step_f2!(d, e, a, b, c, x[2], 14);
+    step_f2!(c, d, e, a, b, x[5], 7);
+    step_f2!(b, c, d, e, a, x[8], 12);
+    step_f2!(a, b, c, d, e, x[20], 9);
+    step_f2!(e, a, b, c, d, x[11], 11);
+    step_f2!(d, e, a, b, c, x[14], 8);
+    step_f2!(c, d, e, a, b, x[1], 15);
+    step_f2!(b, c, d, e, a, x[4], 6);
+    step_f2!(a, b, c, d, e, x[21], 12);
+    step_f2!(e, a, b, c, d, x[7], 9);
+    step_f2!(d, e, a, b, c, x[10], 14);
+    step_f2!(c, d, e, a, b, x[13], 5);
+    step_f2!(b, c, d, e, a, x[0], 13);
+
+    // Group F3 (rounds 41..60)
+    step_f3!(a, b, c, d, e, x[26], 5);
+    step_f3!(e, a, b, c, d, x[12], 11);
+    step_f3!(d, e, a, b, c, x[5], 7);
+    step_f3!(c, d, e, a, b, x[14], 15);
+    step_f3!(b, c, d, e, a, x[7], 6);
+    step_f3!(a, b, c, d, e, x[27], 13);
+    step_f3!(e, a, b, c, d, x[0], 8);
+    step_f3!(d, e, a, b, c, x[9], 14);
+    step_f3!(c, d, e, a, b, x[2], 7);
+    step_f3!(b, c, d, e, a, x[11], 12);
+    step_f3!(a, b, c, d, e, x[24], 9);
+    step_f3!(e, a, b, c, d, x[4], 11);
+    step_f3!(d, e, a, b, c, x[13], 8);
+    step_f3!(c, d, e, a, b, x[6], 15);
+    step_f3!(b, c, d, e, a, x[15], 6);
+    step_f3!(a, b, c, d, e, x[25], 12);
+    step_f3!(e, a, b, c, d, x[8], 9);
+    step_f3!(d, e, a, b, c, x[1], 14);
+    step_f3!(c, d, e, a, b, x[10], 5);
+    step_f3!(b, c, d, e, a, x[3], 13);
+
+    // Group F4 (rounds 61..80)
+    step_f4!(a, b, c, d, e, x[30], 5);
+    step_f4!(e, a, b, c, d, x[7], 11);
+    step_f4!(d, e, a, b, c, x[2], 7);
+    step_f4!(c, d, e, a, b, x[13], 15);
+    step_f4!(b, c, d, e, a, x[8], 6);
+    step_f4!(a, b, c, d, e, x[31], 13);
+    step_f4!(e, a, b, c, d, x[3], 8);
+    step_f4!(d, e, a, b, c, x[14], 14);
+    step_f4!(c, d, e, a, b, x[9], 7);
+    step_f4!(b, c, d, e, a, x[4], 12);
+    step_f4!(a, b, c, d, e, x[28], 9);
+    step_f4!(e, a, b, c, d, x[15], 11);
+    step_f4!(d, e, a, b, c, x[10], 8);
+    step_f4!(c, d, e, a, b, x[5], 15);
+    step_f4!(b, c, d, e, a, x[0], 6);
+    step_f4!(a, b, c, d, e, x[29], 12);
+    step_f4!(e, a, b, c, d, x[11], 9);
+    step_f4!(d, e, a, b, c, x[6], 14);
+    step_f4!(c, d, e, a, b, x[1], 5);
+    step_f4!(b, c, d, e, a, x[12], 13);
+
+    // Update chaining state
+    hash[0] = hash[0].wrapping_add(a);
+    hash[1] = hash[1].wrapping_add(b);
+    hash[2] = hash[2].wrapping_add(c);
+    hash[3] = hash[3].wrapping_add(d);
+    hash[4] = hash[4].wrapping_add(e);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_changes_on_zero_block() {
+        let mut st = [
+            0x67452301,
+            0xEFCDAB89,
+            0x98BADCFE,
+            0x10325476,
+            0xC3D2E1F0,
+        ];
+        let before = st;
+        let blk = [0u8; 64];
+        compress(&mut st, &[blk]);
+        assert_ne!(before, st);
+    }
+}

--- a/has160/src/consts.rs
+++ b/has160/src/consts.rs
@@ -1,0 +1,46 @@
+//! HAS-160 constants.
+
+/// Internal state length (5 x 32-bit words = 160 bits)
+const STATE_LEN: usize = 5;
+
+pub(crate) const STATE_INIT: [u32; 5] = [
+    0x6745_2301,
+    0xEFCD_AB89,
+    0x98BA_DCFE,
+    0x1032_5476,
+    0xC3D2_E1F0,
+];
+
+pub(crate) const K: [u32; 4] = [
+    0x5A82_7999,
+    0x6ED9_EBA1,
+    0x8F1B_BCDC,
+    0xCA62_C1D6,
+];
+
+pub(crate) enum RoundClass {
+    /// First 20 rounds (0..19)
+    Group0,
+    /// Rounds 20..39
+    Group1,
+    /// Rounds 40..59
+    Group2,
+    /// Rounds 60..79
+    Group3,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_init_values_match_expected() {
+        assert_eq!(STATE_INIT[0], 0x6745_2301);
+        assert_eq!(STATE_INIT[4], 0xC3D2_E1F0);
+    }
+
+    #[test]
+    fn k_constants_match_expected() {
+        assert_eq!(K, [0x5A82_7999, 0x6ED9_EBA1, 0x8F1B_BCDC, 0xCA62_C1D6]);
+    }
+}

--- a/has160/src/consts.rs
+++ b/has160/src/consts.rs
@@ -11,8 +11,6 @@ pub(crate) const STATE_INIT: [u32; 5] = [
     0xC3D2_E1F0,
 ];
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -22,6 +20,4 @@ mod tests {
         assert_eq!(STATE_INIT[0], 0x6745_2301);
         assert_eq!(STATE_INIT[4], 0xC3D2_E1F0);
     }
-
-
 }

--- a/has160/src/consts.rs
+++ b/has160/src/consts.rs
@@ -1,7 +1,7 @@
 //! HAS-160 constants.
 
 /// Internal state length (5 x 32-bit words = 160 bits)
-const STATE_LEN: usize = 5;
+pub(crate) const STATE_LEN: usize = 5;
 
 pub(crate) const STATE_INIT: [u32; 5] = [
     0x6745_2301,
@@ -11,23 +11,7 @@ pub(crate) const STATE_INIT: [u32; 5] = [
     0xC3D2_E1F0,
 ];
 
-pub(crate) const K: [u32; 4] = [
-    0x5A82_7999,
-    0x6ED9_EBA1,
-    0x8F1B_BCDC,
-    0xCA62_C1D6,
-];
 
-pub(crate) enum RoundClass {
-    /// First 20 rounds (0..19)
-    Group0,
-    /// Rounds 20..39
-    Group1,
-    /// Rounds 40..59
-    Group2,
-    /// Rounds 60..79
-    Group3,
-}
 
 #[cfg(test)]
 mod tests {
@@ -39,8 +23,5 @@ mod tests {
         assert_eq!(STATE_INIT[4], 0xC3D2_E1F0);
     }
 
-    #[test]
-    fn k_constants_match_expected() {
-        assert_eq!(K, [0x5A82_7999, 0x6ED9_EBA1, 0x8F1B_BCDC, 0xCA62_C1D6]);
-    }
+
 }

--- a/has160/src/lib.rs
+++ b/has160/src/lib.rs
@@ -1,0 +1,18 @@
+#![no_std]
+#![warn(missing_docs, unreachable_pub)]
+
+//! HAS-160 hash function.
+
+pub use digest::{self, Digest};
+
+/// Block-level types
+pub mod block_api;
+mod compress;
+mod consts;
+
+digest::buffer_fixed!(
+    /// HAS-160 hasher.
+    pub struct Has160(block_api::Has160Core);
+    // NOTE: couldn't find an OID
+    impl: FixedHashTraits;
+);

--- a/has160/tests/vectors.rs
+++ b/has160/tests/vectors.rs
@@ -42,48 +42,66 @@ fn test_vector_abc() {
 
 #[test]
 fn test_vector_a() {
-   let expected = "4872bcbc4cd0f0a9dc7c2f7045e5b43b6c830db8";
-   let got = has160_hex(b"a");
-   assert_eq!(got, expected, "HAS-160(\"a\") mismatch: got {got}, expected {expected}");
+    let expected = "4872bcbc4cd0f0a9dc7c2f7045e5b43b6c830db8";
+    let got = has160_hex(b"a");
+    assert_eq!(
+        got, expected,
+        "HAS-160(\"a\") mismatch: got {got}, expected {expected}"
+    );
 }
 
 #[test]
 fn test_vector_message_digest() {
-   let expected = "2338dbc8638d31225f73086246ba529f96710bc6";
-   let got = has160_hex(b"message digest");
-   assert_eq!(got, expected, "HAS-160(\"message digest\") mismatch: got {got}, expected {expected}");
+    let expected = "2338dbc8638d31225f73086246ba529f96710bc6";
+    let got = has160_hex(b"message digest");
+    assert_eq!(
+        got, expected,
+        "HAS-160(\"message digest\") mismatch: got {got}, expected {expected}"
+    );
 }
 
 #[test]
 fn test_vector_alphabet() {
-   let expected = "596185c9ab6703d0d0dbb98702bc0f5729cd1d3c";
-   let got = has160_hex(b"abcdefghijklmnopqrstuvwxyz");
-   assert_eq!(got, expected, "HAS-160(alphabet) mismatch: got {got}, expected {expected}");
+    let expected = "596185c9ab6703d0d0dbb98702bc0f5729cd1d3c";
+    let got = has160_hex(b"abcdefghijklmnopqrstuvwxyz");
+    assert_eq!(
+        got, expected,
+        "HAS-160(alphabet) mismatch: got {got}, expected {expected}"
+    );
 }
 
 #[test]
 fn test_vector_alphanum() {
-   let expected = "cb5d7efbca2f02e0fb7167cabb123af5795764e5";
-   let got = has160_hex(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-   assert_eq!(got, expected, "HAS-160(alphanum) mismatch: got {got}, expected {expected}");
+    let expected = "cb5d7efbca2f02e0fb7167cabb123af5795764e5";
+    let got = has160_hex(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+    assert_eq!(
+        got, expected,
+        "HAS-160(alphanum) mismatch: got {got}, expected {expected}"
+    );
 }
 
 #[test]
 fn test_vector_repeated_digits() {
-   // eight repetitions of "1234567890"
-   let input = b"12345678901234567890123456789012345678901234567890123456789012345678901234567890";
-   assert_eq!(input.len(), 80);
-   let expected = "07f05c8c0773c55ca3a5a695ce6aca4c438911b5";
-   let got = has160_hex(input);
-   assert_eq!(got, expected, "HAS-160(8x\"1234567890\") mismatch: got {got}, expected {expected}");
+    // eight repetitions of "1234567890"
+    let input = b"12345678901234567890123456789012345678901234567890123456789012345678901234567890";
+    assert_eq!(input.len(), 80);
+    let expected = "07f05c8c0773c55ca3a5a695ce6aca4c438911b5";
+    let got = has160_hex(input);
+    assert_eq!(
+        got, expected,
+        "HAS-160(8x\"1234567890\") mismatch: got {got}, expected {expected}"
+    );
 }
 
 #[test]
 fn test_vector_million_a() {
-   let expected = "d6ad6f0608b878da9b87999c2525cc84f4c9f18d";
-   let million = vec![b'a'; 1_000_000];
-   let got = has160_hex(&million);
-   assert_eq!(got, expected, "HAS-160(1e6 * 'a') mismatch: got {got}, expected {expected}");
+    let expected = "d6ad6f0608b878da9b87999c2525cc84f4c9f18d";
+    let million = vec![b'a'; 1_000_000];
+    let got = has160_hex(&million);
+    assert_eq!(
+        got, expected,
+        "HAS-160(1e6 * 'a') mismatch: got {got}, expected {expected}"
+    );
 }
 #[test]
 fn test_streaming_equivalence() {
@@ -104,7 +122,8 @@ fn test_long_message_reproducibility() {
     let whole = has160_hex(msg);
 
     // Split into irregular chunks
-    let chunked = has160_hex_chunked(&[&msg[..5], &msg[5..9], &msg[9..17], &msg[17..30], &msg[30..]]);
+    let chunked =
+        has160_hex_chunked(&[&msg[..5], &msg[5..9], &msg[9..17], &msg[17..30], &msg[30..]]);
 
     assert_eq!(
         whole, chunked,
@@ -155,7 +174,11 @@ fn test_serialization_roundtrip() {
         let ser = manual.serialize();
         let deser = Has160Core::deserialize(&ser).expect("deserialize");
         let ser2 = deser.serialize();
-        assert_eq!(&ser[..], &ser2[..], "Roundtrip serialization failed for default state");
+        assert_eq!(
+            &ser[..],
+            &ser2[..],
+            "Roundtrip serialization failed for default state"
+        );
     }
 
     // Now test non-default (after processing data) by hashing through high-level API,

--- a/has160/tests/vectors.rs
+++ b/has160/tests/vectors.rs
@@ -1,0 +1,169 @@
+//! HAS-160 test vectors.
+
+use has160::{Digest, Has160};
+
+/// Helper: compute HAS-160 digest and return lowercase hex string.
+fn has160_hex(data: &[u8]) -> String {
+    let mut h = Has160::new();
+    h.update(data);
+    let out = h.finalize();
+    out.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+/// Helper: chunked update to test streaming behavior.
+fn has160_hex_chunked(chunks: &[&[u8]]) -> String {
+    let mut h = Has160::new();
+    for c in chunks {
+        h.update(c);
+    }
+    let out = h.finalize();
+    out.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[test]
+fn test_vector_empty() {
+    let expected = "307964ef34151d37c8047adec7ab50f4ff89762d";
+    let got = has160_hex(b"");
+    assert_eq!(
+        got, expected,
+        "HAS-160(\"\") mismatch: got {got}, expected {expected}"
+    );
+}
+
+#[test]
+fn test_vector_abc() {
+    let expected = "975e810488cf2a3d49838478124afce4b1c78804";
+    let got = has160_hex(b"abc");
+    assert_eq!(
+        got, expected,
+        "HAS-160(\"abc\") mismatch: got {got}, expected {expected}"
+    );
+}
+
+#[test]
+fn test_vector_a() {
+   let expected = "4872bcbc4cd0f0a9dc7c2f7045e5b43b6c830db8";
+   let got = has160_hex(b"a");
+   assert_eq!(got, expected, "HAS-160(\"a\") mismatch: got {got}, expected {expected}");
+}
+
+#[test]
+fn test_vector_message_digest() {
+   let expected = "2338dbc8638d31225f73086246ba529f96710bc6";
+   let got = has160_hex(b"message digest");
+   assert_eq!(got, expected, "HAS-160(\"message digest\") mismatch: got {got}, expected {expected}");
+}
+
+#[test]
+fn test_vector_alphabet() {
+   let expected = "596185c9ab6703d0d0dbb98702bc0f5729cd1d3c";
+   let got = has160_hex(b"abcdefghijklmnopqrstuvwxyz");
+   assert_eq!(got, expected, "HAS-160(alphabet) mismatch: got {got}, expected {expected}");
+}
+
+#[test]
+fn test_vector_alphanum() {
+   let expected = "cb5d7efbca2f02e0fb7167cabb123af5795764e5";
+   let got = has160_hex(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+   assert_eq!(got, expected, "HAS-160(alphanum) mismatch: got {got}, expected {expected}");
+}
+
+#[test]
+fn test_vector_repeated_digits() {
+   // eight repetitions of "1234567890"
+   let input = b"12345678901234567890123456789012345678901234567890123456789012345678901234567890";
+   assert_eq!(input.len(), 80);
+   let expected = "07f05c8c0773c55ca3a5a695ce6aca4c438911b5";
+   let got = has160_hex(input);
+   assert_eq!(got, expected, "HAS-160(8x\"1234567890\") mismatch: got {got}, expected {expected}");
+}
+
+#[test]
+fn test_vector_million_a() {
+   let expected = "d6ad6f0608b878da9b87999c2525cc84f4c9f18d";
+   let million = vec![b'a'; 1_000_000];
+   let got = has160_hex(&million);
+   assert_eq!(got, expected, "HAS-160(1e6 * 'a') mismatch: got {got}, expected {expected}");
+}
+#[test]
+fn test_streaming_equivalence() {
+    let data = b"abc";
+    let whole = has160_hex(data);
+    let chunked = has160_hex_chunked(&[b"a", b"b", b"c"]);
+    assert_eq!(
+        whole, chunked,
+        "Streaming update produced different digest than single update"
+    );
+}
+
+#[test]
+fn test_long_message_reproducibility() {
+    // Not a published vector, just internal consistency check.
+    // Ensures that splitting across block boundaries yields same result.
+    let msg = b"The quick brown fox jumps over the lazy dog";
+    let whole = has160_hex(msg);
+
+    // Split into irregular chunks
+    let chunked = has160_hex_chunked(&[&msg[..5], &msg[5..9], &msg[9..17], &msg[17..30], &msg[30..]]);
+
+    assert_eq!(
+        whole, chunked,
+        "Chunked processing altered digest for long message"
+    );
+}
+
+#[test]
+fn test_incremental_reset() {
+    let expected = "307964ef34151d37c8047adec7ab50f4ff89762d";
+
+    // First digest
+    let mut h = Has160::new();
+    h.update(b"");
+    let first = h.clone().finalize();
+    let first_hex: String = first.iter().map(|b| format!("{:02x}", b)).collect();
+    assert_eq!(first_hex, expected, "Initial empty digest mismatch");
+
+    // Reset and recompute
+    h.reset();
+    h.update(b"");
+    let second = h.finalize();
+    let second_hex: String = second.iter().map(|b| format!("{:02x}", b)).collect();
+    assert_eq!(
+        second_hex, expected,
+        "Digest after reset does not match expected empty digest"
+    );
+}
+
+#[test]
+fn test_serialization_roundtrip() {
+    use digest::crypto_common::hazmat::SerializableState;
+    use has160::block_api::Has160Core;
+
+    // Prepare a core with some data processed
+    // Removed unused variable: core
+    {
+        // Simulate update by directly calling UpdateCore logic through Has160 wrapper.
+        // Easiest: use high-level hasher and then extract internal state via re-hash.
+        let mut h = Has160::new();
+        h.update(b"abc");
+        // Serialize from a fresh core => feed "abc" manually
+        let manual = Has160Core::default();
+        // Emulate one-shot update: buffer_fixed abstraction hides internals,
+        // so we just use a separate Has160 to produce a reference digest,
+        // then ensure serialization of core default works.
+        // Here we simply test roundtrip on a default core instead to avoid internal API assumptions.
+        let ser = manual.serialize();
+        let deser = Has160Core::deserialize(&ser).expect("deserialize");
+        let ser2 = deser.serialize();
+        assert_eq!(&ser[..], &ser2[..], "Roundtrip serialization failed for default state");
+    }
+
+    // Now test non-default (after processing data) by hashing through high-level API,
+    // then reconstructing a manual core to compare serialization lengths for sanity.
+    let mut h = Has160::new();
+    h.update(b"abc");
+    let digest = h.finalize(); // ensure finalize works (not checking value here)
+
+    // Just ensure digest length is 20 bytes
+    assert_eq!(digest.len(), 20, "HAS-160 digest length should be 20 bytes");
+}


### PR DESCRIPTION
Adds an implementation for the HAS-160 hashing algorithm.
Relevant Issue with discussion on this: #1 

References:
1. [Random bit blog post](https://www.randombit.net/has160.html)
2. [Original Spec sheet](https://web.archive.org/web/20230603174348/https://www.tta.or.kr/include/Download.jsp?filename=stnfile/TTA-0072.pdf)

<details> <summary>PS</summary>

This proposal for this was originally submitted for GSoC 2024, but iirc the rust crypto project was repealed. I had intended to add this since then. Better late than never :P

</details>