### PR TITLE
Remove implementation of `BlockSizeUser` for XOFs

### DIFF
--- a/cshake/CHANGELOG.md
+++ b/cshake/CHANGELOG.md
@@ -13,8 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal implementation by removing unnecessary buffering ([#849])
 - `Rate: BlockSizes` generic parameter to `const RATE: usize` ([#849])
 
+### Removed
+- Implementations of `BlockSizeUser` ([#856])
+
 [#849]: https://github.com/RustCrypto/hashes/pull/849
 [#855]: https://github.com/RustCrypto/hashes/pull/855
+[#856]: https://github.com/RustCrypto/hashes/pull/856
 
 ## 0.1.1 (2026-04-19)
 ### Fixed

--- a/cshake/src/lib.rs
+++ b/cshake/src/lib.rs
@@ -14,8 +14,8 @@ pub use digest;
 use core::fmt;
 use digest::{
     CollisionResistance, CustomizedInit, ExtendableOutput, HashMarker, Update, XofReader,
-    common::{AlgorithmName, BlockSizeUser},
-    consts::{U16, U32, U136, U168},
+    common::AlgorithmName,
+    consts::{U16, U32},
 };
 use keccak::{Keccak, State1600};
 use sponge_cursor::SpongeCursor;
@@ -237,12 +237,4 @@ impl CollisionResistance for CShake128 {
 }
 impl CollisionResistance for CShake256 {
     type CollisionResistance = U32;
-}
-
-impl BlockSizeUser for CShake128 {
-    type BlockSize = U168;
-}
-
-impl BlockSizeUser for CShake256 {
-    type BlockSize = U136;
 }

--- a/k12/CHANGELOG.md
+++ b/k12/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal implementation by removing unnecessary buffering ([#849])
 - `Rate: BlockSizes` generic parameter to `const RATE: usize` ([#849])
 
+### Removed
+- Implementations of `BlockSizeUser` ([#856])
+
 [#849]: https://github.com/RustCrypto/hashes/pull/849
+[#856]: https://github.com/RustCrypto/hashes/pull/856
 
 ## 0.4.0 (2026-04-24)
 ### Added

--- a/k12/src/custom/borrow.rs
+++ b/k12/src/custom/borrow.rs
@@ -1,8 +1,8 @@
 use core::fmt;
 use digest::{
     CollisionResistance, ExtendableOutput, ExtendableOutputReset, HashMarker, Reset, Update,
-    common::{AlgorithmName, BlockSizeUser},
-    consts::{U16, U32, U136, U168},
+    common::AlgorithmName,
+    consts::{U16, U32},
 };
 
 use crate::{Kt, KtReader, utils::length_encode};
@@ -108,12 +108,4 @@ impl CollisionResistance for CustomRefKt128<'_> {
 
 impl CollisionResistance for CustomRefKt256<'_> {
     type CollisionResistance = U32;
-}
-
-impl BlockSizeUser for CustomRefKt128<'_> {
-    type BlockSize = U168;
-}
-
-impl BlockSizeUser for CustomRefKt256<'_> {
-    type BlockSize = U136;
 }

--- a/k12/src/custom/owned.rs
+++ b/k12/src/custom/owned.rs
@@ -5,8 +5,8 @@ use core::fmt;
 use digest::{
     CollisionResistance, CustomizedInit, ExtendableOutput, ExtendableOutputReset, HashMarker,
     Reset, Update,
-    common::{AlgorithmName, BlockSizeUser},
-    consts::{U16, U32, U136, U168},
+    common::AlgorithmName,
+    consts::{U16, U32},
 };
 
 use crate::{Kt, KtReader, utils::length_encode};
@@ -121,12 +121,4 @@ impl CollisionResistance for CustomKt128 {
 impl CollisionResistance for CustomKt256 {
     // https://www.rfc-editor.org/rfc/rfc9861.html#section-7-8
     type CollisionResistance = U32;
-}
-
-impl BlockSizeUser for CustomKt128 {
-    type BlockSize = U168;
-}
-
-impl BlockSizeUser for CustomKt256 {
-    type BlockSize = U136;
 }

--- a/k12/src/lib.rs
+++ b/k12/src/lib.rs
@@ -13,8 +13,8 @@ pub use digest;
 use core::fmt;
 use digest::{
     CollisionResistance, ExtendableOutput, ExtendableOutputReset, HashMarker, Reset, Update,
-    common::{AlgorithmName, BlockSizeUser},
-    consts::{U16, U32, U136, U168},
+    common::AlgorithmName,
+    consts::{U16, U32},
 };
 
 mod consts;
@@ -180,12 +180,4 @@ impl CollisionResistance for Kt128 {
 // https://www.rfc-editor.org/rfc/rfc9861.html#section-7-8
 impl CollisionResistance for Kt256 {
     type CollisionResistance = U32;
-}
-
-impl BlockSizeUser for Kt128 {
-    type BlockSize = U168;
-}
-
-impl BlockSizeUser for Kt256 {
-    type BlockSize = U136;
 }

--- a/sha3/src/shake.rs
+++ b/sha3/src/shake.rs
@@ -3,10 +3,10 @@ use digest::{
     CollisionResistance, ExtendableOutput, ExtendableOutputReset, HashMarker, Reset, Update,
     XofReader,
     common::{
-        AlgorithmName, BlockSizeUser,
+        AlgorithmName,
         hazmat::{DeserializeStateError, SerializableState, SerializedState},
     },
-    consts::{U16, U32, U136, U168, U201},
+    consts::{U16, U32, U201},
 };
 use keccak::{Keccak, State1600};
 use sponge_cursor::SpongeCursor;
@@ -222,14 +222,7 @@ impl<const RATE: usize> Drop for ShakeReader<RATE> {
 impl CollisionResistance for Shake128 {
     type CollisionResistance = U16;
 }
+
 impl CollisionResistance for Shake256 {
     type CollisionResistance = U32;
-}
-
-impl BlockSizeUser for Shake128 {
-    type BlockSize = U168;
-}
-
-impl BlockSizeUser for Shake256 {
-    type BlockSize = U136;
 }

--- a/turboshake/CHANGELOG.md
+++ b/turboshake/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal implementation by removing unnecessary buffering ([#849])
 - `Rate: BlockSizes` generic parameter to `const RATE: usize` ([#849])
 
+### Removed
+- Implementations of `BlockSizeUser` ([#856])
+
 [#849]: https://github.com/RustCrypto/hashes/pull/849
+[#856]: https://github.com/RustCrypto/hashes/pull/856
 
 ## 0.6.0 (2026-04-24)
 Note: the crate was transferred to RustCrypto from https://github.com/itzmeanjan/turboshake

--- a/turboshake/src/lib.rs
+++ b/turboshake/src/lib.rs
@@ -17,8 +17,8 @@ use core::fmt;
 use digest::{
     CollisionResistance, ExtendableOutput, ExtendableOutputReset, HashMarker, Reset, Update,
     XofReader,
-    common::{AlgorithmName, BlockSizeUser},
-    consts::{U16, U32, U136, U168},
+    common::AlgorithmName,
+    consts::{U16, U32},
 };
 
 /// Number of Keccak rounds used by TurboSHAKE.
@@ -210,12 +210,4 @@ impl<const DS: u8> CollisionResistance for TurboShake128<DS> {
 impl<const DS: u8> CollisionResistance for TurboShake256<DS> {
     // https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#section-7-8
     type CollisionResistance = U32;
-}
-
-impl<const DS: u8> BlockSizeUser for TurboShake128<DS> {
-    type BlockSize = U168;
-}
-
-impl<const DS: u8> BlockSizeUser for TurboShake256<DS> {
-    type BlockSize = U136;
 }


### PR DESCRIPTION
The primary use of `BlockSizeUser` is implementation of HMAC. Our implementation in `hmac` requires fixed output, so XOFs can not be used with it (without `XofFixedWrapper`). XOFs should not be used with HMAC either way, so we probably can drop the impls.