### PR TITLE
sha1: refactor backends selection

### DIFF
--- a/.github/workflows/sha1.yml
+++ b/.github/workflows/sha1.yml
@@ -87,6 +87,9 @@ jobs:
       - uses: RustCrypto/actions/cargo-hack-install@master
       - run: ${{ matrix.deps }}
       - run: cargo hack test --feature-powerset
+      - run: cargo test --all-features
+        env:
+          RUSTFLAGS: -Dwarnings --cfg sha1_backend="soft"
 
   # macOS tests
   macos:
@@ -108,6 +111,9 @@ jobs:
       - run: cargo test --no-default-features
       - run: cargo test
       - run: cargo test --all-features
+      - run: cargo test --all-features
+        env:
+          RUSTFLAGS: -Dwarnings --cfg sha1_backend="aarch64-sha2"
 
   # Windows tests
   windows:

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.11.0 (UNRELEASED)
 ### Added
 - `alloc` crate feature ([#678])
+- `sha1_backend` configuration flag ([#808])
 
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#652])
@@ -19,11 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `asm`, `loongarch64_asm`, and `compress` crate features [#542]
 - `std` crate feature ([#678])
+- `force-soft` crate feature ([#808])
 
 [#542]: https://github.com/RustCrypto/hashes/pull/542
 [#652]: https://github.com/RustCrypto/hashes/pull/652
 [#678]: https://github.com/RustCrypto/hashes/pull/678
 [#716]: https://github.com/RustCrypto/hashes/pull/716
+[#808]: https://github.com/RustCrypto/hashes/pull/808
 
 ## 0.10.6 (2023-09-21)
 ### Added

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -28,7 +28,6 @@ default = ["alloc", "oid"]
 alloc = ["digest/alloc"]
 oid = ["digest/oid"] # Enable OID support
 zeroize = ["digest/zeroize"]
-force-soft = [] # Force software implementation
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(sha1_backend, values("aarch64-sha2", "x86-sha", "soft"))'] }

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -30,5 +30,8 @@ oid = ["digest/oid"] # Enable OID support
 zeroize = ["digest/zeroize"]
 force-soft = [] # Force software implementation
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(sha1_backend, values("aarch64-sha2", "x86-sha", "soft"))'] }
+
 [package.metadata.docs.rs]
 all-features = true

--- a/sha1/src/block_api.rs
+++ b/sha1/src/block_api.rs
@@ -13,15 +13,17 @@ use digest::{
 #[cfg(feature = "zeroize")]
 use digest::zeroize::{Zeroize, ZeroizeOnDrop};
 
-pub use crate::compress::compress;
+use crate::consts::{H0, State};
 
-const STATE_LEN: usize = 5;
-const H0: [u32; STATE_LEN] = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0];
+/// SHA-1 compression function
+pub fn compress(state: &mut State, blocks: &[[u8; 64]]) {
+    crate::compress::compress(state, blocks);
+}
 
 /// Core SHA-1 hasher state.
 #[derive(Clone)]
 pub struct Sha1Core {
-    h: [u32; STATE_LEN],
+    h: State,
     block_len: u64,
 }
 
@@ -123,7 +125,7 @@ impl SerializableState for Sha1Core {
     ) -> Result<Self, DeserializeStateError> {
         let (serialized_h, serialized_block_len) = serialized_state.split::<U20>();
 
-        let mut h = [0; STATE_LEN];
+        let mut h = State::default();
         for (val, chunk) in h.iter_mut().zip(serialized_h.chunks_exact(4)) {
             *val = u32::from_le_bytes(chunk.try_into().unwrap());
         }

--- a/sha1/src/compress.rs
+++ b/sha1/src/compress.rs
@@ -1,27 +1,64 @@
-const K: [u32; 4] = [0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6];
-
 cfg_if::cfg_if! {
-    if #[cfg(feature = "force-soft")] {
+    if #[cfg(sha1_backend = "soft")] {
         mod soft;
-        use soft::compress as compress_inner;
-    } else if #[cfg(all(target_arch = "aarch64"))] {
-        mod soft;
-        mod aarch64;
-        use aarch64::compress as compress_inner;
+        pub(crate) use soft::compress;
+    } else if #[cfg(sha1_backend = "aarch64-sha2")] {
+        mod aarch64_sha2;
+
+        #[cfg(not(target_feature = "sha2"))]
+        compile_error!("aarch64-sha2 backend requires sha2 target feature");
+
+        pub(crate) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+            // SAFETY: we checked above that the required target features are enabled
+            unsafe { aarch64_sha2::compress(state, blocks) }
+        }
+    } else if #[cfg(sha1_backend = "x86-sha")] {
+        mod x86_sha;
+
+        #[cfg(not(all(
+            target_feature = "sha",
+            target_feature = "sse2",
+            target_feature = "ssse3",
+            target_feature = "sse4.1",
+        )))]
+        compile_error!("x86-sha backend requires sha, sse2, ssse3, sse4.1 target features");
+
+        pub(crate) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+            // SAFETY: we checked above that the required target features are enabled
+            unsafe { x86_sha::compress(state, blocks) }
+        }
     } else if #[cfg(target_arch = "loongarch64")] {
         mod loongarch64_asm;
-        use loongarch64_asm::compress as compress_inner;
-    } else if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-        mod soft;
-        mod x86;
-        use x86::compress as compress_inner;
+        pub(crate) use loongarch64_asm::compress;
     } else {
         mod soft;
-        use soft::compress as compress_inner;
-    }
-}
 
-/// SHA-1 compression function
-pub fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
-    compress_inner(state, blocks);
+        cfg_if::cfg_if! {
+            if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+                mod x86_sha;
+                cpufeatures::new!(shani_cpuid, "sha", "sse2", "ssse3", "sse4.1");
+            } else if #[cfg(target_arch = "aarch64")] {
+                mod aarch64_sha2;
+                cpufeatures::new!(sha2_hwcap, "sha2");
+            }
+        }
+
+        pub(crate) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+            cfg_if::cfg_if! {
+                if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+                    if shani_cpuid::get() {
+                        // SAFETY: we checked that required target features are available
+                        return unsafe { x86_sha::compress(state, blocks) };
+                    }
+                } else if #[cfg(target_arch = "aarch64")] {
+                    if sha2_hwcap::get() {
+                        // SAFETY: we checked that `sha2` target feature is available
+                        return unsafe { aarch64_sha2::compress(state, blocks) };
+                    }
+                }
+            }
+
+            soft::compress(state, blocks);
+        }
+    }
 }

--- a/sha1/src/compress/aarch64_sha2.rs
+++ b/sha1/src/compress/aarch64_sha2.rs
@@ -1,18 +1,14 @@
 //! SHA-1 `aarch64` backend.
 
-use super::K;
+use crate::consts::K;
 
-// Per rustc target feature docs for `aarch64-unknown-linux-gnu` and
-// `aarch64-apple-darwin` platforms, the `sha2` target feature enables
-// SHA-1 as well:
-//
-// > Enable SHA1 and SHA256 support.
-cpufeatures::new!(sha1_hwcap, "sha2");
+#[cfg(not(target_arch = "aarch64"))]
+compile_error!("aarch64-sha2 backend can be used only aarch64 target arches");
 
 // note that `sha2` implicitly enables `neon`
 #[target_feature(enable = "sha2")]
 #[allow(unsafe_op_in_unsafe_fn)]
-unsafe fn compress_sha1_neon(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+pub(crate) unsafe fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
     use core::arch::aarch64::*;
 
     let mut abcd = vld1q_u32(state.as_ptr());
@@ -171,15 +167,4 @@ unsafe fn compress_sha1_neon(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
     // Save state
     vst1q_u32(state.as_mut_ptr(), abcd);
     state[4] = e0;
-}
-
-pub(super) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
-    // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725 after stabilization
-    if sha1_hwcap::get() {
-        unsafe {
-            compress_sha1_neon(state, blocks);
-        }
-    } else {
-        super::soft::compress(state, blocks);
-    }
 }

--- a/sha1/src/compress/loongarch64_asm.rs
+++ b/sha1/src/compress/loongarch64_asm.rs
@@ -1,7 +1,10 @@
 //! LoongArch64 assembly backend
 
-use super::K;
+use crate::consts::K;
 use core::arch::asm;
+
+#[cfg(not(target_arch = "loongarch64"))]
+compile_error!("loongarch-asm backend can be used only on loongarch64 target arches");
 
 macro_rules! c {
     ($($l:expr)*) => {

--- a/sha1/src/compress/loongarch64_asm.rs
+++ b/sha1/src/compress/loongarch64_asm.rs
@@ -104,7 +104,7 @@ macro_rules! roundtail {
     };
 }
 
-pub(super) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+pub(crate) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
     if blocks.is_empty() {
         return;
     }

--- a/sha1/src/compress/soft.rs
+++ b/sha1/src/compress/soft.rs
@@ -249,7 +249,7 @@ fn read_block(block: &[u8; 64]) -> [u32; 16] {
     })
 }
 
-pub(super) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+pub(crate) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
     for block in blocks.iter().map(read_block) {
         digest_block(state, block);
     }

--- a/sha1/src/compress/soft.rs
+++ b/sha1/src/compress/soft.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::many_single_char_names)]
-use super::K;
+use crate::consts::K;
 
 #[inline(always)]
 fn add(a: [u32; 4], b: [u32; 4]) -> [u32; 4] {
@@ -193,7 +193,7 @@ macro_rules! schedule_rounds4 {
 }
 
 #[inline(always)]
-fn sha1_digest_block_u32(state: &mut [u32; 5], block: &[u32; 16]) {
+fn digest_block(state: &mut [u32; 5], block: [u32; 16]) {
     let mut w0 = [block[0], block[1], block[2], block[3]];
     let mut w1 = [block[4], block[5], block[6], block[7]];
     let mut w2 = [block[8], block[9], block[10], block[11]];
@@ -242,16 +242,15 @@ fn sha1_digest_block_u32(state: &mut [u32; 5], block: &[u32; 16]) {
     state[4] = state[4].wrapping_add(e);
 }
 
+fn read_block(block: &[u8; 64]) -> [u32; 16] {
+    core::array::from_fn(|i| {
+        let chunk = &block[4 * i..][..4];
+        u32::from_be_bytes(chunk.try_into().unwrap())
+    })
+}
+
 pub(super) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
-    let mut block_u32 = [0u32; 16];
-    // since LLVM can't properly use aliasing yet it will make
-    // unnecessary state stores without this copy
-    let mut state_cpy = *state;
-    for block in blocks.iter() {
-        for (o, chunk) in block_u32.iter_mut().zip(block.chunks_exact(4)) {
-            *o = u32::from_be_bytes(chunk.try_into().unwrap());
-        }
-        sha1_digest_block_u32(&mut state_cpy, &block_u32);
+    for block in blocks.iter().map(read_block) {
+        digest_block(state, block);
     }
-    *state = state_cpy;
 }

--- a/sha1/src/compress/x86_sha.rs
+++ b/sha1/src/compress/x86_sha.rs
@@ -33,7 +33,7 @@ macro_rules! schedule_rounds4 {
 
 #[target_feature(enable = "sha,sse2,ssse3,sse4.1")]
 #[allow(unsafe_op_in_unsafe_fn)]
-pub(super) unsafe fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+pub(crate) unsafe fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
     #[allow(non_snake_case)]
     let MASK: __m128i = _mm_set_epi64x(0x0001_0203_0405_0607, 0x0809_0A0B_0C0D_0E0F);
 

--- a/sha1/src/compress/x86_sha.rs
+++ b/sha1/src/compress/x86_sha.rs
@@ -1,6 +1,7 @@
 //! SHA-1 `x86`/`x86_64` backend
 
-#![cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+compile_error!("x86-sha backend can be used only on x86 and x86_64 target arches");
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
@@ -32,7 +33,7 @@ macro_rules! schedule_rounds4 {
 
 #[target_feature(enable = "sha,sse2,ssse3,sse4.1")]
 #[allow(unsafe_op_in_unsafe_fn)]
-unsafe fn digest_blocks(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
+pub(super) unsafe fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
     #[allow(non_snake_case)]
     let MASK: __m128i = _mm_set_epi64x(0x0001_0203_0405_0607, 0x0809_0A0B_0C0D_0E0F);
 
@@ -88,18 +89,4 @@ unsafe fn digest_blocks(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
     state_abcd = _mm_shuffle_epi32(state_abcd, 0b00011011);
     _mm_storeu_si128(state.as_mut_ptr().cast(), state_abcd);
     state[4] = _mm_extract_epi32(state_e, 3) as u32;
-}
-
-cpufeatures::new!(shani_cpuid, "sha", "sse2", "ssse3", "sse4.1");
-
-pub(super) fn compress(state: &mut [u32; 5], blocks: &[[u8; 64]]) {
-    // TODO: Replace with https://github.com/rust-lang/rfcs/pull/2725
-    // after stabilization
-    if shani_cpuid::get() {
-        unsafe {
-            digest_blocks(state, blocks);
-        }
-    } else {
-        super::soft::compress(state, blocks);
-    }
 }

--- a/sha1/src/consts.rs
+++ b/sha1/src/consts.rs
@@ -1,0 +1,7 @@
+pub(crate) const STATE_LEN: usize = 5;
+
+pub(crate) type State = [u32; STATE_LEN];
+
+pub(crate) const H0: State = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0];
+
+pub(crate) const K: [u32; 4] = [0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6];

--- a/sha1/src/lib.rs
+++ b/sha1/src/lib.rs
@@ -12,6 +12,7 @@ pub use digest::{self, Digest};
 /// Block-level types
 pub mod block_api;
 mod compress;
+mod consts;
 
 digest::buffer_fixed!(
     /// SHA-1 hasher.


### PR DESCRIPTION
Replaces the `force-soft` crate feature with `sha1_backend` flags.