### PR TITLE
Release sha3 v0.10.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "digest",
  "hex-literal",

--- a/sha3/CHANGELOG.md
+++ b/sha3/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.10.9 (UNRELEASED)
+## 0.10.9 (2026-04-19)
 ### Fixed
 - Non-compliant initialization of cSHAKE when serialized length of function name and
   customization string is a multiple of the block size ([#836], backport of [#834])

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 description = """
 Pure Rust implementation of SHA-3, a family of Keccak-based hash functions
 including the SHAKE family of eXtendable-Output Functions (XOFs), as well as


### PR DESCRIPTION
### Fixed
- Non-compliant initialization of cSHAKE when serialized length of function name and
  customization string is a multiple of the block size ([#836], backport of [#834])

[#834]: https://github.com/RustCrypto/hashes/pull/834
[#836]: https://github.com/RustCrypto/hashes/pull/836