### PR TITLE
Release turboshake v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "turboshake"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/turboshake/CHANGELOG.md
+++ b/turboshake/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 (UNRELEASED)
+## 0.7.0 (2026-05-13)
 ### Added
 - `CTurboShake128` and `CTurboShake256` type aliases generic over domain separator ([#866])
 

--- a/turboshake/Cargo.toml
+++ b/turboshake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turboshake"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Added
- `CTurboShake128` and `CTurboShake256` type aliases generic over domain separator ([#866])

### Changed
- Internal implementation by removing unnecessary buffering ([#849])
- `Rate: BlockSizes` generic parameter to `const RATE: usize` ([#849])
- `TurboShake128` and `TurboShake256` type aliases are no longer generic over the domain separator
  and use the default value instead ([#866])

### Removed
- Implementations of `BlockSizeUser` ([#856])

[#849]: https://github.com/RustCrypto/hashes/pull/849
[#856]: https://github.com/RustCrypto/hashes/pull/856
[#866]: https://github.com/RustCrypto/hashes/pull/866