### PR TITLE
Release turboshake v0.6.0

### DIFF
--- a/turboshake/CHANGELOG.md
+++ b/turboshake/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.6.0 (UNRELEASED)
+## 0.6.0 (2026-04-24)
 Note: the crate was transferred to RustCrypto from https://github.com/itzmeanjan/turboshake
 
 ### Changed


### PR DESCRIPTION
Note: the crate was transferred to RustCrypto from https://github.com/itzmeanjan/turboshake

### Changed
- New implementation moved from the `sha3` crate ([#815])

[#815]: https://github.com/RustCrypto/hashes/pull/815
