### PR TITLE
sha3 v0.11.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,8 +201,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0-rc.1"
-source = "git+https://github.com/RustCrypto/sponges#38d10d219450dae3c2d4506f7b2ce13e6eb32f63"
+version = "0.2.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882b69cb15b1f78b51342322a97ccd16f5123d1dc8a3da981a95244f488e8692"
 dependencies = [
  "cpufeatures",
 ]
@@ -313,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.7"
+version = "0.11.0-rc.8"
 dependencies = [
  "digest",
  "hex-literal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,3 @@ opt-level = 2
 sha1 = { path = "sha1" }
 sha3 = { path = "sha3" }
 whirlpool = { path = "whirlpool" }
-
-keccak = { git = "https://github.com/RustCrypto/sponges" }

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0-rc.7"
+version = "0.11.0-rc.8"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as
@@ -18,7 +18,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 digest = "0.11"
-keccak = "0.2.0-rc.1"
+keccak = "0.2.0-rc.2"
 
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }


### PR DESCRIPTION
Includes `digest` v0.11.1 compatibility.

Also bumps `keccak` to v0.2.0-rc.2.