### PR TITLE
bash-prg-hash: fix minimal versions

### DIFF
--- a/bash-prg-hash/CHANGELOG.md
+++ b/bash-prg-hash/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (UNRELEASED)
+### Fixed
+- Use correct minimal version of `digest` dependency ([#861])
+
+[#861]: https://github.com/RustCrypto/hashes/pull/861
 
 ## 0.1.0 (2026-05-12)
 - Initial release ([#751])

--- a/bash-prg-hash/Cargo.toml
+++ b/bash-prg-hash/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["belt", "stb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-digest = { version = "0.11", default-features = false }
+digest = { version = "0.11.3", default-features = false }
 bash-f = "0.1"
 sponge-cursor = "0.1"
 
 [dev-dependencies]
-digest = { version = "0.11", default-features = false, features = ["dev"] }
+digest = { version = "0.11.3", default-features = false, features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/bash-prg-hash/Cargo.toml
+++ b/bash-prg-hash/Cargo.toml
@@ -18,7 +18,7 @@ bash-f = "0.1"
 sponge-cursor = "0.1"
 
 [dev-dependencies]
-digest = { version = "0.11", features = ["dev"] }
+digest = { version = "0.11", default-features = false, features = ["dev"] }
 hex-literal = "1"
 
 [features]


### PR DESCRIPTION
The crate depends on `TryCustomizedInit` which was introduced in `digest` v0.11.3.

The minimal versions job was broken (see https://github.com/RustCrypto/actions/pull/59), so it missed the incorrect dependency specification.