### PR TITLE
fix(bash-hash): use bit size in AlgorithmName output

### DIFF
--- a/bash-hash/src/block_api.rs
+++ b/bash-hash/src/block_api.rs
@@ -113,7 +113,7 @@ impl<OS: OutputSize> Reset for BashHashCore<OS> {
 
 impl<OS: OutputSize> AlgorithmName for BashHashCore<OS> {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "BashHash{}", OS::USIZE)
+        write!(f, "BashHash{}", OS::USIZE * 8)
     }
 }
 

--- a/bash-hash/tests/mod.rs
+++ b/bash-hash/tests/mod.rs
@@ -46,13 +46,3 @@ test_bash_rand!(
 digest::hash_serialization_test!(bash256_serialization, BashHash256);
 digest::hash_serialization_test!(bash384_serialization, BashHash384);
 digest::hash_serialization_test!(bash512_serialization, BashHash512);
-
-#[test]
-fn algorithm_name() {
-    let s = format!("{:?}", BashHash256::new());
-    assert!(s.contains("BashHash256"), "expected BashHash256, got: {s}");
-    let s = format!("{:?}", BashHash384::new());
-    assert!(s.contains("BashHash384"), "expected BashHash384, got: {s}");
-    let s = format!("{:?}", BashHash512::new());
-    assert!(s.contains("BashHash512"), "expected BashHash512, got: {s}");
-}

--- a/bash-hash/tests/mod.rs
+++ b/bash-hash/tests/mod.rs
@@ -46,3 +46,13 @@ test_bash_rand!(
 digest::hash_serialization_test!(bash256_serialization, BashHash256);
 digest::hash_serialization_test!(bash384_serialization, BashHash384);
 digest::hash_serialization_test!(bash512_serialization, BashHash512);
+
+#[test]
+fn algorithm_name() {
+    let s = format!("{:?}", BashHash256::new());
+    assert!(s.contains("BashHash256"), "expected BashHash256, got: {s}");
+    let s = format!("{:?}", BashHash384::new());
+    assert!(s.contains("BashHash384"), "expected BashHash384, got: {s}");
+    let s = format!("{:?}", BashHash512::new());
+    assert!(s.contains("BashHash512"), "expected BashHash512, got: {s}");
+}


### PR DESCRIPTION
`AlgorithmName::write_alg_name` used `OS::USIZE` which is the output size in bytes (32, 48, 64), producing names like "BashHash32" instead of "BashHash256". This is inconsistent with the official naming from STB 34.101.77 (reference impl uses bash256/bash384/bash512), the public type aliases (BashHash256, BashHash384, BashHash512), and the RustCrypto convention of using bit sizes in algorithm names.

Fixed by changing `OS::USIZE` to `OS::USIZE * 8`. Added test that verifies the Debug output contains correct bit-sized names.