### PR TITLE
Cut new prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ascon-hash256"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 dependencies = [
  "ascon",
  "base16ct",
@@ -37,7 +37,7 @@ checksum = "bfed5cd32720841afa8cd58c89a317e9efb0c8083e1b349dae4098f022620353"
 
 [[package]]
 name = "bash-hash"
-version = "0.1.0"
+version = "0.1.0-rc.0"
 dependencies = [
  "base16ct",
  "bash-f",
@@ -53,7 +53,7 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 dependencies = [
  "base16ct",
  "belt-block",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 dependencies = [
  "base16ct",
  "digest",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "fsb"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "gost94"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "groestl"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "jh"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "k12"
-version = "0.4.0-rc.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "digest",
  "hex-literal",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "kupyna"
-version = "0.1.0"
+version = "0.1.0-pre"
 dependencies = [
  "base16ct",
  "digest",
@@ -224,7 +224,7 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "md2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "md4"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 dependencies = [
  "base16ct",
  "digest",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.6"
 dependencies = [
  "base16ct",
  "digest",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "shabal"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "skein"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 dependencies = [
  "base16ct",
  "digest",
@@ -365,7 +365,7 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 dependencies = [
  "base16ct",
  "digest",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "tiger"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "base16ct",
  "digest",
@@ -421,7 +421,7 @@ checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
 name = "whirlpool"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 dependencies = [
  "base16ct",
  "digest",

--- a/ascon-hash256/Cargo.toml
+++ b/ascon-hash256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon-hash256"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 description = "Implementation of Ascon-Hash256 and Ascon-XOF256"
 authors = [
     "Sebastian Ramacher <sebastian.ramacher@ait.ac.at>",

--- a/bash-hash/Cargo.toml
+++ b/bash-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bash-hash"
-version = "0.1.0"
+version = "0.1.0-rc.0"
 description = "bash hash function (STB 34.101.77-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-hash"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 description = "BelT hash function (STB 34.101.31-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsb"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "FSB hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gost94"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = "GOST R 34.11-94 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "groestl"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = "Grøstl hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jh"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "Pure Rust implementation of the JH cryptographic hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k12"
-version = "0.4.0-rc.0"
+version = "0.4.0-rc.1"
 description = "Pure Rust implementation of the KangarooTwelve hash function"
 authors = ["RustCrypto Developers", "Diggory Hardy <github1@dhardy.name>"]
 license = "Apache-2.0 OR MIT"
@@ -14,7 +14,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 digest = "0.11.0-rc.8"
-sha3 = { version = "0.11.0-rc.3", default-features = false }
+sha3 = { version = "0.11.0-rc.6", default-features = false }
 
 [dev-dependencies]
 digest = { version = "0.11.0-rc.8", features = ["alloc", "dev"] }

--- a/kupyna/Cargo.toml
+++ b/kupyna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kupyna"
-version = "0.1.0"
+version = "0.1.0-pre"
 description = "Kupyna (DSTU 7564:2014) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md2"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 license = "MIT OR Apache-2.0"
 authors = ["RustCrypto Developers"]
 description = "MD2 hash function"

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md4"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 description = "MD4 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ripemd"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 description = "Pure Rust implementation of the RIPEMD hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 
 [dependencies]
 digest = "0.11.0-rc.8"
-sha1 = { version = "0.11.0-rc.3", default-features = false }
+sha1 = { version = "0.11.0-rc.4", default-features = false }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0-rc.5"
+version = "0.11.0-rc.6"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shabal"
-version = "0.5.0-rc.0"
+version = "0.5.0-rc.1"
 description = "Shabal hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skein"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "Skein hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm3"
-version = "0.5.0-rc.3"
+version = "0.5.0-rc.4"
 description = "SM3 (OSCCA GM/T 0004-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/tiger/Cargo.toml
+++ b/tiger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiger"
-version = "0.3.0-rc.0"
+version = "0.3.0-rc.1"
 description = "Tiger hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whirlpool"
-version = "0.11.0-rc.3"
+version = "0.11.0-rc.4"
 description = "Whirlpool hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
These include `digest` v0.11.0-rc.8 which transitively pins to `rand_core` v0.10.0-rc-6 by way of `crypto-common`.

- `ascon-hash256` v0.5.0-rc.1
- `bash-hash` v0.1.0-rc.0
- `belt-hash` v0.2.0-rc.4
- `blake2` v0.11.0-rc.4
- `fsb` v0.2.0-rc.1
- `gost94` v0.11.0-rc.1
- `groestl` v0.11.0-rc.1
- `jh` v0.2.0-rc.1
- `k12` v0.4.0-rc.1
- `md-5` v0.11.0-rc.4
- `md2` v0.11.0-rc.1
- `md4` v0.11.0-rc.1
- `ripemd` v0.2.0-rc.4
- `sha1` v0.11.0-rc.4
- `sha2` v0.11.0-rc.4
- `sha3` v0.11.0-rc.6
- `shabal` v0.5.0-rc.1
- `skein` v0.2.0-rc.1
- `sm3` v0.5.0-rc.4
- `streebog` v0.11.0-rc.4
- `tiger` v0.3.0-rc.1
- `whirlpool` v0.11.0-rc.4