### PR TITLE
Fix bash-hash package metadata and README links

### DIFF
--- a/bash-hash/CHANGELOG.md
+++ b/bash-hash/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (UNRELEASED)
+### Fixed
+- Package metadata and README links ([#886])
+
+[#886]: https://github.com/RustCrypto/hashes/pull/886
+
 ## 0.1.0 (2026-03-27)
 - Initial release ([#745])
 

--- a/bash-hash/Cargo.toml
+++ b/bash-hash/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/bash-hash"
 readme = "README.md"
 repository = "https://github.com/RustCrypto/hashes"
 license = "MIT OR Apache-2.0"
-keywords = ["bash", "stb", "hash", "digest"]
+keywords = ["stb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 description = "bash hash function (STB 34.101.77-2020)"
 

--- a/bash-hash/Cargo.toml
+++ b/bash-hash/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 authors = ["RustCrypto Developers"]
 edition = "2024"
 rust-version = "1.85"
-documentation = "https://docs.rs/belt-hash"
+documentation = "https://docs.rs/bash-hash"
 readme = "README.md"
 repository = "https://github.com/RustCrypto/hashes"
 license = "MIT OR Apache-2.0"
-keywords = ["belt", "stb", "hash", "digest"]
+keywords = ["bash", "stb", "hash", "digest"]
 categories = ["cryptography", "no-std"]
 description = "bash hash function (STB 34.101.77-2020)"
 

--- a/bash-hash/README.md
+++ b/bash-hash/README.md
@@ -40,16 +40,16 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/belt-hash.svg
-[crate-link]: https://crates.io/crates/belt-hash
-[docs-image]: https://docs.rs/belt-hash/badge.svg
-[docs-link]: https://docs.rs/belt-hash
+[crate-image]: https://img.shields.io/crates/v/bash-hash.svg
+[crate-link]: https://crates.io/crates/bash-hash
+[docs-image]: https://docs.rs/bash-hash/badge.svg
+[docs-link]: https://docs.rs/bash-hash
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260041-hashes
-[build-image]: https://github.com/RustCrypto/hashes/actions/workflows/belt-hash.yml/badge.svg?branch=master
-[build-link]: https://github.com/RustCrypto/hashes/actions/workflows/belt-hash.yml?query=branch:master
+[build-image]: https://github.com/RustCrypto/hashes/actions/workflows/bash-hash.yml/badge.svg?branch=master
+[build-link]: https://github.com/RustCrypto/hashes/actions/workflows/bash-hash.yml?query=branch:master
 
 [//]: # (general links)
 


### PR DESCRIPTION
Updates bash-hash metadata and README badge links that were still pointing to belt-hash. This fixes the published documentation URL, crate/docs badges, workflow badge, and crate keyword so they consistently reference bash-hash.