### PR TITLE
Release belt-hash v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "0304188fd8684b910d24cae451c724cd5140a037c407e696247e94bb57b06434"
 
 [[package]]
 name = "belt-hash"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "belt-block",
  "digest",

--- a/belt-hash/CHANGELOG.md
+++ b/belt-hash/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.1 (UNRELEASED)
+## 0.2.1 (2026-04-13)
 ### Changed
 - Bump `belt-block` dependency from v0.1.1 to v0.2 ([#821])
 

--- a/belt-hash/Cargo.toml
+++ b/belt-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-hash"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Changed
- Bump `belt-block` dependency from v0.1.1 to v0.2 ([#821])

[#821]: https://github.com/RustCrypto/hashes/pull/821