### PR TITLE
Release cshake v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "cshake"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/cshake/CHANGELOG.md
+++ b/cshake/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2026-05-12)
 ### Added
 - `CShake128Reader` and `CShake256Reader` type aliases ([#855])
 

--- a/cshake/Cargo.toml
+++ b/cshake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cshake"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Added
- `CShake128Reader` and `CShake256Reader` type aliases ([#855])

### Changed
- Internal implementation by removing unnecessary buffering ([#849])
- `Rate: BlockSizes` generic parameter to `const RATE: usize` ([#849])

### Removed
- Implementations of `BlockSizeUser` ([#856])

[#849]: https://github.com/RustCrypto/hashes/pull/849
[#855]: https://github.com/RustCrypto/hashes/pull/855
[#856]: https://github.com/RustCrypto/hashes/pull/856