### PR TITLE
sha3: bump `keccak` to v0.2

### DIFF
--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 digest = "0.11"
-keccak = "0.2.0-rc.2"
+keccak = "0.2"
 
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }


### PR DESCRIPTION
This was missed in #796/#799.

Release PR: RustCrypto/sponges#117