### PR TITLE
Release bash-prg-hash v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "bash-prg-hash"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bash-f",
  "digest",

--- a/bash-prg-hash/CHANGELOG.md
+++ b/bash-prg-hash/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.1 (UNRELEASED)
+## 0.1.1 (2026-05-12)
 ### Fixed
 - Use correct minimal version of `digest` dependency ([#861])
 
 [#861]: https://github.com/RustCrypto/hashes/pull/861
 
-## 0.1.0 (2026-05-12)
+## 0.1.0 (2026-05-12) [YANKED]
 - Initial release ([#751])
 
 [#751]: https://github.com/RustCrypto/hashes/pull/751

--- a/bash-prg-hash/Cargo.toml
+++ b/bash-prg-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bash-prg-hash"
-version = "0.1.0"
+version = "0.1.1"
 description = "bash-prg-hash function (STB 34.101.77-2020)"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Fixed
- Use correct minimal version of `digest` dependency ([#861])

[#861]: https://github.com/RustCrypto/hashes/pull/861