### PR TITLE
jh: remove ppv-lite86 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,6 @@ version = "0.2.0"
 dependencies = [
  "digest",
  "hex-literal",
- "ppv-lite86",
 ]
 
 [[package]]
@@ -226,33 +225,6 @@ version = "0.11.0"
 dependencies = [
  "digest",
  "hex-literal",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
-dependencies = [
- "proc-macro2",
 ]
 
 [[package]]
@@ -346,17 +318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.118"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "threefish"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,37 +341,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
 name = "whirlpool"
 version = "0.11.0"
 dependencies = [
  "digest",
  "hex-literal",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/jh/CHANGELOG.md
+++ b/jh/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.2.1 (UNRELEASED)
 ### Changed
 - Implementation of the `SerializableState` trait ([#889])
+- Replace the `ppv-lite86` compressor with portable and SSE2 backends ([#546])
 
+[#546]: https://github.com/RustCrypto/hashes/issues/546
 [#889]: https://github.com/RustCrypto/hashes/pull/889
 
 ## 0.2.0 (2026-03-27)

--- a/jh/Cargo.toml
+++ b/jh/Cargo.toml
@@ -15,7 +15,6 @@ description = "Pure Rust implementation of the JH cryptographic hash function"
 [dependencies]
 digest = "0.11"
 hex-literal = "1"
-simd = { package = "ppv-lite86", version = "0.2.6" }
 
 [dev-dependencies]
 digest = { version = "0.11", features = ["dev"] }

--- a/jh/src/block_api.rs
+++ b/jh/src/block_api.rs
@@ -74,7 +74,7 @@ impl VariableOutputCore for JhCore {
             buffer.digest_pad(0x80, &[], |b| self.state.update(b));
             buffer.digest_pad(0, &bit_len.to_be_bytes(), |b| self.state.update(b));
         }
-        out.copy_from_slice(&self.state.finalize()[64..]);
+        self.state.write_digest(out);
     }
 }
 
@@ -98,7 +98,7 @@ impl SerializableState for JhCore {
         let mut serialized_state = SerializedState::<Self>::default();
         let (state_dst, block_len_dst) = serialized_state.split_at_mut(128);
 
-        state_dst.copy_from_slice(self.state.finalize());
+        self.state.write_state(state_dst);
         block_len_dst.copy_from_slice(&self.block_len.to_le_bytes());
 
         serialized_state
@@ -122,12 +122,7 @@ impl Drop for JhCore {
         #[cfg(feature = "zeroize")]
         {
             use digest::zeroize::Zeroize;
-            const N: usize = core::mem::size_of::<Compressor>();
-            // TODO: remove this unsafe after migration from `ppv-lite86`
-            unsafe {
-                let p: *mut [u8; N] = (&mut self.state as *mut Compressor).cast();
-                core::ptr::write_volatile(p, [0u8; N]);
-            }
+            self.state.zeroize();
             self.block_len.zeroize();
         }
     }

--- a/jh/src/compressor.rs
+++ b/jh/src/compressor.rs
@@ -1,8 +1,7 @@
-#![allow(non_upper_case_globals)]
-
-use core::ptr;
 use digest::array::{Array, typenum::U64};
-use simd::{AndNot, Machine, Swap64, VZip, Vec2, dispatch, vec128_storage};
+
+#[cfg(feature = "zeroize")]
+use digest::zeroize::Zeroize;
 
 #[rustfmt::skip]
 macro_rules! unroll7 {
@@ -17,171 +16,309 @@ macro_rules! unroll7 {
     };
 }
 
-#[repr(C)]
-#[derive(Copy, Clone)]
-struct X8<M: Machine>(
-    M::u128x1,
-    M::u128x1,
-    M::u128x1,
-    M::u128x1,
-    M::u128x1,
-    M::u128x1,
-    M::u128x1,
-    M::u128x1,
-);
+#[inline(always)]
+fn read_word(bytes: &[u8], index: usize) -> u128 {
+    let mut word = [0u8; 16];
+    word.copy_from_slice(&bytes[16 * index..16 * (index + 1)]);
+    u128::from_ne_bytes(word)
+}
 
-impl<M: Machine> X8<M> {
-    #[inline(always)]
-    fn zip(self) -> (M::u128x2, M::u128x2, M::u128x2, M::u128x2) {
-        (
-            [self.0, self.1].vzip(),
-            [self.2, self.3].vzip(),
-            [self.4, self.5].vzip(),
-            [self.6, self.7].vzip(),
-        )
+/// Computes one S-box selected by a round constant bit.
+#[cfg(any(not(target_arch = "x86_64"), miri, test))]
+#[inline(always)]
+fn sbox(
+    mut x0: u128,
+    mut x1: u128,
+    mut x2: u128,
+    mut x3: u128,
+    mut round_constant: u128,
+) -> (u128, u128, u128, u128) {
+    x3 = !x3;
+    x0 ^= !x2 & round_constant;
+    round_constant ^= x0 & x1;
+    x0 ^= x3 & x2;
+    x3 ^= !x1 & x2;
+    x1 ^= x0 & x2;
+    x2 ^= !x3 & x0;
+    x0 ^= x1 | x3;
+    x3 ^= x1 & x2;
+    x2 ^= round_constant;
+    x1 ^= round_constant & x0;
+    (x0, x1, x2, x3)
+}
+
+#[cfg(any(not(target_arch = "x86_64"), miri, test))]
+#[inline(always)]
+fn linear(mut state: [u128; 8]) -> [u128; 8] {
+    state[1] ^= state[2];
+    state[3] ^= state[4];
+    state[5] ^= state[6] ^ state[0];
+    state[7] ^= state[0];
+    state[0] ^= state[3];
+    state[2] ^= state[5];
+    state[4] ^= state[7] ^ state[1];
+    state[6] ^= state[1];
+    state
+}
+
+#[cfg(any(not(target_arch = "x86_64"), miri, test))]
+#[inline(always)]
+fn swap_bits(word: u128, shift: u32) -> u128 {
+    let mask = match shift {
+        1 => 0x55555555555555555555555555555555,
+        2 => 0x33333333333333333333333333333333,
+        4 => 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f,
+        8 => 0x00ff00ff00ff00ff00ff00ff00ff00ff,
+        16 => 0x0000ffff0000ffff0000ffff0000ffff,
+        32 => 0x00000000ffffffff00000000ffffffff,
+        64 => 0x0000000000000000ffffffffffffffff,
+        _ => unreachable!(),
+    };
+    ((word & mask) << shift) | ((word & !mask) >> shift)
+}
+
+#[cfg(any(not(target_arch = "x86_64"), miri, test))]
+#[inline]
+fn compress(state: &mut [u128; 8], data: &Array<u8, U64>) {
+    let mut words = *state;
+    for (i, word) in words[..4].iter_mut().enumerate() {
+        *word ^= read_word(data, i);
     }
 
-    #[inline(always)]
-    fn unzip((a, b, c, d): (M::u128x2, M::u128x2, M::u128x2, M::u128x2)) -> Self {
-        X8(
-            a.extract(0),
-            a.extract(1),
-            b.extract(0),
-            b.extract(1),
-            c.extract(0),
-            c.extract(1),
-            d.extract(0),
-            d.extract(1),
-        )
-    }
-}
-
-/// two Sboxes computed in parallel; each Sbox implements S0 and S1, selected by a constant bit
-#[inline(always)]
-fn ss<M: Machine>(state: X8<M>, mut k: M::u128x2) -> X8<M> {
-    let mut m = state.zip();
-    // TODO: replace ! with andnot ops?
-    m.3 = !m.3;
-    m.0 ^= m.2.andnot(k);
-    k ^= m.0 & m.1;
-    m.0 ^= m.3 & m.2;
-    m.3 ^= m.1.andnot(m.2);
-    m.1 ^= m.0 & m.2;
-    m.2 ^= m.3.andnot(m.0);
-    m.0 ^= m.1 | m.3;
-    m.3 ^= m.1 & m.2;
-    m.2 ^= k;
-    m.1 ^= k & m.0;
-    X8::unzip(m)
-}
-
-#[inline(always)]
-fn l<M: Machine>(mut y: X8<M>) -> X8<M> {
-    y.1 ^= y.2;
-    y.3 ^= y.4;
-    y.5 ^= y.6 ^ y.0;
-    y.7 ^= y.0;
-    y.0 ^= y.3;
-    y.2 ^= y.5;
-    y.4 ^= y.7 ^ y.1;
-    y.6 ^= y.1;
-    y
-}
-
-union X2Bytes<M: Machine> {
-    x2: M::u128x2,
-    bytes: [u8; 32],
-}
-
-#[inline(always)]
-#[doc(hidden)]
-fn f8_impl<M: Machine>(mach: M, state: &mut [vec128_storage; 8], data: *const u8) {
-    #[allow(clippy::cast_ptr_alignment)]
-    let data: *const M::u128x1 = data.cast();
-    let mut y = X8::<M>(
-        mach.unpack(state[0]),
-        mach.unpack(state[1]),
-        mach.unpack(state[2]),
-        mach.unpack(state[3]),
-        mach.unpack(state[4]),
-        mach.unpack(state[5]),
-        mach.unpack(state[6]),
-        mach.unpack(state[7]),
-    );
-    unsafe {
-        y.0 ^= ptr::read_unaligned(data);
-        y.1 ^= ptr::read_unaligned(data.offset(1));
-        y.2 ^= ptr::read_unaligned(data.offset(2));
-        y.3 ^= ptr::read_unaligned(data.offset(3));
-    }
-    for rc in crate::consts::E8_BITSLICE_ROUNDCONSTANT.chunks_exact(7) {
-        unroll7!(j, {
-            y = ss(y, unsafe { X2Bytes::<M> { bytes: rc[j] }.x2 });
-            y = l(y);
-            let f = match j {
-                0 => M::u128x1::swap1,
-                1 => M::u128x1::swap2,
-                2 => M::u128x1::swap4,
-                3 => M::u128x1::swap8,
-                4 => M::u128x1::swap16,
-                5 => M::u128x1::swap32,
-                6 => M::u128x1::swap64,
-                _ => unreachable!(),
-            };
-            y = X8(y.0, f(y.1), y.2, f(y.3), y.4, f(y.5), y.6, f(y.7));
+    for constants in crate::consts::E8_BITSLICE_ROUNDCONSTANT.chunks_exact(7) {
+        unroll7!(J, {
+            let even = sbox(
+                words[0],
+                words[2],
+                words[4],
+                words[6],
+                read_word(&constants[J], 0),
+            );
+            let odd = sbox(
+                words[1],
+                words[3],
+                words[5],
+                words[7],
+                read_word(&constants[J], 1),
+            );
+            words = [even.0, odd.0, even.1, odd.1, even.2, odd.2, even.3, odd.3];
+            words = linear(words);
+            words[1] = swap_bits(words[1], 1 << J);
+            words[3] = swap_bits(words[3], 1 << J);
+            words[5] = swap_bits(words[5], 1 << J);
+            words[7] = swap_bits(words[7], 1 << J);
         });
     }
-    unsafe {
-        y.4 ^= ptr::read_unaligned(data);
-        y.5 ^= ptr::read_unaligned(data.offset(1));
-        y.6 ^= ptr::read_unaligned(data.offset(2));
-        y.7 ^= ptr::read_unaligned(data.offset(3));
+
+    for (i, word) in words[4..].iter_mut().enumerate() {
+        *word ^= read_word(data, i);
     }
-    *state = [
-        y.0.into(),
-        y.1.into(),
-        y.2.into(),
-        y.3.into(),
-        y.4.into(),
-        y.5.into(),
-        y.6.into(),
-        y.7.into(),
-    ];
+    *state = words;
 }
 
-pub(crate) union Compressor {
-    cv: [vec128_storage; 8],
-    bytes: [u8; 128],
+#[cfg(all(target_arch = "x86_64", not(miri)))]
+mod x86_64 {
+    use super::*;
+    use core::arch::x86_64::*;
+
+    #[inline(always)]
+    fn sbox(
+        mut x0: __m128i,
+        mut x1: __m128i,
+        mut x2: __m128i,
+        mut x3: __m128i,
+        mut round_constant: __m128i,
+    ) -> (__m128i, __m128i, __m128i, __m128i) {
+        // SSE2 is part of the x86_64 architecture baseline.
+        unsafe {
+            x3 = _mm_xor_si128(x3, _mm_set1_epi32(-1));
+            x0 = _mm_xor_si128(x0, _mm_andnot_si128(x2, round_constant));
+            round_constant = _mm_xor_si128(round_constant, _mm_and_si128(x0, x1));
+            x0 = _mm_xor_si128(x0, _mm_and_si128(x3, x2));
+            x3 = _mm_xor_si128(x3, _mm_andnot_si128(x1, x2));
+            x1 = _mm_xor_si128(x1, _mm_and_si128(x0, x2));
+            x2 = _mm_xor_si128(x2, _mm_andnot_si128(x3, x0));
+            x0 = _mm_xor_si128(x0, _mm_or_si128(x1, x3));
+            x3 = _mm_xor_si128(x3, _mm_and_si128(x1, x2));
+            x2 = _mm_xor_si128(x2, round_constant);
+            x1 = _mm_xor_si128(x1, _mm_and_si128(round_constant, x0));
+            (x0, x1, x2, x3)
+        }
+    }
+
+    #[inline(always)]
+    fn linear(mut state: [__m128i; 8]) -> [__m128i; 8] {
+        unsafe {
+            state[1] = _mm_xor_si128(state[1], state[2]);
+            state[3] = _mm_xor_si128(state[3], state[4]);
+            state[5] = _mm_xor_si128(state[5], _mm_xor_si128(state[6], state[0]));
+            state[7] = _mm_xor_si128(state[7], state[0]);
+            state[0] = _mm_xor_si128(state[0], state[3]);
+            state[2] = _mm_xor_si128(state[2], state[5]);
+            state[4] = _mm_xor_si128(state[4], _mm_xor_si128(state[7], state[1]));
+            state[6] = _mm_xor_si128(state[6], state[1]);
+            state
+        }
+    }
+
+    macro_rules! swap_small {
+        ($word:expr, $shift:literal, $mask:literal) => {{
+            let mask = _mm_set1_epi8($mask as i8);
+            _mm_or_si128(
+                _mm_srli_epi16::<$shift>(_mm_and_si128($word, mask)),
+                _mm_and_si128(_mm_slli_epi16::<$shift>($word), mask),
+            )
+        }};
+    }
+
+    #[inline(always)]
+    fn swap_bits(word: __m128i, shift: u32) -> __m128i {
+        unsafe {
+            match shift {
+                1 => swap_small!(word, 1, 0xaau8),
+                2 => swap_small!(word, 2, 0xccu8),
+                4 => swap_small!(word, 4, 0xf0u8),
+                8 => _mm_or_si128(_mm_slli_epi16::<8>(word), _mm_srli_epi16::<8>(word)),
+                16 => _mm_shufflehi_epi16::<0b1011_0001>(_mm_shufflelo_epi16::<0b1011_0001>(word)),
+                32 => _mm_shuffle_epi32::<0b1011_0001>(word),
+                64 => _mm_shuffle_epi32::<0b0100_1110>(word),
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[inline]
+    pub(super) fn compress(state: &mut [u128; 8], data: &Array<u8, U64>) {
+        unsafe {
+            let state_ptr = state.as_mut_ptr().cast::<__m128i>();
+            let data_ptr = data.as_ptr().cast::<__m128i>();
+            let mut words = [
+                _mm_loadu_si128(state_ptr),
+                _mm_loadu_si128(state_ptr.add(1)),
+                _mm_loadu_si128(state_ptr.add(2)),
+                _mm_loadu_si128(state_ptr.add(3)),
+                _mm_loadu_si128(state_ptr.add(4)),
+                _mm_loadu_si128(state_ptr.add(5)),
+                _mm_loadu_si128(state_ptr.add(6)),
+                _mm_loadu_si128(state_ptr.add(7)),
+            ];
+            words[0] = _mm_xor_si128(words[0], _mm_loadu_si128(data_ptr));
+            words[1] = _mm_xor_si128(words[1], _mm_loadu_si128(data_ptr.add(1)));
+            words[2] = _mm_xor_si128(words[2], _mm_loadu_si128(data_ptr.add(2)));
+            words[3] = _mm_xor_si128(words[3], _mm_loadu_si128(data_ptr.add(3)));
+
+            for constants in crate::consts::E8_BITSLICE_ROUNDCONSTANT.chunks_exact(7) {
+                unroll7!(J, {
+                    let constant_ptr = constants[J].as_ptr().cast::<__m128i>();
+                    let even = sbox(
+                        words[0],
+                        words[2],
+                        words[4],
+                        words[6],
+                        _mm_loadu_si128(constant_ptr),
+                    );
+                    let odd = sbox(
+                        words[1],
+                        words[3],
+                        words[5],
+                        words[7],
+                        _mm_loadu_si128(constant_ptr.add(1)),
+                    );
+                    words = [even.0, odd.0, even.1, odd.1, even.2, odd.2, even.3, odd.3];
+                    words = linear(words);
+                    words[1] = swap_bits(words[1], 1 << J);
+                    words[3] = swap_bits(words[3], 1 << J);
+                    words[5] = swap_bits(words[5], 1 << J);
+                    words[7] = swap_bits(words[7], 1 << J);
+                });
+            }
+
+            words[4] = _mm_xor_si128(words[4], _mm_loadu_si128(data_ptr));
+            words[5] = _mm_xor_si128(words[5], _mm_loadu_si128(data_ptr.add(1)));
+            words[6] = _mm_xor_si128(words[6], _mm_loadu_si128(data_ptr.add(2)));
+            words[7] = _mm_xor_si128(words[7], _mm_loadu_si128(data_ptr.add(3)));
+            for (i, word) in words.iter().enumerate() {
+                _mm_storeu_si128(state_ptr.add(i), *word);
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Compressor {
+    state: [u128; 8],
 }
 
 impl Compressor {
     #[inline]
     pub(crate) fn new(bytes: [u8; 128]) -> Self {
-        Compressor { bytes }
+        Self {
+            state: core::array::from_fn(|i| read_word(&bytes, i)),
+        }
     }
 
     #[inline]
-    #[allow(unexpected_cfgs)] // TODO: remove after dependency on ppv-lite86 is eliminated
     pub(crate) fn update(&mut self, data: &Array<u8, U64>) {
-        simd::dispatch!(mach, M, {
-            fn f8(state: &mut [vec128_storage; 8], data: *const u8) {
-                f8_impl(mach, state, data);
-            }
-        });
-
-        f8(unsafe { &mut self.cv }, data.as_ptr());
+        #[cfg(all(target_arch = "x86_64", not(miri)))]
+        x86_64::compress(&mut self.state, data);
+        #[cfg(any(not(target_arch = "x86_64"), miri))]
+        compress(&mut self.state, data);
     }
 
     #[inline]
-    pub(crate) fn finalize(&self) -> &[u8; 128] {
-        unsafe { &self.bytes }
+    fn write_words(words: &[u128], bytes: &mut [u8]) {
+        assert_eq!(bytes.len(), 16 * words.len());
+        for (word, chunk) in words.iter().zip(bytes.chunks_exact_mut(16)) {
+            chunk.copy_from_slice(&word.to_ne_bytes());
+        }
+    }
+
+    #[inline]
+    pub(crate) fn write_digest(&self, out: &mut [u8]) {
+        Self::write_words(&self.state[4..], out);
+    }
+
+    #[inline]
+    pub(crate) fn write_state(&self, out: &mut [u8]) {
+        Self::write_words(&self.state, out);
     }
 }
 
-impl Clone for Compressor {
-    fn clone(&self) -> Self {
-        Self {
-            bytes: unsafe { self.bytes },
+#[cfg(feature = "zeroize")]
+impl Zeroize for Compressor {
+    fn zeroize(&mut self) {
+        self.state.zeroize();
+    }
+}
+
+#[cfg(all(test, target_arch = "x86_64", not(miri)))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn portable_matches_x86_64() {
+        let mut seed = 0x243f6a8885a308d3u64;
+
+        for _ in 0..16 {
+            let mut next = || {
+                seed ^= seed << 13;
+                seed ^= seed >> 7;
+                seed ^= seed << 17;
+                seed
+            };
+            let state = core::array::from_fn(|_| {
+                let lo = next() as u128;
+                let hi = next() as u128;
+                lo | (hi << 64)
+            });
+            let data = Array::from_fn(|_| next() as u8);
+
+            let mut portable = state;
+            compress(&mut portable, &data);
+            let mut accelerated = state;
+            x86_64::compress(&mut accelerated, &data);
+
+            assert_eq!(portable, accelerated);
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace the `ppv-lite86` compressor with a portable `u128` implementation and an SSE2 backend for x86_64
- store the compressor as typed words so `zeroize` can wipe it without the previous unsafe byte cast
- write final and serialized state directly into destination buffers and check portable/SSE2 equivalence

SSE2 is part of the x86_64 baseline, so this keeps the accelerated path without runtime feature detection

Closes #546

## Testing

- `cargo +1.85.1 hack test --feature-powerset`
- `cargo +stable hack test --feature-powerset`
- `cargo +1.85.1 clippy --all -- -D warnings`
- JH cross-build matrix for `thumbv7em-none-eabi` and `wasm32-unknown-unknown` on MSRV and stable
- minimal versions check with the CI command
- `cargo +stable package -p jh --allow-dirty`

The 10,000-byte JH-256 bench stayed within noise at 292 MB/s before and 297 MB/s after