### PR TITLE
sha2: cross compile to uefi

### DIFF
--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -152,6 +152,7 @@ jobs:
         target:
           - aarch64-unknown-linux-gnu
           - powerpc-unknown-linux-gnu
+          - x86_64-unknown-uefi 
         features:
           - default
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is an attempt at reproducing an LLVM error I've seen in the field:


```
rustc-LLVM ERROR: Do not know how to split the result of this operator!
```

I have no clue where this actually comes from.