### PR TITLE
fix(blake2): remove redundant clone on Copy type

### DIFF
--- a/blake2/src/macros.rs
+++ b/blake2/src/macros.rs
@@ -85,7 +85,7 @@ macro_rules! blake2_impl {
                 ];
                 $name {
                     #[cfg(feature = "reset")]
-                    h0: h.clone(),
+                    h0: h,
                     h,
                     t: 0,
                 }


### PR DESCRIPTION
The `h` variable is `[$vec; 2]` where `$vec` (u32x4/u64x4) implements `Copy`. Calling `.clone()` on a `Copy` type is redundant since it's semantically equivalent to a simple copy. The same pattern is already used correctly in the `Reset` impl where `self.h0` is assigned directly without `.clone()`.