### PR TITLE
Release sha1 v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -18,9 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation of the `SerializableState` trait ([#716])
 
 ### Removed
-- `asm`, `loongarch64_asm`, and `compress` crate features [#542]
-- `std` crate feature ([#678])
-- `force-soft` crate feature ([#808])
+- `asm`, `loongarch64_asm`, `force-soft`, `std`, and `compress` crate features
+  ([#542], [#678], [#808])
 
 [#542]: https://github.com/RustCrypto/hashes/pull/542
 [#652]: https://github.com/RustCrypto/hashes/pull/652

--- a/sha1/CHANGELOG.md
+++ b/sha1/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (UNRELEASED)
+## 0.11.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 - `sha1_backend` configuration flag ([#808])

--- a/sha1/Cargo.toml
+++ b/sha1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha1"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Added
- `alloc` crate feature ([#678])
- `sha1_backend` configuration flag ([#808])

### Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#652])
- Relax MSRV policy and allow MSRV bumps in patch releases
- Update to `digest` v0.11
- Replace type aliases with newtypes ([#678])
- Implementation of the `SerializableState` trait ([#716])

### Removed
- `asm`, `loongarch64_asm`, `force-soft`, `std`, and `compress` crate features ([#542], [#678], [#808])

[#542]: https://github.com/RustCrypto/hashes/pull/542
[#652]: https://github.com/RustCrypto/hashes/pull/652
[#678]: https://github.com/RustCrypto/hashes/pull/678
[#716]: https://github.com/RustCrypto/hashes/pull/716
[#808]: https://github.com/RustCrypto/hashes/pull/808