### PR TITLE
Remove README examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,18 +16,11 @@ name = "ascon-hash256"
 version = "0.5.0-rc.2"
 dependencies = [
  "ascon",
- "base16ct",
  "digest",
  "hex",
  "hex-literal",
  "spectral",
 ]
-
-[[package]]
-name = "base16ct"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "bash-f"
@@ -39,7 +32,6 @@ checksum = "bfed5cd32720841afa8cd58c89a317e9efb0c8083e1b349dae4098f022620353"
 name = "bash-hash"
 version = "0.1.0-rc.1"
 dependencies = [
- "base16ct",
  "bash-f",
  "digest",
  "hex-literal",
@@ -55,7 +47,6 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 name = "belt-hash"
 version = "0.2.0-rc.5"
 dependencies = [
- "base16ct",
  "belt-block",
  "digest",
  "hex-literal",
@@ -65,7 +56,6 @@ dependencies = [
 name = "blake2"
 version = "0.11.0-rc.5"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -158,7 +148,6 @@ dependencies = [
 name = "fsb"
 version = "0.2.0-rc.2"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
  "whirlpool",
@@ -168,7 +157,6 @@ dependencies = [
 name = "gost94"
 version = "0.11.0-rc.2"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -177,7 +165,6 @@ dependencies = [
 name = "groestl"
 version = "0.11.0-rc.2"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -207,7 +194,6 @@ dependencies = [
 name = "jh"
 version = "0.2.0-rc.1"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
  "ppv-lite86",
@@ -235,7 +221,6 @@ dependencies = [
 name = "kupyna"
 version = "0.1.0-pre.0"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -250,7 +235,6 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 name = "md-5"
 version = "0.11.0-rc.5"
 dependencies = [
- "base16ct",
  "cfg-if",
  "digest",
  "hex-literal",
@@ -260,7 +244,6 @@ dependencies = [
 name = "md2"
 version = "0.11.0-rc.2"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -269,7 +252,6 @@ dependencies = [
 name = "md4"
 version = "0.11.0-rc.2"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -305,7 +287,6 @@ dependencies = [
 name = "ripemd"
 version = "0.2.0-rc.5"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -314,7 +295,6 @@ dependencies = [
 name = "sha1"
 version = "0.11.0-rc.5"
 dependencies = [
- "base16ct",
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest",
@@ -325,7 +305,6 @@ dependencies = [
 name = "sha1-checked"
 version = "0.11.0-rc.0"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
  "sha1",
@@ -336,7 +315,6 @@ dependencies = [
 name = "sha2"
 version = "0.11.0-rc.5"
 dependencies = [
- "base16ct",
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest",
@@ -347,7 +325,6 @@ dependencies = [
 name = "sha3"
 version = "0.11.0-rc.7"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
  "keccak",
@@ -357,7 +334,6 @@ dependencies = [
 name = "shabal"
 version = "0.5.0-rc.2"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -366,7 +342,6 @@ dependencies = [
 name = "skein"
 version = "0.2.0-rc.2"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
  "threefish",
@@ -376,7 +351,6 @@ dependencies = [
 name = "sm3"
 version = "0.5.0-rc.5"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -391,7 +365,6 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 name = "streebog"
 version = "0.11.0-rc.5"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -420,7 +393,6 @@ dependencies = [
 name = "tiger"
 version = "0.3.0-rc.2"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]
@@ -441,7 +413,6 @@ checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 name = "whirlpool"
 version = "0.11.0-rc.5"
 dependencies = [
- "base16ct",
  "digest",
  "hex-literal",
 ]

--- a/ascon-hash256/Cargo.toml
+++ b/ascon-hash256/Cargo.toml
@@ -23,7 +23,6 @@ ascon = { version = "0.5.0-rc.0", default-features = false }
 spectral = { version = "0.6", default-features = false }
 hex = "0.4"
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc"]

--- a/ascon-hash256/README.md
+++ b/ascon-hash256/README.md
@@ -27,10 +27,6 @@ hasher.update(b"some bytes");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("e909c2f6da9cb3028423265c8f23fc2d26bfc0f3db704683ef16b787a945ed68"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "e909c2f6da9cb3028423265c8f23fc2d26bfc0f3db704683ef16b787a945ed68");
 ```
 
 XOF hashing:

--- a/ascon-hash256/README.md
+++ b/ascon-hash256/README.md
@@ -46,7 +46,7 @@ reader.read(&mut dst);
 assert_eq!(dst, hex!("8c7dd114a0"));
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -79,4 +79,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [1]: https://doi.org/10.6028/NIST.SP.800-232.ipd
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/bash-hash/Cargo.toml
+++ b/bash-hash/Cargo.toml
@@ -19,7 +19,6 @@ bash-f = "0.1"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/bash-hash/README.md
+++ b/bash-hash/README.md
@@ -25,7 +25,7 @@ let hex_hash = base16ct::upper::encode_string(&hash);
 assert_eq!(hex_hash, "2FC08EEC942378C0F8A6E5F1890D907B706BE393B0386E20A73D4D17A46BBD10");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -58,4 +58,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [STB 34.101.77-2020]: http://apmi.bsu.by/assets/files/std/bash-spec241.pdf
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/bash-hash/README.md
+++ b/bash-hash/README.md
@@ -19,10 +19,6 @@ hasher.update(b"hello world");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("2FC08EEC942378C0F8A6E5F1890D907B706BE393B0386E20A73D4D17A46BBD10"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::upper::encode_string(&hash);
-assert_eq!(hex_hash, "2FC08EEC942378C0F8A6E5F1890D907B706BE393B0386E20A73D4D17A46BBD10");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -19,7 +19,6 @@ belt-block = { version = "0.1.1", default-features = false }
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/belt-hash/README.md
+++ b/belt-hash/README.md
@@ -19,10 +19,6 @@ hasher.update(b"hello world");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("afb175816416fbadad4629ecbd78e1887789881f2d2e5b80c22a746b7ac7ba88"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "afb175816416fbadad4629ecbd78e1887789881f2d2e5b80c22a746b7ac7ba88");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/belt-hash/README.md
+++ b/belt-hash/README.md
@@ -25,7 +25,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "afb175816416fbadad4629ecbd78e1887789881f2d2e5b80c22a746b7ac7ba88");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -59,4 +59,4 @@ dual licensed as above, without any additional terms or conditions.
 
 [BelT]: https://ru.wikipedia.org/wiki/BelT
 [STB 34.101.31-2020]: http://apmi.bsu.by/assets/files/std/belt-spec371.pdf
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/blake2/Cargo.toml
+++ b/blake2/Cargo.toml
@@ -18,7 +18,6 @@ digest = { version = "0.11", features = ["mac"] }
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc"]

--- a/blake2/README.md
+++ b/blake2/README.md
@@ -41,7 +41,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "9aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ### Variable output size
 
@@ -90,4 +90,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [BLAKE2]: https://blake2.net/
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/blake2/README.md
+++ b/blake2/README.md
@@ -35,10 +35,6 @@ let mut hasher = Blake2s256::new();
 hasher.update(b"hello world");
 let hash = hasher.finalize();
 assert_eq!(hash, hex!("9aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "9aec6806794561107e594b1f6a8a6b0c92a0cba9acf5e5e93cca06f781813b0b");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -19,7 +19,6 @@ whirlpool = { version = "0.11.0-rc.3", default-features = false }
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc"]

--- a/fsb/README.md
+++ b/fsb/README.md
@@ -37,7 +37,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "0f036dc3761aed2cba9de586a85976eedde6fa8f115c0190763decc02f28edbc");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -70,4 +70,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [FSB]: https://www.paris.inria.fr/secret/CBCrypto/index.php?pg=fsb
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/fsb/README.md
+++ b/fsb/README.md
@@ -31,10 +31,6 @@ hasher.update(b"hello");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("0f036dc3761aed2cba9de586a85976eedde6fa8f115c0190763decc02f28edbc"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "0f036dc3761aed2cba9de586a85976eedde6fa8f115c0190763decc02f28edbc");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/gost94/README.md
+++ b/gost94/README.md
@@ -20,10 +20,6 @@ hasher.update("The quick brown fox jumps over the lazy dog");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("9004294a361a508c586fe53d1f1b02746765e71b765472786e4770d565830a76"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "9004294a361a508c586fe53d1f1b02746765e71b765472786e4770d565830a76");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/gost94/README.md
+++ b/gost94/README.md
@@ -26,12 +26,15 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "9004294a361a508c586fe53d1f1b02746765e71b765472786e4770d565830a76");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## Associated OIDs.
+
 There can be a confusion regarding OIDs associated with declared types.
-According to the [RFC 4357], the OIDs 1.2.643.2.2.30.1 and 1.2.643.2.2.30.0 are used to identify the hash function parameter sets (CryptoPro vs Test ones).
-According to [RFC 4490] the OID 1.2.643.2.2.9 identifies the GOST 34.311-95 (former GOST R 34.11-94) function, but then it continues that this function MUST be used only with the CryptoPro parameter set.
+According to the [RFC 4357], the OIDs 1.2.643.2.2.30.1 and 1.2.643.2.2.30.0 are used to identify
+the hash function parameter sets (CryptoPro vs Test ones). According to [RFC 4490]
+OID 1.2.643.2.2.9 identifies the GOST 34.311-95 (former GOST R 34.11-94) function,
+but then it continues that this function MUST be used only with the CryptoPro parameter set.
 
 ## License
 
@@ -66,4 +69,4 @@ dual licensed as above, without any additional terms or conditions.
 [GOST R 34.11-94]: https://en.wikipedia.org/wiki/GOST_(hash_function)
 [RFC 4357]: https://www.rfc-editor.org/rfc/rfc4357
 [RFC 4490]: https://www.rfc-editor.org/rfc/rfc4490
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc"]

--- a/groestl/README.md
+++ b/groestl/README.md
@@ -20,10 +20,6 @@ hasher.update(b"my message");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("dc0283ca481efa76b7c19dd5a0b763dff0e867451bd9488a9c59f6c8b8047a86"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "dc0283ca481efa76b7c19dd5a0b763dff0e867451bd9488a9c59f6c8b8047a86");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/groestl/README.md
+++ b/groestl/README.md
@@ -26,7 +26,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "dc0283ca481efa76b7c19dd5a0b763dff0e867451bd9488a9c59f6c8b8047a86");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -59,4 +59,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [Grøstl]: https://en.wikipedia.org/wiki/Grøstl
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -19,7 +19,6 @@ simd = { package = "ppv-lite86", version = "0.2.6" }
 
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc"]

--- a/jh/README.md
+++ b/jh/README.md
@@ -27,10 +27,6 @@ hasher.update(b"hello");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("94fd3f4c564957c6754265676bf8b244c707d3ffb294e18af1f2e4f9b8306089"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "94fd3f4c564957c6754265676bf8b244c707d3ffb294e18af1f2e4f9b8306089");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/jh/README.md
+++ b/jh/README.md
@@ -33,7 +33,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "94fd3f4c564957c6754265676bf8b244c707d3ffb294e18af1f2e4f9b8306089");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -66,4 +66,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [JH]: https://en.wikipedia.org/wiki/JH_(hash_function)
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/kupyna/Cargo.toml
+++ b/kupyna/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc"]

--- a/kupyna/README.md
+++ b/kupyna/README.md
@@ -26,7 +26,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "538e2e238142df05e954702aa75d6942cebe30d44bd514df365d13bdcb6b1458");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -59,4 +59,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [Kupyna]: https://eprint.iacr.org/2015/885.pdf
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/kupyna/README.md
+++ b/kupyna/README.md
@@ -20,10 +20,6 @@ hasher.update(b"my message");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("538e2e238142df05e954702aa75d6942cebe30d44bd514df365d13bdcb6b1458"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "538e2e238142df05e954702aa75d6942cebe30d44bd514df365d13bdcb6b1458");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/md2/README.md
+++ b/md2/README.md
@@ -20,10 +20,6 @@ hasher.update(b"hello world");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("d9cce882ee690a5c1ce70beff3a78c77"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "d9cce882ee690a5c1ce70beff3a78c77");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/md2/README.md
+++ b/md2/README.md
@@ -26,7 +26,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "d9cce882ee690a5c1ce70beff3a78c77");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -59,4 +59,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [MD2]: https://en.wikipedia.org/wiki/MD2_(hash_function)
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/md4/README.md
+++ b/md4/README.md
@@ -31,7 +31,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "aa010fbc1d14c795d86ef98c95479d17");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -64,4 +64,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [MD4]: https://en.wikipedia.org/wiki/MD4
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/md4/README.md
+++ b/md4/README.md
@@ -25,10 +25,6 @@ hasher.update(b"hello world");
 // which in this case is equivalent to [u8; 16]
 let hash = hasher.finalize();
 assert_eq!(hash, hex!("aa010fbc1d14c795d86ef98c95479d17"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "aa010fbc1d14c795d86ef98c95479d17");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -22,7 +22,6 @@ cfg-if = "1"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/md5/README.md
+++ b/md5/README.md
@@ -39,7 +39,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "5eb63bbbe01eeed093cb22bb8f5acdc3");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -72,7 +72,7 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [MD5]: https://en.wikipedia.org/wiki/MD5
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest
 [1]: https://www.kb.cert.org/vuls/id/836068
 [2]: https://dl.acm.org/citation.cfm?id=1724151
 [RFC 6151]: https://tools.ietf.org/html/rfc6151

--- a/md5/README.md
+++ b/md5/README.md
@@ -33,10 +33,6 @@ hasher.update(b"hello world");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("5eb63bbbe01eeed093cb22bb8f5acdc3"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "5eb63bbbe01eeed093cb22bb8f5acdc3");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/ripemd/README.md
+++ b/ripemd/README.md
@@ -27,10 +27,6 @@ let hash160 = hasher.finalize();
 
 assert_eq!(hash160, hex!("7f772647d88750add82d8e1a7a3e5c0902a346a3"));
 
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash160 = base16ct::lower::encode_string(&hash160);
-assert_eq!(hex_hash160, "7f772647d88750add82d8e1a7a3e5c0902a346a3");
-
 // Same example for RIPEMD-320
 let mut hasher = Ripemd320::new();
 hasher.update(b"Hello world!");

--- a/ripemd/README.md
+++ b/ripemd/README.md
@@ -42,7 +42,7 @@ assert_eq!(hash320, hex!(
 ));
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -75,4 +75,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [RIPEMD]: https://en.wikipedia.org/wiki/RIPEMD
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/sha1-checked/Cargo.toml
+++ b/sha1-checked/Cargo.toml
@@ -25,7 +25,6 @@ zeroize = { version = "1.8", default-features = false, optional = true }
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/sha1-checked/README.md
+++ b/sha1-checked/README.md
@@ -52,7 +52,7 @@ assert_eq!(result.hash().as_ref(), hex!("2aae6c35c94fcfb415dbe95f408b9ce91ee846e
 assert!(!result.has_collision());
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -86,6 +86,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [SHA-1]: https://en.wikipedia.org/wiki/SHA-1
 [1]: https://sha-mbles.github.io/
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest
 [algorithm]: https://github.com/cr-marcstevens/sha1collisiondetection
 [paper]: https://marc-stevens.nl/research/papers/C13-S.pdf

--- a/sha1-checked/README.md
+++ b/sha1-checked/README.md
@@ -32,10 +32,6 @@ use sha1_checked::Sha1;
 let result = Sha1::try_digest(b"hello world");
 assert_eq!(result.hash().as_ref(), hex!("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"));
 assert!(!result.has_collision());
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(result.hash().as_ref());
-assert_eq!(hex_hash, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
 ```
 
 ### Incremental API

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -22,7 +22,6 @@ cpufeatures = "0.3"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/sha1/README.md
+++ b/sha1/README.md
@@ -49,7 +49,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -83,5 +83,5 @@ dual licensed as above, without any additional terms or conditions.
 
 [SHA-1]: https://en.wikipedia.org/wiki/SHA-1
 [1]: https://sha-mbles.github.io/
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest
 [sha1-checked]: https://crates.io/crates/sha1-checked

--- a/sha1/README.md
+++ b/sha1/README.md
@@ -43,10 +43,6 @@ hasher.update(b"hello world");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/sha2/Cargo.toml
+++ b/sha2/Cargo.toml
@@ -25,7 +25,6 @@ cpufeatures = "0.3"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/sha2/README.md
+++ b/sha2/README.md
@@ -28,10 +28,6 @@ use hex_literal::hex;
 
 let hash = Sha256::digest(b"hello world");
 assert_eq!(hash, hex!("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
 ```
 
 ### Incremental API

--- a/sha2/README.md
+++ b/sha2/README.md
@@ -57,7 +57,7 @@ assert_eq!(hash512, hex!(
 ));
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## Backends
 
@@ -113,4 +113,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [SHA-2]: https://en.wikipedia.org/wiki/SHA-2
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -23,7 +23,6 @@ keccak = "0.2.0-rc.1"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/sha3/README.md
+++ b/sha3/README.md
@@ -57,7 +57,7 @@ reader.read(&mut buf);
 assert_eq!(buf, hex!("5881092dd818bf5cf8a3"));
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -89,6 +89,6 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (general links)
 
-[examples section]: https://github.com/RustCrypto/hashes#Examples
 [SHA-3]: https://en.wikipedia.org/wiki/SHA-3
 [SHA-3 Derived Functions]: https://csrc.nist.gov/pubs/sp/800/185/final
+[`digest`]: https://docs.rs/digest

--- a/sha3/README.md
+++ b/sha3/README.md
@@ -34,10 +34,6 @@ hasher.update(b"abc");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532");
 ```
 
 SHAKE functions have an extendable output, so finalization method returns

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc"]

--- a/shabal/README.md
+++ b/shabal/README.md
@@ -22,10 +22,6 @@ hasher.update(b"helloworld");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("d945dee21ffca23ac232763aa9cac6c15805f144db9d6c97395437e01c8595a8"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "d945dee21ffca23ac232763aa9cac6c15805f144db9d6c97395437e01c8595a8");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/shabal/README.md
+++ b/shabal/README.md
@@ -28,7 +28,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "d945dee21ffca23ac232763aa9cac6c15805f144db9d6c97395437e01c8595a8");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -61,4 +61,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [Shabal]: https://www.cs.rit.edu/~ark/20090927/Round2Candidates/Shabal.pdf
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -19,7 +19,6 @@ threefish = { version = "0.6.0-rc.1", default-features = false }
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc"]

--- a/skein/README.md
+++ b/skein/README.md
@@ -32,7 +32,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "b3250457e05d3060b1a4bbc1428bc75a3f525ca389aeab96cfa34638d96e492a");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -65,4 +65,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [Skein]: https://schneier.com/academic/skein
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/skein/README.md
+++ b/skein/README.md
@@ -26,10 +26,6 @@ hasher.update(b"jumps over the lazy dog");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("b3250457e05d3060b1a4bbc1428bc75a3f525ca389aeab96cfa34638d96e492a"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "b3250457e05d3060b1a4bbc1428bc75a3f525ca389aeab96cfa34638d96e492a");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/sm3/README.md
+++ b/sm3/README.md
@@ -21,10 +21,6 @@ hasher.update(b"hello world");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("44f0061e69fa6fdfc290c494654a05dc0c053da7e5c52b84ef93a9d67d3fff88"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "44f0061e69fa6fdfc290c494654a05dc0c053da7e5c52b84ef93a9d67d3fff88");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/sm3/README.md
+++ b/sm3/README.md
@@ -27,7 +27,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "44f0061e69fa6fdfc290c494654a05dc0c053da7e5c52b84ef93a9d67d3fff88");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -60,4 +60,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [SM3]: https://en.wikipedia.org/wiki/SM3_(hash_function)
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc", "oid"]

--- a/streebog/README.md
+++ b/streebog/README.md
@@ -36,7 +36,7 @@ assert_eq!(hash512, hex!(
 ));
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -69,4 +69,4 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (general links)
 
 [Streebog]: https://en.wikipedia.org/wiki/Streebog
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/streebog/README.md
+++ b/streebog/README.md
@@ -21,10 +21,6 @@ let hash256 = hasher.finalize();
 
 assert_eq!(hash256, hex!("3e7dea7f2384b6c5a3d0e24aaa29c05e89ddd762145030ec22c71a6db8b2c1f4"));
 
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash256 = base16ct::lower::encode_string(&hash256);
-assert_eq!(hex_hash256, "3e7dea7f2384b6c5a3d0e24aaa29c05e89ddd762145030ec22c71a6db8b2c1f4");
-
 // Same example for Streebog-512
 let mut hasher = Streebog512::new();
 hasher.update("The quick brown fox jumps over the lazy dog.");

--- a/tiger/Cargo.toml
+++ b/tiger/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc"]

--- a/tiger/README.md
+++ b/tiger/README.md
@@ -28,7 +28,7 @@ let hex_hash = base16ct::lower::encode_string(&hash);
 assert_eq!(hex_hash, "4c8fbddae0b6f25832af45e7c62811bb64ec3e43691e9cc3");
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -60,4 +60,4 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, without 
 [//]: # (general links)
 
 [Tiger]: https://en.wikipedia.org/wiki/Tiger_(hash_function)
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/tiger/README.md
+++ b/tiger/README.md
@@ -22,10 +22,6 @@ hasher.update(b"hello world");
 let hash = hasher.finalize();
 
 assert_eq!(hash, hex!("4c8fbddae0b6f25832af45e7c62811bb64ec3e43691e9cc3"));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(hex_hash, "4c8fbddae0b6f25832af45e7c62811bb64ec3e43691e9cc3");
 ```
 
 See the [`digest`] crate docs for additional examples.

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.11"
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }
 hex-literal = "1"
-base16ct = { version = "1", features = ["alloc"] }
 
 [features]
 default = ["alloc"]

--- a/whirlpool/README.md
+++ b/whirlpool/README.md
@@ -44,7 +44,7 @@ assert_eq!(
 );
 ```
 
-Also, see the [examples section] in the RustCrypto/hashes readme.
+See the [`digest`] crate docs for additional examples.
 
 ## License
 
@@ -78,4 +78,4 @@ dual licensed as above, without any additional terms or conditions.
 
 [Whirlpool]: https://en.wikipedia.org/wiki/Whirlpool_(hash_function)
 [1]: https://web.archive.org/web/20171129084214/http://www.larc.usp.br/~pbarreto/WhirlpoolPage.html
-[examples section]: https://github.com/RustCrypto/hashes#Examples
+[`digest`]: https://docs.rs/digest

--- a/whirlpool/README.md
+++ b/whirlpool/README.md
@@ -34,14 +34,6 @@ assert_eq!(hash, hex!(
     "8eaccdc136903c458ea0b1376be2a5fc9dc5b8ce8892a3b4f43366e2610c206c"
     "a373816495e63db0fff2ff25f75aa7162f332c9f518c3036456502a8414d300a"
 ));
-
-// Hex-encode hash using https://docs.rs/base16ct
-let hex_hash = base16ct::lower::encode_string(&hash);
-assert_eq!(
-    hex_hash,
-    "8eaccdc136903c458ea0b1376be2a5fc9dc5b8ce8892a3b4f43366e2610c206c\
-     a373816495e63db0fff2ff25f75aa7162f332c9f518c3036456502a8414d300a",
-);
 ```
 
 See the [`digest`] crate docs for additional examples.


### PR DESCRIPTION
The examples now reside in the `digest`'s README/docs. This PR also updates references in the implementation crate READMEs and removes `base16ct` examples from them. I plan to add `base16ct` examples to `digest` in a later PR.