### PR TITLE
sha3: improve hasher usage documentation

### DIFF
--- a/sha3/README.md
+++ b/sha3/README.md
@@ -21,17 +21,25 @@ Additionally, this crate supports:
 ## Examples
 
 Output size of SHA3-256 is fixed, so its functionality is usually
-accessed via the `Digest` trait:
+accessed via the [`Digest`] trait, which provides both one-shot and
+incremental interfaces:
 
 ```rust
 use hex_literal::hex;
 use sha3::{Digest, Sha3_256};
 
-let mut hasher = Sha3_256::new();
-hasher.update(b"abc");
-let hash = hasher.finalize();
+let expected = hex!("3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532");
 
-assert_eq!(hash, hex!("3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532"));
+// One-shot interface
+let hash = Sha3_256::digest(b"abc");
+assert_eq!(hash, expected);
+
+// Incremental interface
+let mut hasher = Sha3_256::new();
+hasher.update(b"a");
+hasher.update(b"bc");
+let hash = hasher.finalize();
+assert_eq!(hash, expected);
 ```
 
 See the [`digest`] crate docs for additional examples.
@@ -68,4 +76,5 @@ dual licensed as above, without any additional terms or conditions.
 
 [SHA-3]: https://en.wikipedia.org/wiki/SHA-3
 [`shake`]: http://docs.rs/shake
+[`Digest`]: https://docs.rs/digest/latest/digest/trait.Digest.html
 [`digest`]: https://docs.rs/digest

--- a/sha3/src/lib.rs
+++ b/sha3/src/lib.rs
@@ -33,6 +33,8 @@ macro_rules! impl_sha3_variants {
         $name:ident($rate_ty:ty, $out_len:ty, $pad:expr);
     )*) => {$(
         $(#[$attr])*
+        #[doc = ""]
+        #[doc = "See the [`Digest`] trait for usage."]
         #[derive(Clone, Default)]
         pub struct $name {
             state: State1600,
@@ -149,7 +151,7 @@ impl_sha3_variants!(
     Sha3_256(U136, U32, SHA3_PAD);
     /// SHA-3-384 hasher.
     Sha3_384(U104, U48, SHA3_PAD);
-    /// SHA-3-256 hasher.
+    /// SHA-3-512 hasher.
     Sha3_512(U72, U64, SHA3_PAD);
 
     /// Keccak-224 hasher.


### PR DESCRIPTION
## Summary

- Link the SHA-3 and Keccak hasher types to the `Digest` trait so their usage is discoverable from the generated API documentation.
- Update the README example to demonstrate both the one-shot `digest` interface and incremental hashing with multiple `update` calls.
- Correct the `Sha3_512` documentation, which incorrectly described it as a SHA-3-256 hasher.

Closes #441.

## Testing

- `cargo +1.85.0 test -p sha3 --all-features --locked`
- `cargo test -p sha3 --all-features --locked`
- `cargo doc -p sha3 --all-features --no-deps --locked`
- `cargo fmt --all -- --check`
- `git diff --check`