### PR TITLE
md5: add note about library renaming

### DIFF
--- a/md5/README.md
+++ b/md5/README.md
@@ -22,6 +22,12 @@ Collision attacks against MD5 are both practical and trivial, and
 [RFC 6151] advises no new IETF protocols can be designed MD5-based constructions,
 including HMAC-MD5.
 
+## Library name
+
+Note that this crate is named as `md-5` (the `md5` crate is not part of the RustCrypto project),
+but it renames the library to `md5`. In other words, in your Cargo.toml you should use
+`md_5 = "0.11"`, but in you source code imports from this crate will look like `use md5::Md5;`
+
 ## Examples
 
 ```rust

--- a/md5/README.md
+++ b/md5/README.md
@@ -26,7 +26,7 @@ including HMAC-MD5.
 
 Note that this crate is named as `md-5` (the `md5` crate is not part of the RustCrypto project),
 but it renames the library to `md5`. In other words, in your Cargo.toml you should use
-`md_5 = "0.11"`, but in you source code imports from this crate will look like `use md5::Md5;`
+`md_5 = "0.11"`, but in you source code imports from this crate will look like `use md5::Md5;`.
 
 ## Examples
 


### PR DESCRIPTION
The library renaming can be confusing for users, see: https://github.com/RustCrypto/hashes/issues/669