### PR TITLE
turboshake: introduce separate customizable type aliases

### DIFF
--- a/turboshake/CHANGELOG.md
+++ b/turboshake/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal implementation by removing unnecessary buffering ([#849])
 - `Rate: BlockSizes` generic parameter to `const RATE: usize` ([#849])
 - `TurboShake128` and `TurboShake256` type aliases are no longer generic over the domain separator
-  and use the default value instead. ([#866])
+  and use the default value instead ([#866])
 
 ### Removed
 - Implementations of `BlockSizeUser` ([#856])

--- a/turboshake/CHANGELOG.md
+++ b/turboshake/CHANGELOG.md
@@ -6,15 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.7.0 (UNRELEASED)
+### Added
+- `CTurboShake128` and `CTurboShake256` type aliases generic over domain separator ([#866])
+
 ### Changed
 - Internal implementation by removing unnecessary buffering ([#849])
 - `Rate: BlockSizes` generic parameter to `const RATE: usize` ([#849])
+- `TurboShake128` and `TurboShake256` type aliases are no longer generic over the domain separator
+  and use the default value instead. ([#866])
 
 ### Removed
 - Implementations of `BlockSizeUser` ([#856])
 
 [#849]: https://github.com/RustCrypto/hashes/pull/849
 [#856]: https://github.com/RustCrypto/hashes/pull/856
+[#866]: https://github.com/RustCrypto/hashes/pull/866
 
 ## 0.6.0 (2026-04-24)
 Note: the crate was transferred to RustCrypto from https://github.com/itzmeanjan/turboshake

--- a/turboshake/README.md
+++ b/turboshake/README.md
@@ -16,18 +16,16 @@ XOF reader from which results of arbitrary length can be read. Note that
 these functions do not implement `Digest`, so lower-level traits have to
 be imported:
 
+TurboSHAKE supports limited customization using "domain separator" value.
+This implementation handles it using the const generic parameter `DS`.
+
+With the default domain separator:
 ```rust
 use turboshake::TurboShake128;
 use turboshake::digest::{Update, ExtendableOutput, XofReader};
 use hex_literal::hex;
 
-// With the default domain separator.
-// 
-// Note that we have to use `<TurboShake128>` because of
-// the inadequate handling of defaults in Rust.
-// Alternatively, you could use `let mut hasher: TurboShake128 = Default::default();`
-// or `TurboShake128::<DEFAULT_DS>::default()`.
-let mut hasher = <TurboShake128>::default();
+let mut hasher = TurboShake128::default();
 hasher.update(b"abc");
 let mut reader = hasher.finalize_xof();
 let mut buf = [0u8; 10];
@@ -35,9 +33,15 @@ reader.read(&mut buf);
 assert_eq!(buf, hex!("dcf1646dfe993a8eb6b7"));
 reader.read(&mut buf);
 assert_eq!(buf, hex!("82d1faaca6d82416a5dc"));
+```
 
-// With a custom domain separator
-let mut hasher = TurboShake128::<0x10>::default();
+With a custom domain separator:
+```rust
+use turboshake::CTurboShake128;
+use turboshake::digest::{Update, ExtendableOutput, XofReader};
+use hex_literal::hex;
+
+let mut hasher = CTurboShake128::<0x10>::default();
 hasher.update(b"abc");
 let mut reader = hasher.finalize_xof();
 let mut buf = [0u8; 10];

--- a/turboshake/src/lib.rs
+++ b/turboshake/src/lib.rs
@@ -25,7 +25,7 @@ use digest::{
 const ROUNDS: usize = 12;
 
 /// Default domain separator value.
-const DEFAULT_DS: u8 = 0x1F;
+pub const DEFAULT_DS: u8 = 0x1F;
 
 /// TurboSHAKE hasher generic over rate and domain separator.
 ///

--- a/turboshake/src/lib.rs
+++ b/turboshake/src/lib.rs
@@ -25,7 +25,7 @@ use digest::{
 const ROUNDS: usize = 12;
 
 /// Default domain separator value.
-pub const DEFAULT_DS: u8 = 0x1F;
+const DEFAULT_DS: u8 = 0x1F;
 
 /// TurboSHAKE hasher generic over rate and domain separator.
 ///
@@ -142,7 +142,7 @@ impl<const RATE: usize, const DS: u8> Drop for TurboShake<RATE, DS> {
         {
             use digest::zeroize::Zeroize;
             self.state.zeroize();
-            // self.buffer is zeroized by its `Drop`
+            self.cursor.zeroize();
         }
     }
 }
@@ -192,22 +192,31 @@ impl<const RATE: usize> Drop for TurboShakeReader<RATE> {
 #[cfg(feature = "zeroize")]
 impl<const RATE: usize> digest::zeroize::ZeroizeOnDrop for TurboShakeReader<RATE> {}
 
-/// TurboSHAKE128 hasher with domain separator.
-pub type TurboShake128<const DS: u8 = DEFAULT_DS> = TurboShake<168, DS>;
-/// TurboSHAKE256 hasher with domain separator.
-pub type TurboShake256<const DS: u8 = DEFAULT_DS> = TurboShake<136, DS>;
+/// TurboSHAKE128 hasher with a custom domain separator.
+///
+/// Domain separator `DS` MUST be in the range `0x01..=0x7f`.
+pub type CTurboShake128<const DS: u8> = TurboShake<168, DS>;
+/// TurboSHAKE256 hasher with a custom domain separator.
+///
+/// Domain separator `DS` MUST be in the range `0x01..=0x7f`.
+pub type CTurboShake256<const DS: u8> = TurboShake<136, DS>;
+
+/// TurboSHAKE128 hasher with the default domain separator.
+pub type TurboShake128 = CTurboShake128<DEFAULT_DS>;
+/// TurboSHAKE256 hasher with the default domain separator.
+pub type TurboShake256 = CTurboShake256<DEFAULT_DS>;
 
 /// TurboSHAKE128 XOF reader.
 pub type TurboShake128Reader = TurboShakeReader<168>;
 /// TurboSHAKE256 XOF reader.
 pub type TurboShake256Reader = TurboShakeReader<136>;
 
-impl<const DS: u8> CollisionResistance for TurboShake128<DS> {
+impl<const DS: u8> CollisionResistance for CTurboShake128<DS> {
     // https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#section-7-7
     type CollisionResistance = U16;
 }
 
-impl<const DS: u8> CollisionResistance for TurboShake256<DS> {
+impl<const DS: u8> CollisionResistance for CTurboShake256<DS> {
     // https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-17.html#section-7-8
     type CollisionResistance = U32;
 }

--- a/turboshake/tests/turboshake.rs
+++ b/turboshake/tests/turboshake.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 use digest::ExtendableOutput;
-use turboshake::{TurboShake128, TurboShake256};
+use turboshake::{CTurboShake128, CTurboShake256};
 
 #[derive(Debug, Clone, Copy)]
 pub struct TestVector {
@@ -104,25 +104,25 @@ macro_rules! new_test {
 new_test!(
     turboshake128_6,
     "turboshake128_6",
-    TurboShake128<6>,
+    CTurboShake128<6>,
     turbo_shake_test,
 );
 new_test!(
     turboshake128_7,
     "turboshake128_7",
-    TurboShake128<7>,
+    CTurboShake128<7>,
     turbo_shake_test,
 );
 new_test!(
     turboshake256_6,
     "turboshake256_6",
-    TurboShake256<6>,
+    CTurboShake256<6>,
     turbo_shake_test,
 );
 
 new_test!(
     turboshake256_7,
     "turboshake256_7",
-    TurboShake256<7>,
+    CTurboShake256<7>,
     turbo_shake_test,
 );


### PR DESCRIPTION
Change `TurboShake128/256` type aliases to use the default domain separator (DS) and introduce separate `CTurboShake128/256` type aliases generic over DS.

It's effectively a work around for the subpar handling of default type/const parameters in Rust.