### PR TITLE
Cut new releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "bfed5cd32720841afa8cd58c89a317e9efb0c8083e1b349dae4098f022620353"
 
 [[package]]
 name = "bash-hash"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "bash-f",
  "digest",
@@ -45,7 +45,7 @@ checksum = "d9aa1eef3994e2ccd304a78fe3fea4a73e5792007f85f09b79bb82143ca5f82b"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0-rc.5"
+version = "0.2.0"
 dependencies = [
  "belt-block",
  "digest",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "fsb"
-version = "0.2.0-rc.2"
+version = "0.2.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "gost94"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "groestl"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "jh"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "kupyna"
-version = "0.1.0-pre.0"
+version = "0.1.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -225,7 +225,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "md-5"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 dependencies = [
  "cfg-if",
  "digest",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "md2"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "md4"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.2.0-rc.5"
+version = "0.2.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "shabal"
-version = "0.5.0-rc.2"
+version = "0.5.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "skein"
-version = "0.2.0-rc.2"
+version = "0.2.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "sm3"
-version = "0.5.0-rc.5"
+version = "0.5.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -355,7 +355,7 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 
 [[package]]
 name = "streebog"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "tiger"
-version = "0.3.0-rc.2"
+version = "0.3.0"
 dependencies = [
  "digest",
  "hex-literal",
@@ -403,7 +403,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "whirlpool"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/bash-hash/CHANGELOG.md
+++ b/bash-hash/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## 0.1.0 (UNRELEASED)
+## 0.1.0 (2023-03-27)
 - Initial release ([#745])
 
 [#745]: https://github.com/RustCrypto/hashes/pull/745

--- a/bash-hash/Cargo.toml
+++ b/bash-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bash-hash"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/belt-hash/CHANGELOG.md
+++ b/belt-hash/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-hash"
-version = "0.2.0-rc.5"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/fsb/CHANGELOG.md
+++ b/fsb/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/fsb/Cargo.toml
+++ b/fsb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsb"
-version = "0.2.0-rc.2"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/gost94/CHANGELOG.md
+++ b/gost94/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (UNRELEASED)
+## 0.11.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/gost94/Cargo.toml
+++ b/gost94/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gost94"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/groestl/CHANGELOG.md
+++ b/groestl/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (UNRELEASED)
+## 0.11.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/groestl/Cargo.toml
+++ b/groestl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "groestl"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/jh/CHANGELOG.md
+++ b/jh/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jh"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/kupyna/CHANGELOG.md
+++ b/kupyna/CHANGELOG.md
@@ -4,5 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 (UNRELEASED)
-- Initial release
+## 0.1.0 (2023-03-27)
+- Initial release ([#621])
+
+[#621]: https://github.com/RustCrypto/hashes/pull/621

--- a/kupyna/Cargo.toml
+++ b/kupyna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kupyna"
-version = "0.1.0-pre.0"
+version = "0.1.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/md2/CHANGELOG.md
+++ b/md2/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (UNRELEASED)
+## 0.11.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/md2/Cargo.toml
+++ b/md2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md2"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/md4/CHANGELOG.md
+++ b/md4/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (UNRELEASED)
+## 0.11.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/md4/Cargo.toml
+++ b/md4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md4"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/md5/CHANGELOG.md
+++ b/md5/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (UNRELEASED)
+## 0.11.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 - Expose compression function from the `block_api` module ([#735])

--- a/md5/Cargo.toml
+++ b/md5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-5"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/ripemd/CHANGELOG.md
+++ b/ripemd/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/ripemd/Cargo.toml
+++ b/ripemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ripemd"
-version = "0.2.0-rc.5"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/shabal/CHANGELOG.md
+++ b/shabal/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (UNRELEASED)
+## 0.5.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/shabal/Cargo.toml
+++ b/shabal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shabal"
-version = "0.5.0-rc.2"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/skein/CHANGELOG.md
+++ b/skein/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skein"
-version = "0.2.0-rc.2"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/sm3/CHANGELOG.md
+++ b/sm3/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (UNRELEASED)
+## 0.5.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 - `oid` crate feature and `AssociatedOid` trait implementation ([#706])

--- a/sm3/Cargo.toml
+++ b/sm3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sm3"
-version = "0.5.0-rc.5"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/streebog/CHANGELOG.md
+++ b/streebog/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (UNRELEASED)
+## 0.11.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/streebog/Cargo.toml
+++ b/streebog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streebog"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/tiger/Cargo.toml
+++ b/tiger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiger"
-version = "0.3.0-rc.2"
+version = "0.3.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"

--- a/whirlpool/CHANGELOG.md
+++ b/whirlpool/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (UNRELEASED)
+## 0.11.0 (2023-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/whirlpool/Cargo.toml
+++ b/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whirlpool"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
List of released crates:
- bash-hash v0.1.0
- belt-hash v0.2.0
- fsb v0.2.0
- gost94 v0.11.0
- groestl v0.11.0
- jh v0.2.0
- kupyna v0.1.0
- md2 v0.11.0
- md4 v0.11.0
- md5 v0.11.0
- ripemd v0.2.0
- shabal v0.5.0
- sm3 v0.5.0
- streebog v0.11.0
- tiger v0.3.0
- whirlpool v0.11.0

Most crates contain the following changelog:
### Added
- `alloc` crate feature ([#678])

### Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#652])
- Relax MSRV policy and allow MSRV bumps in patch releases
- Update to `digest` v0.11
- Replace type aliases with newtypes ([#678])
- Implementation of the `SerializableState` trait ([#716])

### Removed
- `std` crate feature ([#678])

[#652]: https://github.com/RustCrypto/hashes/pull/652
[#678]: https://github.com/RustCrypto/hashes/pull/678
[#716]: https://github.com/RustCrypto/hashes/pull/716