### PR TITLE
Release bash-prg-hash v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 [`ascon‑hash256`]: ./ascon-hash256
 [`ascon‑xof128`]: ./ascon-xof128
 [`bash‑hash`]: ./bash-hash
-[`bash‑prg-hash`]: ./bash-prg-hash
+[`bash-prg‑hash`]: ./bash-prg-hash
 [`belt‑hash`]: ./belt-hash
 [`blake2`]: ./blake2
 [`cshake`]: ./cshake

--- a/bash-prg-hash/CHANGELOG.md
+++ b/bash-prg-hash/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## 0.1.0 (UNRELEASED)
+## 0.1.0 (2026-05-12)
 - Initial release ([#751])
 
 [#745]: https://github.com/RustCrypto/hashes/pull/751

--- a/bash-prg-hash/CHANGELOG.md
+++ b/bash-prg-hash/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.1.0 (2026-05-12)
 - Initial release ([#751])
 
-[#745]: https://github.com/RustCrypto/hashes/pull/751
+[#751]: https://github.com/RustCrypto/hashes/pull/751

--- a/bash-prg-hash/README.md
+++ b/bash-prg-hash/README.md
@@ -1,4 +1,4 @@
-# RustCrypto: bash prg hash
+# RustCrypto: bash-prg-hash
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]


### PR DESCRIPTION
- Initial release ([#751])

[#751]: https://github.com/RustCrypto/hashes/pull/751
