### PR TITLE
sha2: use inline assembly instead of unstable intrinsics for riscv-zknh backend

### DIFF
--- a/.github/workflows/sha2.yml
+++ b/.github/workflows/sha2.yml
@@ -183,7 +183,7 @@ jobs:
         run: cargo install cross --git https://github.com/cross-rs/cross
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
+          toolchain: stable
       - run: cross test --package sha2 --all-features --target riscv64gc-unknown-linux-gnu
         env:
           RUSTFLAGS: -Dwarnings --cfg sha2_backend="soft"

--- a/sha2/CHANGELOG.md
+++ b/sha2/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Removed workaround for unaligned loads in `riscv-zknh` backend ([#879])
 - `riscv-zknh` no longer requires `zbkb` (or `zbb`) target feature ([#879])
+- `riscv-zknh` no longer requires nightly toolchain ([#915])
 
 [#879]: https://github.com/RustCrypto/hashes/pull/879
+[#915]: https://github.com/RustCrypto/hashes/pull/915
 
 ## 0.11.0 (2026-03-25)
 ### Changed

--- a/sha2/README.md
+++ b/sha2/README.md
@@ -104,10 +104,10 @@ flags respectively.
 
 ### About `riscv-zknh`
 
-This is an experimental RISC-V-only backend which requires a Nightly compiler and
-to enable the `Zknh` target feature at compile time. For a more efficient code generation,
-it's recommended to enable the `Zbkb` (or `Zbb`) and `unaligned-scalar-mem` target features
-(see [this LLVM issue][Zicclsm] for more information). For example, you can do it by using
+This is an experimental RISC-V-only backend which requires enabling the `Zknh` target
+feature at compile time. For a more efficient code generation, it's recommended to enable
+the `Zbkb` (or `Zbb`) and `unaligned-scalar-mem` target features (see [this LLVM issue][Zicclsm]
+for more information). For example, you can do it by using
 `RUSTFLAGS="-C target-feature=+zknh,+zbkb,+unaligned-scalar-mem"`.
 
 [Zicclsm]: https://github.com/llvm/llvm-project/issues/110454

--- a/sha2/src/lib.rs
+++ b/sha2/src/lib.rs
@@ -6,14 +6,6 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, unreachable_pub)]
-#![cfg_attr(
-    any(
-        sha2_backend = "riscv-zknh",
-        sha2_256_backend = "riscv-zknh",
-        sha2_256_backend = "riscv-zknh",
-    ),
-    feature(riscv_ext_intrinsics)
-)]
 #![allow(clippy::needless_range_loop)]
 
 pub use digest::{self, Digest};

--- a/sha2/src/sha256/riscv_zknh.rs
+++ b/sha2/src/sha256/riscv_zknh.rs
@@ -1,10 +1,31 @@
 #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
 compile_error!("riscv-zknh backend can be used only on riscv32 and riscv64 target arches");
 
-#[cfg(target_arch = "riscv32")]
-use core::arch::riscv32::{sha256sig0, sha256sig1, sha256sum0, sha256sum1};
-#[cfg(target_arch = "riscv64")]
-use core::arch::riscv64::{sha256sig0, sha256sig1, sha256sum0, sha256sum1};
+use core::arch::asm;
+
+fn sha256sig0(x: u32) -> u32 {
+    let a: u32;
+    unsafe { asm!("sha256sig0 {rd}, {rs1}", rd = out(reg) a, rs1 = in(reg) x) };
+    a
+}
+
+fn sha256sig1(x: u32) -> u32 {
+    let a: u32;
+    unsafe { asm!("sha256sig1 {rd}, {rs1}", rd = out(reg) a, rs1 = in(reg) x) };
+    a
+}
+
+fn sha256sum0(x: u32) -> u32 {
+    let a: u32;
+    unsafe { asm!("sha256sum0 {rd}, {rs1}", rd = out(reg) a, rs1 = in(reg) x) };
+    a
+}
+
+fn sha256sum1(x: u32) -> u32 {
+    let a: u32;
+    unsafe { asm!("sha256sum1 {rd}, {rs1}", rd = out(reg) a, rs1 = in(reg) x) };
+    a
+}
 
 cfg_if::cfg_if! {
     if #[cfg(sha2_backend_riscv_zknh = "compact")] {

--- a/sha2/src/sha512/riscv_zknh.rs
+++ b/sha2/src/sha512/riscv_zknh.rs
@@ -1,3 +1,5 @@
+use core::arch::asm;
+
 #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
 compile_error!("riscv-zknh backend can be used only on riscv32 and riscv64 target arches");
 
@@ -24,37 +26,64 @@ pub(super) fn compress(state: &mut [u64; 8], blocks: &[[u8; 128]]) {
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "riscv64")] {
-        use core::arch::riscv64::{sha512sig0, sha512sig1, sha512sum0, sha512sum1};
-    } else {
-        use core::arch::riscv32::{
-            sha512sig0h, sha512sig0l, sha512sig1h, sha512sig1l, sha512sum0r, sha512sum1r,
-        };
+        fn sha512sum0(x: u64) -> u64 {
+            let a: u64;
+            unsafe { asm!("sha512sum0 {rd}, {rs1}", rd = out(reg) a, rs1 = in(reg) x); }
+            a
+        }
 
+        fn sha512sum1(x: u64) -> u64 {
+            let a: u64;
+            unsafe { asm!("sha512sum1 {rd}, {rs1}", rd = out(reg) a, rs1 = in(reg) x); }
+            a
+        }
+
+        fn sha512sig0(x: u64) -> u64 {
+            let a: u64;
+            unsafe { asm!("sha512sig0 {rd}, {rs1}", rd = out(reg) a, rs1 = in(reg) x); }
+            a
+        }
+
+        fn sha512sig1(x: u64) -> u64 {
+            let a: u64;
+            unsafe { asm!("sha512sig1 {rd}, {rs1}", rd = out(reg) a, rs1 = in(reg) x); }
+            a
+        }
+
+    } else {
         #[target_feature(enable = "zknh")]
         fn sha512sum0(x: u64) -> u64 {
-            let a = sha512sum0r((x >> 32) as u32, x as u32);
-            let b = sha512sum0r(x as u32, (x >> 32) as u32);
+            let a: u32;
+            unsafe { asm!("sha512sum0r {rd}, {rs1}, {rs2}", rd = out(reg) a, rs1 = in(reg) (x >> 32) as u32, rs2 = in(reg) x as u32); }
+            let b: u32;
+            unsafe { asm!("sha512sum0r {rd}, {rs1}, {rs2}", rd = out(reg) b, rs1 = in(reg) x as u32, rs2 = in(reg) (x >> 32) as u32); }
             ((a as u64) << 32) | (b as u64)
         }
 
         #[target_feature(enable = "zknh")]
         fn sha512sum1(x: u64) -> u64 {
-            let a = sha512sum1r((x >> 32) as u32, x as u32);
-            let b = sha512sum1r(x as u32, (x >> 32) as u32);
+            let a: u32;
+            unsafe { asm!("sha512sum1r {rd}, {rs1}, {rs2}", rd = out(reg) a, rs1 = in(reg) (x >> 32) as u32, rs2 = in(reg) x as u32); }
+            let b: u32;
+            unsafe { asm!("sha512sum1r {rd}, {rs1}, {rs2}", rd = out(reg) b, rs1 = in(reg) x as u32, rs2 = in(reg) (x >> 32) as u32); }
             ((a as u64) << 32) | (b as u64)
         }
 
         #[target_feature(enable = "zknh")]
         fn sha512sig0(x: u64) -> u64 {
-            let a = sha512sig0h((x >> 32) as u32, x as u32);
-            let b = sha512sig0l(x as u32, (x >> 32) as u32);
+            let a: u32;
+            unsafe { asm!("sha512sig0h {rd}, {rs1}, {rs2}", rd = out(reg) a, rs1 = in(reg) (x >> 32) as u32, rs2 = in(reg) x as u32); }
+            let b: u32;
+            unsafe { asm!("sha512sig0l {rd}, {rs1}, {rs2}", rd = out(reg) b, rs1 = in(reg) x as u32, rs2 = in(reg) (x >> 32) as u32); }
             ((a as u64) << 32) | (b as u64)
         }
 
         #[target_feature(enable = "zknh")]
         fn sha512sig1(x: u64) -> u64 {
-            let a = sha512sig1h((x >> 32) as u32, x as u32);
-            let b = sha512sig1l(x as u32, (x >> 32) as u32);
+            let a: u32;
+            unsafe { asm!("sha512sig1h {rd}, {rs1}, {rs2}", rd = out(reg) a, rs1 = in(reg) (x >> 32) as u32, rs2 = in(reg) x as u32); }
+            let b: u32;
+            unsafe { asm!("sha512sig1l {rd}, {rs1}, {rs2}", rd = out(reg) b, rs1 = in(reg) x as u32, rs2 = in(reg) (x >> 32) as u32); }
             ((a as u64) << 32) | (b as u64)
         }
     }


### PR DESCRIPTION
This allows the backend to be used on stable Rust.

Although it behaves in the same way as before, the codegen is slightly different now, and I haven't been able to pin down why.