### PR TITLE
sha3: use `KeccakP1600` struct for state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,15 +96,6 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -211,10 +202,9 @@ dependencies = [
 [[package]]
 name = "keccak"
 version = "0.2.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a412fe37705d515cba9dbf1448291a717e187e2351df908cfc0137cbec3d480"
+source = "git+https://github.com/RustCrypto/sponges#38d10d219450dae3c2d4506f7b2ce13e6eb32f63"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -296,7 +286,7 @@ name = "sha1"
 version = "0.11.0-rc.5"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
  "hex-literal",
 ]
@@ -316,7 +306,7 @@ name = "sha2"
 version = "0.11.0-rc.5"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
  "hex-literal",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,5 @@ opt-level = 2
 sha1 = { path = "sha1" }
 sha3 = { path = "sha3" }
 whirlpool = { path = "whirlpool" }
+
+keccak = { git = "https://github.com/RustCrypto/sponges" }

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -29,7 +29,6 @@ default = ["alloc", "oid"]
 alloc = ["digest/alloc"]
 oid = ["digest/oid"] # Enable OID support.
 zeroize = ["digest/zeroize"]
-asm = ["keccak/asm"] # Enable ASM (currently ARMv8 only).
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Added in RustCrypto/sponges#107

This struct can automatially make use of CPU intrinsics when they are available. Currently only supports ARMv8's `FEAT_SHA3` intrinsics.