### PR TITLE
Release cshake v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "cshake"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "digest",
  "hex-literal",

--- a/cshake/CHANGELOG.md
+++ b/cshake/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.1 (2026-04-19)
 ### Fixed
-- Non-compliant initialization when length of serialized function name and customization string
-  is multiple of block size ([#834])
+- Non-compliant initialization when serialized length of function name and customization string
+  is a multiple of the block size ([#834])
 
 [#834]: https://github.com/RustCrypto/hashes/pull/834
 

--- a/cshake/CHANGELOG.md
+++ b/cshake/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2026-04-19)
+### Fixed
+- Non-compliant initialization when length of serialized function name and customization string
+  is multiple of block size ([#834])
+
+[#834]: https://github.com/RustCrypto/hashes/pull/834
+
 ## 0.1.0 (2026-04-13)
 - Initial release with implementation moved from the `sha3` crate ([#815])
 

--- a/cshake/Cargo.toml
+++ b/cshake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cshake"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Fixed
- Non-compliant initialization when serialized length of function name and customization string
  is a multiple of the block size ([#834])

[#834]: https://github.com/RustCrypto/hashes/pull/834