### PR TITLE
cshake: remove implementation of `Reset` traits

### DIFF
--- a/cshake/src/lib.rs
+++ b/cshake/src/lib.rs
@@ -21,6 +21,9 @@ use digest::{
 };
 use keccak::{Keccak, State1600};
 
+const SHAKE_PAD: u8 = 0x1F;
+const CSHAKE_PAD: u8 = 0x04;
+
 /// cSHAKE128 hasher.
 pub type CShake128 = CShake<U168>;
 /// cSHAKE256 hasher.
@@ -33,7 +36,7 @@ pub type CShake256 = CShake<U136>;
 pub struct CShake<Rate: BlockSizes> {
     state: State1600,
     buffer: EagerBuffer<Rate>,
-    is_customized: bool,
+    pad: u8,
     keccak: Keccak,
 }
 
@@ -47,7 +50,7 @@ impl<Rate: BlockSizes> Default for CShake<Rate> {
             state: Default::default(),
             buffer: Default::default(),
             keccak: Keccak::new(),
-            is_customized: false,
+            pad: SHAKE_PAD,
         }
     }
 }
@@ -95,7 +98,7 @@ impl<Rate: BlockSizes> CShake<Rate> {
             update_blocks(f1600, state, &[buffer.pad_with_zeros()])
         });
 
-        state.is_customized = true;
+        state.pad = CSHAKE_PAD;
         state
     }
 }
@@ -133,21 +136,13 @@ impl<Rate: BlockSizes> CShake<Rate> {
         let Self {
             state,
             buffer,
-            is_customized,
+            pad,
             keccak,
         } = self;
 
-        const SHAKE_PAD: u8 = 0x1f;
-        const CSHAKE_PAD: u8 = 0x04;
-
         let pos = buffer.get_pos();
         let mut block = buffer.pad_with_zeros();
-        let pad = if *is_customized {
-            CSHAKE_PAD
-        } else {
-            SHAKE_PAD
-        };
-        block[pos] = pad;
+        block[pos] = *pad;
         let n = block.len();
         block[n - 1] |= 0x80;
 
@@ -200,7 +195,7 @@ impl<Rate: BlockSizes> Drop for CShake<Rate> {
         {
             use digest::zeroize::Zeroize;
             self.state.zeroize();
-            self.is_customized.zeroize();
+            self.pad.zeroize();
             // self.buffer is zeroized by its `Drop`
         }
     }

--- a/cshake/src/lib.rs
+++ b/cshake/src/lib.rs
@@ -43,15 +43,7 @@ pub struct CShake<Rate: BlockSizes> {
 impl<Rate: BlockSizes> Default for CShake<Rate> {
     #[inline]
     fn default() -> Self {
-        const {
-            assert!(Rate::USIZE == 168 || Rate::USIZE == 136, "unsupported rate");
-        }
-        Self {
-            state: Default::default(),
-            buffer: Default::default(),
-            keccak: Keccak::new(),
-            pad: SHAKE_PAD,
-        }
+        Self::new_with_function_name(b"", b"")
     }
 }
 
@@ -61,10 +53,21 @@ impl<Rate: BlockSizes> CShake<Rate> {
     /// Note that the function name is intended for use by NIST and should only be set to
     /// values defined by NIST. You probably don't need to use this function.
     pub fn new_with_function_name(function_name: &[u8], customization: &[u8]) -> Self {
-        let mut state = Self::default();
+        const {
+            assert!(Rate::USIZE == 168 || Rate::USIZE == 136, "unsupported rate");
+        }
+
+        let buffer = Default::default();
+        let keccak = Keccak::new();
+        let mut state = State1600::default();
 
         if function_name.is_empty() && customization.is_empty() {
-            return state;
+            return Self {
+                state,
+                buffer,
+                keccak,
+                pad: SHAKE_PAD,
+            };
         }
 
         #[inline(always)]
@@ -75,9 +78,9 @@ impl<Rate: BlockSizes> CShake<Rate> {
             &b[i..]
         }
 
-        state.keccak.with_f1600(|f1600| {
+        keccak.with_f1600(|f1600| {
             let mut buffer: EagerBuffer<Rate> = Default::default();
-            let state = &mut state.state;
+            let state = &mut state;
             let mut b = [0u8; 9];
 
             buffer.digest_blocks(left_encode(Rate::U64, &mut b), |blocks| {
@@ -98,8 +101,12 @@ impl<Rate: BlockSizes> CShake<Rate> {
             update_blocks(f1600, state, &[buffer.pad_with_zeros()])
         });
 
-        state.pad = CSHAKE_PAD;
-        state
+        Self {
+            state,
+            buffer,
+            keccak,
+            pad: CSHAKE_PAD,
+        }
     }
 }
 

--- a/cshake/src/lib.rs
+++ b/cshake/src/lib.rs
@@ -13,8 +13,7 @@ pub use digest;
 
 use core::fmt;
 use digest::{
-    CollisionResistance, CustomizedInit, ExtendableOutput, ExtendableOutputReset, HashMarker,
-    Reset, Update, XofReader,
+    CollisionResistance, CustomizedInit, ExtendableOutput, HashMarker, Update, XofReader,
     array::Array,
     block_api::{AlgorithmName, BlockSizeUser},
     block_buffer::{BlockSizes, EagerBuffer, ReadBuffer},
@@ -33,9 +32,9 @@ pub type CShake256 = CShake<U136>;
 #[derive(Clone)]
 pub struct CShake<Rate: BlockSizes> {
     state: State1600,
-    initial_state: State1600,
-    keccak: Keccak,
     buffer: EagerBuffer<Rate>,
+    is_customized: bool,
+    keccak: Keccak,
 }
 
 impl<Rate: BlockSizes> Default for CShake<Rate> {
@@ -46,9 +45,9 @@ impl<Rate: BlockSizes> Default for CShake<Rate> {
         }
         Self {
             state: Default::default(),
-            initial_state: Default::default(),
-            keccak: Keccak::new(),
             buffer: Default::default(),
+            keccak: Keccak::new(),
+            is_customized: false,
         }
     }
 }
@@ -96,7 +95,7 @@ impl<Rate: BlockSizes> CShake<Rate> {
             update_blocks(f1600, state, &[buffer.pad_with_zeros()])
         });
 
-        state.initial_state = state.state;
+        state.is_customized = true;
         state
     }
 }
@@ -129,21 +128,13 @@ impl<Rate: BlockSizes> Update for CShake<Rate> {
     }
 }
 
-impl<Rate: BlockSizes> Reset for CShake<Rate> {
-    #[inline]
-    fn reset(&mut self) {
-        self.state = self.initial_state;
-        self.buffer.reset();
-    }
-}
-
 impl<Rate: BlockSizes> CShake<Rate> {
     fn finalize_dirty(&mut self) {
         let Self {
             state,
-            keccak,
             buffer,
-            initial_state,
+            is_customized,
+            keccak,
         } = self;
 
         const SHAKE_PAD: u8 = 0x1f;
@@ -151,10 +142,10 @@ impl<Rate: BlockSizes> CShake<Rate> {
 
         let pos = buffer.get_pos();
         let mut block = buffer.pad_with_zeros();
-        let pad = if initial_state.iter().all(|&b| b == 0) {
-            SHAKE_PAD
-        } else {
+        let pad = if *is_customized {
             CSHAKE_PAD
+        } else {
+            SHAKE_PAD
         };
         block[pos] = pad;
         let n = block.len();
@@ -178,20 +169,6 @@ impl<Rate: BlockSizes> ExtendableOutput for CShake<Rate> {
             keccak: self.keccak,
             buffer: Default::default(),
         }
-    }
-}
-
-impl<Rate: BlockSizes> ExtendableOutputReset for CShake<Rate> {
-    #[inline]
-    fn finalize_xof_reset(&mut self) -> Self::Reader {
-        self.finalize_dirty();
-        let reader = Self::Reader {
-            state: self.state,
-            keccak: self.keccak,
-            buffer: Default::default(),
-        };
-        self.reset();
-        reader
     }
 }
 
@@ -223,7 +200,7 @@ impl<Rate: BlockSizes> Drop for CShake<Rate> {
         {
             use digest::zeroize::Zeroize;
             self.state.zeroize();
-            self.initial_state.zeroize();
+            self.is_customized.zeroize();
             // self.buffer is zeroized by its `Drop`
         }
     }

--- a/cshake/tests/cshake.rs
+++ b/cshake/tests/cshake.rs
@@ -1,4 +1,4 @@
-use digest::{CustomizedInit, ExtendableOutputReset};
+use digest::{CustomizedInit, ExtendableOutput};
 
 #[derive(Debug, Clone, Copy)]
 pub struct TestVector {
@@ -7,7 +7,7 @@ pub struct TestVector {
     pub output: &'static [u8],
 }
 
-pub(crate) fn cshake_reset_test<D>(
+pub(crate) fn cshake_test<D>(
     &TestVector {
         customization,
         input,
@@ -15,7 +15,7 @@ pub(crate) fn cshake_reset_test<D>(
     }: &TestVector,
 ) -> Result<(), &'static str>
 where
-    D: CustomizedInit + ExtendableOutputReset + Clone,
+    D: CustomizedInit + ExtendableOutput + Clone,
 {
     let mut hasher = D::new_customized(customization);
     let mut buf = [0u8; 1024];
@@ -29,15 +29,6 @@ where
     }
     buf.iter_mut().for_each(|b| *b = 0);
 
-    // Test if reset works correctly
-    hasher2.reset();
-    hasher2.update(input);
-    hasher2.finalize_xof_reset_into(buf);
-    if buf != output {
-        return Err("whole message after reset");
-    }
-    buf.iter_mut().for_each(|b| *b = 0);
-
     // Test that it works when accepting the message in chunks
     for n in 1..core::cmp::min(17, input.len()) {
         let mut hasher = D::new_customized(customization);
@@ -46,12 +37,6 @@ where
             hasher2.update(chunk);
         }
         hasher.finalize_xof_into(buf);
-        if buf != output {
-            return Err("message in chunks");
-        }
-        buf.iter_mut().for_each(|b| *b = 0);
-
-        hasher2.finalize_xof_reset_into(buf);
         if buf != output {
             return Err("message in chunks");
         }
@@ -71,9 +56,7 @@ macro_rules! new_cshake_test {
             );
 
             for (i, tv) in TEST_VECTORS.iter().enumerate() {
-                if let Err(reason) =
-                    cshake_reset_test::<$hasher>(tv)
-                {
+                if let Err(reason) = cshake_test::<$hasher>(tv) {
                     panic!(
                         "\n\
                          Failed test #{i}\n\


### PR DESCRIPTION
The reset ability is probably needed extremely rarely in practice and its support balloons the `CShake` state size.

Additionally, comparing `initial_state` against zeros to determine whether the function was customized or not could be potentially problematic, since it may be possible to craft a customization string which results in a zeroed state after permutation is applied. (Considering the used encoding, I don't think it's possible, but it has to be proved separately)

In future we could add separate resettable types if there is demand for them.