### PR TITLE
Release ascon-xof128 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ascon-xof128"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ascon",
  "digest",
@@ -193,9 +193,9 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]

--- a/ascon-xof128/CHANGELOG.md
+++ b/ascon-xof128/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2026-05-12)
 ### Changed
 - Internal implementation by removing unnecessary buffering ([#849])
 - Serialization format used by `SerializableState` implementations ([#849])

--- a/ascon-xof128/Cargo.toml
+++ b/ascon-xof128/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascon-xof128"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Changed
- Internal implementation by removing unnecessary buffering ([#849])
- Serialization format used by `SerializableState` implementations ([#849])
- Replaced implementation of `CustomizedInit` with `TryCustomizedInit` ([#857])

[#849]: https://github.com/RustCrypto/hashes/pull/849
[#857]: https://github.com/RustCrypto/hashes/pull/857