### PR TITLE
sha3 v0.11.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0-rc.8"
+version = "0.11.0-rc.9"
 dependencies = [
  "digest",
  "hex-literal",

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0-rc.8"
+version = "0.11.0-rc.9"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as


### PR DESCRIPTION
Compatible with `keccak` v0.2.0.

Closes #795 