### PR TITLE
Release sha3 v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "digest",
  "hex-literal",

--- a/sha3/CHANGELOG.md
+++ b/sha3/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.12.0 (UNRELEASED)
+## 0.12.0 (2026-05-15)
 ### Changed
 - Internal implementation by removing unnecessary buffering ([#849])
 - Serialization format used by `SerializableState` trait implementations ([#849])

--- a/sha3/Cargo.toml
+++ b/sha3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha3"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"


### PR DESCRIPTION
### Changed
- Internal implementation by removing unnecessary buffering ([#849])
- Serialization format used by `SerializableState` trait implementations ([#849])

### Removed
- `Shake`, `Shake128`, and `Shake256` types (moved to the `shake` crate) ([#869])

[#849]: https://github.com/RustCrypto/hashes/pull/849
[#869]: https://github.com/RustCrypto/hashes/pull/869