### PR TITLE
Release `skein` v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "const-oid"
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "threefish"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8620a71dd833b597b37a17af3c07782f81c232978da6027842eb3ab006119d"
+checksum = "d01bb3253ac4d5c6c7dbb6f4f66a8178a24deefe0067357ace6482db2f3ccc6e"
 dependencies = [
  "zeroize",
 ]

--- a/skein/CHANGELOG.md
+++ b/skein/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2023-03-27)
+## 0.2.0 (2026-04-10)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/skein/Cargo.toml
+++ b/skein/Cargo.toml
@@ -14,7 +14,7 @@ description = "Skein hash functions"
 
 [dependencies]
 digest = "0.11"
-threefish = { version = "0.6.0-rc.1", default-features = false }
+threefish = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }


### PR DESCRIPTION
### Added
- `alloc` crate feature ([#678])

### Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#652])
- Relax MSRV policy and allow MSRV bumps in patch releases
- Update to `digest` v0.11
- Replace type aliases with newtypes ([#678])
- Implementation of the `SerializableState` trait ([#716])

### Removed
- `std` crate feature ([#678])

[#652]: https://github.com/RustCrypto/hashes/pull/652
[#678]: https://github.com/RustCrypto/hashes/pull/678
[#716]: https://github.com/RustCrypto/hashes/pull/716