### PR TITLE
Release k12 v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "k12"
-version = "0.4.0-rc.1"
+version = "0.4.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/k12/CHANGELOG.md
+++ b/k12/CHANGELOG.md
@@ -8,18 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.4.0 (2026-04-24)
 ### Added
 - `alloc` crate feature ([#678])
+- `Kt`, `Kt128` and `Kt256` non-customizable types ([#839])
+- `custom` module with customizable variants ([#839])
 
 ### Changed
 - Edition changed to 2024 and MSRV bumped to 1.85 ([#652])
 - Relax MSRV policy and allow MSRV bumps in patch releases
 - Update to `digest` v0.11
-- Replace type aliases with newtypes ([#678])
+- New implementation with parallel processing support ([#839])
 
 ### Removed
 - `std` crate feature ([#678])
+- `KangarooTwelve*` types ([#839])
 
 [#652]: https://github.com/RustCrypto/hashes/pull/652
 [#678]: https://github.com/RustCrypto/hashes/pull/678
+[#839]: https://github.com/RustCrypto/hashes/pull/839
 
 ## 0.3.0 (2023-06-10)
 ### Added

--- a/k12/CHANGELOG.md
+++ b/k12/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.4.0 (UNRELEASED)
+## 0.4.0 (2026-04-24)
 ### Added
 - `alloc` crate feature ([#678])
 

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k12"
-version = "0.4.0-rc.1"
+version = "0.4.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Added
- `alloc` crate feature ([#678])
- `Kt`, `Kt128` and `Kt256` non-customizable types ([#839])
- `custom` module with customizable variants ([#839])

### Changed
- Edition changed to 2024 and MSRV bumped to 1.85 ([#652])
- Relax MSRV policy and allow MSRV bumps in patch releases
- Update to `digest` v0.11
- New implementation with parallel processing support ([#839])

### Removed
- `std` crate feature ([#678])
- `KangarooTwelve*` types ([#839])

[#652]: https://github.com/RustCrypto/hashes/pull/652
[#678]: https://github.com/RustCrypto/hashes/pull/678
[#839]: https://github.com/RustCrypto/hashes/pull/839