### PR TITLE
perf(k12): remove redundant 8KiB buffer zeroing in process_chunk

### DIFF
--- a/k12/src/block_api.rs
+++ b/k12/src/block_api.rs
@@ -47,7 +47,6 @@ impl<'cs> KangarooTwelveCore<'cs> {
         }
 
         self.chain_length += 1;
-        self.buffer = [0u8; CHUNK_SIZE];
         self.bufpos = 0;
     }
 

--- a/k12/src/block_api.rs
+++ b/k12/src/block_api.rs
@@ -39,7 +39,7 @@ impl<'cs> KangarooTwelveCore<'cs> {
     }
 
     fn process_chunk(&mut self) {
-        debug_assert!(self.bufpos == CHUNK_SIZE);
+        debug_assert_eq!(self.bufpos, CHUNK_SIZE);
         if self.chain_length == 0 {
             self.final_tshk.update(&self.buffer);
         } else {


### PR DESCRIPTION
The buffer was zeroed after each full chunk in KangarooTwelveCore::process_chunk(). This is unnecessary because subsequent reads only consume [..bufpos] and bufpos is reset to 0. Removing the memset avoids extra work on long inputs and aligns with the project’s pattern of cleaning sensitive data via Drop under the zeroize feature.