### PR TITLE
Fix release year in changelogs

### DIFF
--- a/bash-hash/CHANGELOG.md
+++ b/bash-hash/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 (2023-03-27)
+## 0.1.0 (2026-03-27)
 - Initial release ([#745])
 
 [#745]: https://github.com/RustCrypto/hashes/pull/745

--- a/belt-hash/CHANGELOG.md
+++ b/belt-hash/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2023-03-27)
+## 0.2.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/fsb/CHANGELOG.md
+++ b/fsb/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2023-03-27)
+## 0.2.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/gost94/CHANGELOG.md
+++ b/gost94/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (2023-03-27)
+## 0.11.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/groestl/CHANGELOG.md
+++ b/groestl/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (2023-03-27)
+## 0.11.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/jh/CHANGELOG.md
+++ b/jh/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2023-03-27)
+## 0.2.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/kupyna/CHANGELOG.md
+++ b/kupyna/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 (2023-03-27)
+## 0.1.0 (2026-03-27)
 - Initial release ([#621])
 
 [#621]: https://github.com/RustCrypto/hashes/pull/621

--- a/md2/CHANGELOG.md
+++ b/md2/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (2023-03-27)
+## 0.11.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/md4/CHANGELOG.md
+++ b/md4/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (2023-03-27)
+## 0.11.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/md5/CHANGELOG.md
+++ b/md5/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (2023-03-27)
+## 0.11.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 - Expose compression function from the `block_api` module ([#735])

--- a/ripemd/CHANGELOG.md
+++ b/ripemd/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2023-03-27)
+## 0.2.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/shabal/CHANGELOG.md
+++ b/shabal/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (2023-03-27)
+## 0.5.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/sm3/CHANGELOG.md
+++ b/sm3/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (2023-03-27)
+## 0.5.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 - `oid` crate feature and `AssociatedOid` trait implementation ([#706])

--- a/streebog/CHANGELOG.md
+++ b/streebog/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (2023-03-27)
+## 0.11.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/tiger/CHANGELOG.md
+++ b/tiger/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (UNRELEASED)
+## 0.3.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/whirlpool/CHANGELOG.md
+++ b/whirlpool/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.11.0 (2023-03-27)
+## 0.11.0 (2026-03-27)
 ### Added
 - `alloc` crate feature ([#678])
 


### PR DESCRIPTION
For some reason, I erroneously copy-pasted 2023 instead of 2026 in #812.