### PR TITLE
Bump `digest` dependency to v0.11.0-rc.11

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -4,5 +4,6 @@ extend-exclude = [
 ]
 
 [default.extend-words]
-"GOST" = "GOST"
-
+consts = "consts"
+cpy = "cpy"
+GOST = "GOST"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "ascon-hash256"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 dependencies = [
  "ascon",
  "base16ct",
@@ -37,7 +37,7 @@ checksum = "bfed5cd32720841afa8cd58c89a317e9efb0c8083e1b349dae4098f022620353"
 
 [[package]]
 name = "bash-hash"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 dependencies = [
  "base16ct",
  "bash-f",
@@ -53,7 +53,7 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 dependencies = [
  "base16ct",
  "belt-block",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 dependencies = [
  "base16ct",
  "digest",
@@ -109,18 +109,18 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7722afd27468475c9b6063dc03a57ef2ca833816981619f8ebe64d38d207eef"
+checksum = "6f8441110cea75afde0b89a8d796e2bc67b23432f5a9566cb15d9d365d91a2b0"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.9"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
+checksum = "02b42f1d9edf5207c137646b568a0168ca0ec25b7f9eaf7f9961da51a3d91cea"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "fsb"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "gost94"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "groestl"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "kupyna"
-version = "0.1.0-pre"
+version = "0.1.0-pre.0"
 dependencies = [
  "base16ct",
  "digest",
@@ -224,7 +224,7 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "md2"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "md4"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 dependencies = [
  "base16ct",
  "digest",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 dependencies = [
  "base16ct",
  "cfg-if",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.6"
+version = "0.11.0-rc.7"
 dependencies = [
  "base16ct",
  "digest",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "shabal"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "skein"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-rc.4"
+version = "0.5.0-rc.5"
 dependencies = [
  "base16ct",
  "digest",
@@ -365,7 +365,7 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 dependencies = [
  "base16ct",
  "digest",
@@ -391,16 +391,16 @@ dependencies = [
 
 [[package]]
 name = "threefish"
-version = "0.6.0-rc.0"
+version = "0.6.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cd7fdb58d3b9c24db1d799b0e52853efac97926be93914efa648d9204ff52f"
+checksum = "dd8620a71dd833b597b37a17af3c07782f81c232978da6027842eb3ab006119d"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "tiger"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "base16ct",
  "digest",
@@ -421,7 +421,7 @@ checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
 name = "whirlpool"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 dependencies = [
  "base16ct",
  "digest",

--- a/ascon-hash256/Cargo.toml
+++ b/ascon-hash256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon-hash256"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 description = "Implementation of Ascon-Hash256 and Ascon-XOF256"
 authors = [
     "Sebastian Ramacher <sebastian.ramacher@ait.ac.at>",
@@ -16,7 +16,7 @@ keywords = ["hash", "ascon"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 ascon = { version = "0.5.0-rc.0", default-features = false }
 
 [dev-dependencies]

--- a/ascon-hash256/src/lib.rs
+++ b/ascon-hash256/src/lib.rs
@@ -17,8 +17,8 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, ExtendableOutputCore,
         FixedOutputCore, UpdateCore, XofReaderCore,
     },
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     consts::{U8, U16, U32, U40},
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
 };
 
 /// Produce mask for padding.

--- a/bash-hash/Cargo.toml
+++ b/bash-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bash-hash"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 description = "bash hash function (STB 34.101.77-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ keywords = ["belt", "stb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 bash-f = "0.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/bash-hash/src/block_api.rs
+++ b/bash-hash/src/block_api.rs
@@ -5,7 +5,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::U192,
 };
 

--- a/bash-hash/src/serialize.rs
+++ b/bash-hash/src/serialize.rs
@@ -3,7 +3,7 @@ use core::ops::Add;
 use digest::{
     array::ArraySize,
     block_buffer::BlockBuffer,
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{Sum, U0, U192},
 };
 

--- a/bash-hash/src/variants.rs
+++ b/bash-hash/src/variants.rs
@@ -1,4 +1,4 @@
-use digest::{array::ArraySize, crypto_common::BlockSizes, typenum};
+use digest::{array::ArraySize, common::BlockSizes, typenum};
 
 /// Sealed trait to prevent external implementations.
 pub trait Sealed {}

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-hash"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 description = "BelT hash function (STB 34.101.31-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ keywords = ["belt", "stb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 belt-block = { version = "0.1.1", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/belt-hash/src/block_api.rs
+++ b/belt-hash/src/block_api.rs
@@ -6,7 +6,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{U32, U64, Unsigned},
 };
 

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blake2"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 description = "BLAKE2 hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["blake2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.11.0-rc.9", features = ["mac"] }
+digest = { version = "0.11.0-rc.11", features = ["mac"] }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/blake2/src/lib.rs
+++ b/blake2/src/lib.rs
@@ -21,8 +21,8 @@ use digest::{
         UpdateCore, VariableOutputCore, VariableOutputCoreCustomized,
     },
     block_buffer::{Lazy, LazyBuffer},
+    common::{InvalidLength, Key, KeyInit, KeySizeUser},
     consts::{U4, U16, U32, U64, U128},
-    crypto_common::{InvalidLength, Key, KeyInit, KeySizeUser},
     typenum::{IsLessOrEqual, True, Unsigned},
 };
 #[cfg(feature = "reset")]

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsb"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 description = "FSB hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ keywords = ["fsb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 whirlpool = { version = "0.11.0-rc.3", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/fsb/src/block_api.rs
+++ b/fsb/src/block_api.rs
@@ -6,7 +6,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{Sum, U8, Unsigned},
 };
 

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gost94"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = "GOST R 34.11-94 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["gost94", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/gost94/src/block_api.rs
+++ b/gost94/src/block_api.rs
@@ -7,7 +7,7 @@ use digest::{
         AlgorithmName, Block as TBlock, BlockSizeUser, Buffer, BufferKindUser, Eager,
         FixedOutputCore, OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{U32, U96, Unsigned},
 };
 

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "groestl"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = "Grøstl hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["groestl", "grostl", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/groestl/src/block_api.rs
+++ b/groestl/src/block_api.rs
@@ -5,7 +5,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, OutputSizeUser,
         TruncSide, UpdateCore, VariableOutputCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{Sum, U8, U32, U64, U128, Unsigned},
 };
 

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["jh", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 hex-literal = "1"
 simd = { package = "ppv-lite86", version = "0.2.6" }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 base16ct = { version = "1", features = ["alloc"] }
 
 [features]

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
-sha3 = { version = "0.11.0-rc.6", default-features = false }
+digest = "0.11.0-rc.11"
+sha3 = { version = "0.11.0-rc.7", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["alloc", "dev"] }
+digest = { version = "0.11.0-rc.11", features = ["alloc", "dev"] }
 hex-literal = "1"
 
 [features]

--- a/kupyna/Cargo.toml
+++ b/kupyna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kupyna"
-version = "0.1.0-pre"
+version = "0.1.0-pre.0"
 description = "Kupyna (DSTU 7564:2014) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ categories = ["cryptography", "no-std"]
 rust-version = "1.85"
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/kupyna/src/block_api.rs
+++ b/kupyna/src/block_api.rs
@@ -9,7 +9,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, OutputSizeUser,
         TruncSide, UpdateCore, VariableOutputCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{U32, U64, U72, U128, U136, Unsigned},
 };
 

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md2"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 license = "MIT OR Apache-2.0"
 authors = ["RustCrypto Developers"]
 description = "MD2 hash function"
@@ -13,10 +13,10 @@ keywords = ["md2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/md2/src/block_api.rs
+++ b/md2/src/block_api.rs
@@ -6,8 +6,8 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     consts::{U16, U48, U64},
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
 };
 
 use crate::consts::S;

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md4"
-version = "0.11.0-rc.1"
+version = "0.11.0-rc.2"
 description = "MD4 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["md4", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/md4/src/block_api.rs
+++ b/md4/src/block_api.rs
@@ -5,7 +5,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{U16, U24, U64, Unsigned},
 };
 

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 description = "MD5 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -16,11 +16,11 @@ categories = ["cryptography", "no-std"]
 name = "md5"
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 cfg-if = "1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/md5/src/block_api.rs
+++ b/md5/src/block_api.rs
@@ -6,7 +6,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{U16, U24, U64, Unsigned},
 };
 

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ripemd"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 description = "Pure Rust implementation of the RIPEMD hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["ripemd", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/ripemd/src/block_api.rs
+++ b/ripemd/src/block_api.rs
@@ -5,7 +5,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{Sum, U8, U16, U20, U32, U40, U64, Unsigned},
 };
 

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -18,12 +18,12 @@ exclude = [
 ]
 
 [dependencies]
-digest = "0.11.0-rc.9"
-sha1 = { version = "0.11.0-rc.4", default-features = false }
+digest = "0.11.0-rc.11"
+sha1 = { version = "0.11.0-rc.5", default-features = false }
 zeroize = { version = "1.8", default-features = false, optional = true }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 description = "SHA-1 hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,14 +13,14 @@ keywords = ["sha1", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 cfg-if = "1.0"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/sha1/src/block_api.rs
+++ b/sha1/src/block_api.rs
@@ -6,7 +6,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{U20, U28, U64, Unsigned},
 };
 

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha2"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 description = """
 Pure Rust implementation of the SHA-2 hash function family
 including SHA-224, SHA-256, SHA-384, and SHA-512.
@@ -16,14 +16,14 @@ keywords = ["sha2", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 cfg-if = "1"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/sha2/src/block_api.rs
+++ b/sha2/src/block_api.rs
@@ -7,7 +7,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, OutputSizeUser,
         TruncSide, UpdateCore, VariableOutputCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{U32, U40, U64, U80, U128, Unsigned},
 };
 

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0-rc.6"
+version = "0.11.0-rc.7"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as
@@ -17,11 +17,11 @@ keywords = ["sha3", "keccak", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 keccak = "0.2.0-rc.1"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/sha3/src/block_api.rs
+++ b/sha3/src/block_api.rs
@@ -7,7 +7,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, ExtendableOutputCore,
         FixedOutputCore, OutputSizeUser, Reset, UpdateCore, XofReaderCore,
     },
-    crypto_common::{
+    common::{
         BlockSizes,
         hazmat::{DeserializeStateError, SerializableState, SerializedState},
     },

--- a/sha3/src/cshake.rs
+++ b/sha3/src/cshake.rs
@@ -9,8 +9,8 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, ExtendableOutputCore,
         UpdateCore,
     },
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     consts::{U16, U32, U136, U168, U400},
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::Unsigned,
 };
 

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shabal"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 description = "Shabal hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["shabal", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/shabal/src/block_api.rs
+++ b/shabal/src/block_api.rs
@@ -7,8 +7,8 @@ use digest::{
         AlgorithmName, BlockSizeUser, Buffer, BufferKindUser, Eager, OutputSizeUser, TruncSide,
         UpdateCore, VariableOutputCore,
     },
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     consts::{U8, U48, U64, U184},
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
 };
 
 type BlockSize = U64;

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skein"
-version = "0.2.0-rc.1"
+version = "0.2.0-rc.2"
 description = "Skein hash functions"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ keywords = ["skein", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
-threefish = { version = "0.6.0-rc.0", default-features = false }
+digest = "0.11.0-rc.11"
+threefish = { version = "0.6.0-rc.1", default-features = false }
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/skein/src/block_api.rs
+++ b/skein/src/block_api.rs
@@ -6,7 +6,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, FixedOutputCore, Lazy,
         OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{Sum, U16, U32, U64, U128, Unsigned},
 };
 use threefish::{Threefish256, Threefish512, Threefish1024};

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm3"
-version = "0.5.0-rc.4"
+version = "0.5.0-rc.5"
 description = "SM3 (OSCCA GM/T 0004-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["sm3", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/sm3/src/block_api.rs
+++ b/sm3/src/block_api.rs
@@ -6,7 +6,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{U32, U40, U64, Unsigned},
 };
 

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 description = "Streebog (GOST R 34.11-2012) hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["streebog", "gost", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/streebog/src/block_api.rs
+++ b/streebog/src/block_api.rs
@@ -6,8 +6,8 @@ use digest::{
         AlgorithmName, Block as GenBlock, BlockSizeUser, Buffer, BufferKindUser, Eager,
         OutputSizeUser, TruncSide, UpdateCore, VariableOutputCore,
     },
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     consts::{U64, U192},
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
 };
 
 #[cfg(feature = "zeroize")]

--- a/tiger/Cargo.toml
+++ b/tiger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiger"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 description = "Tiger hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["hash", "tiger", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/tiger/src/block_api.rs
+++ b/tiger/src/block_api.rs
@@ -6,7 +6,7 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     typenum::{U24, U32, U64, Unsigned},
 };
 

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whirlpool"
-version = "0.11.0-rc.4"
+version = "0.11.0-rc.5"
 description = "Whirlpool hash function"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ keywords = ["whirlpool", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = "0.11.0-rc.9"
+digest = "0.11.0-rc.11"
 
 [dev-dependencies]
-digest = { version = "0.11.0-rc.9", features = ["dev"] }
+digest = { version = "0.11.0-rc.11", features = ["dev"] }
 hex-literal = "1"
 base16ct = { version = "1", features = ["alloc"] }
 

--- a/whirlpool/src/block_api.rs
+++ b/whirlpool/src/block_api.rs
@@ -6,8 +6,8 @@ use digest::{
         AlgorithmName, Block, BlockSizeUser, Buffer, BufferKindUser, Eager, FixedOutputCore,
         OutputSizeUser, Reset, UpdateCore,
     },
+    common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
     consts::{U64, U72},
-    crypto_common::hazmat::{DeserializeStateError, SerializableState, SerializedState},
 };
 
 use crate::compress::compress;


### PR DESCRIPTION
This release removed `digest::crypto_common` in favor of `digest::common` which necessitated changes in the following crates, whose versions have been bumped so we can cut a new release with these changes:

- `ascon-hash256` v0.5.0-rc.2
- `bash-hash` v0.1.0-rc.1
- `belt-hash` v0.2.0-rc.5
- `blake2` v0.11.0-rc.5
- `fsb` v0.2.0-rc.2
- `gost94` v0.11.0-rc.2
- `groestl` v0.11.0-rc.2
- `kupyna` v0.1.0-pre.0
- `md2` v0.11.0-rc.2
- `md4` v0.11.0-rc.2
- `md-5` v0.11.0-rc.5
- `ripemd` v0.2.0-rc.5
- `sha1` v0.11.0-rc.5
- `sha2` v0.11.0-rc.5
- `sha3` v0.11.0-rc.7
- `shabal` v0.5.0-rc.2
- `skein` v0.2.0-rc.2
- `sm3` v0.5.0-rc.5
- `streebog` v0.11.0-rc.5
- `tiger` v0.3.0-rc.2
- `whirlpool` v0.11.0-rc.5