### PR TITLE
Release k12 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "k12"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/k12/CHANGELOG.md
+++ b/k12/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (UNRELEASED)
+## 0.5.0 (2026-05-12)
 ### Changed
 - Internal implementation by removing unnecessary buffering ([#849])
 - `Rate: BlockSizes` generic parameter to `const RATE: usize` ([#849])

--- a/k12/Cargo.toml
+++ b/k12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k12"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Changed
- Internal implementation by removing unnecessary buffering ([#849])
- `Rate: BlockSizes` generic parameter to `const RATE: usize` ([#849])

### Removed
- Implementations of `BlockSizeUser` ([#856])

[#849]: https://github.com/RustCrypto/hashes/pull/849
[#856]: https://github.com/RustCrypto/hashes/pull/856